### PR TITLE
[FLIZ-56] filter 추가, Login 유저를 Controller 에서 받기 위한 ArgumentResolver 추가 작업

### DIFF
--- a/src/main/java/spring/fitlinkbe/domain/common/PersonalDetailRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/PersonalDetailRepository.java
@@ -4,4 +4,6 @@ import spring.fitlinkbe.domain.common.model.PersonalDetail;
 
 public interface PersonalDetailRepository {
     PersonalDetail saveIfNotExist(PersonalDetail personalDetail);
+
+    PersonalDetail getById(Long personalDetailId);
 }

--- a/src/main/java/spring/fitlinkbe/domain/common/annotation/Login.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/annotation/Login.java
@@ -1,0 +1,11 @@
+package spring.fitlinkbe.domain.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Login {
+}

--- a/src/main/java/spring/fitlinkbe/domain/common/exception/CustomException.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/exception/CustomException.java
@@ -11,6 +11,11 @@ public class CustomException extends RuntimeException {
     private final ErrorCode errorCode;
     private final String msg;
 
+    public CustomException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.msg = errorCode.getMsg();
+    }
+
     @Override
     public String getMessage() {
         return "[%s] %s".formatted(errorCode, msg);

--- a/src/main/java/spring/fitlinkbe/domain/common/exception/CustomException.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/exception/CustomException.java
@@ -1,11 +1,11 @@
 package spring.fitlinkbe.domain.common.exception;
 
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
-@AllArgsConstructor
 @Getter
+@RequiredArgsConstructor
 public class CustomException extends RuntimeException {
 
     private final ErrorCode errorCode;
@@ -16,8 +16,13 @@ public class CustomException extends RuntimeException {
         this.msg = errorCode.getMsg();
     }
 
+
     @Override
     public String getMessage() {
-        return "[%s] %s".formatted(errorCode, msg);
+        return "[%s] %s".formatted(errorCode, errorCode.getMsg());
+    }
+
+    public int getStatus() {
+        return errorCode.getStatus();
     }
 }

--- a/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
@@ -1,21 +1,19 @@
 package spring.fitlinkbe.domain.common.exception;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-@AllArgsConstructor
 @Getter
 public enum ErrorCode {
 
     // Trainer 관련 ErrorCode
-    TRAINER_IS_NOT_FOUND("트레이너 정보가 존재하지 않습니다."),
+    TRAINER_IS_NOT_FOUND("트레이너 정보가 존재하지 않습니다.", 404),
 
     // Member 관련 ErrorCode
 
     // Reservation 관련 ErrorCode
-    RESERVATION_IS_FAILED("예약에 실패하였습니다."),
+    RESERVATION_IS_FAILED("예약에 실패하였습니다.", 400),
 
     // Session 관련 ErrorCode
 
@@ -31,5 +29,5 @@ public enum ErrorCode {
     ;
 
     private final String msg;
-    private int status;
+    private final int status;
 }

--- a/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
@@ -1,9 +1,11 @@
 package spring.fitlinkbe.domain.common.exception;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@AllArgsConstructor
 @Getter
 public enum ErrorCode {
 
@@ -20,7 +22,14 @@ public enum ErrorCode {
     // Notification 관련 ErrorCode
 
     // Auth 관련 ErrorCode
-    UNSUPPORTED_OAUTH_PROVIDER("지원하지 않는 OAuth 제공자입니다.");
+    UNSUPPORTED_OAUTH_PROVIDER("지원하지 않는 OAuth 제공자입니다.", 400),
+    EXPIRED_TOKEN("토큰이 만료되었습니다.", 401),
+    USER_STATUS_NOT_ALLOWED("해당 유저 상태에서는 요청 불가합니다.", 403),
+
+    // Common ErrorCode
+    PERSONAL_DETAIL_NOT_FOUND("Personal Detail 정보가 존재하지 않습니다.", 404),
+    ;
 
     private final String msg;
+    private int status;
 }

--- a/src/main/java/spring/fitlinkbe/infra/common/PersonalDetailRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/common/PersonalDetailRepositoryImpl.java
@@ -3,6 +3,8 @@ package spring.fitlinkbe.infra.common;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import spring.fitlinkbe.domain.common.PersonalDetailRepository;
+import spring.fitlinkbe.domain.common.exception.CustomException;
+import spring.fitlinkbe.domain.common.exception.ErrorCode;
 import spring.fitlinkbe.domain.common.model.PersonalDetail;
 import spring.fitlinkbe.infra.common.model.PersonalDetailEntity;
 
@@ -25,5 +27,12 @@ public class PersonalDetailRepositoryImpl implements PersonalDetailRepository {
             PersonalDetailEntity entity = personalDetailJpaRepository.save(PersonalDetailEntity.from(personalDetail));
             return entity.toDomain();
         }
+    }
+
+    @Override
+    public PersonalDetail getById(Long personalDetailId) {
+        return personalDetailJpaRepository.findById(personalDetailId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PERSONAL_DETAIL_NOT_FOUND))
+                .toDomain();
     }
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/common/exception/ApiControllerAdvice.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/common/exception/ApiControllerAdvice.java
@@ -17,7 +17,7 @@ public class ApiControllerAdvice {
     @ExceptionHandler(CustomException.class)
     public ApiResultResponse<Object> handlerCustomException(CustomException e) {
         log.info("CustomException is occurred! {}", e.getMessage());
-        return ApiResultResponse.of(HttpStatus.OK, false, e.getMessage(), null);
+        return ApiResultResponse.of(HttpStatus.valueOf(e.getStatus()), false, e.getMessage(), null);
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/common/exception/ApiControllerAdvice.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/common/exception/ApiControllerAdvice.java
@@ -23,7 +23,6 @@ public class ApiControllerAdvice {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(Exception.class)
     public ApiResultResponse<Object> handlerException(Exception e) {
-        e.printStackTrace();
         log.error("Exception is occurred! {}", e.getMessage());
         return ApiResultResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, false, null);
     }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/common/exception/ApiControllerAdvice.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/common/exception/ApiControllerAdvice.java
@@ -23,6 +23,7 @@ public class ApiControllerAdvice {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(Exception.class)
     public ApiResultResponse<Object> handlerException(Exception e) {
+        e.printStackTrace();
         log.error("Exception is occurred! {}", e.getMessage());
         return ApiResultResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, false, null);
     }

--- a/src/main/java/spring/fitlinkbe/support/argumentresolver/Login.java
+++ b/src/main/java/spring/fitlinkbe/support/argumentresolver/Login.java
@@ -1,4 +1,4 @@
-package spring.fitlinkbe.domain.common.annotation;
+package spring.fitlinkbe.support.argumentresolver;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/spring/fitlinkbe/support/argumentresolver/LoginMemberArgumentResolver.java
+++ b/src/main/java/spring/fitlinkbe/support/argumentresolver/LoginMemberArgumentResolver.java
@@ -8,7 +8,6 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import spring.fitlinkbe.domain.common.PersonalDetailRepository;
-import spring.fitlinkbe.domain.common.annotation.Login;
 import spring.fitlinkbe.support.security.AuthTokenProvider;
 import spring.fitlinkbe.support.security.SecurityUser;
 import spring.fitlinkbe.support.utils.HeaderUtils;

--- a/src/main/java/spring/fitlinkbe/support/argumentresolver/LoginMemberArgumentResolver.java
+++ b/src/main/java/spring/fitlinkbe/support/argumentresolver/LoginMemberArgumentResolver.java
@@ -1,0 +1,39 @@
+package spring.fitlinkbe.support.argumentresolver;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import spring.fitlinkbe.domain.common.PersonalDetailRepository;
+import spring.fitlinkbe.domain.common.annotation.Login;
+import spring.fitlinkbe.support.security.AuthTokenProvider;
+import spring.fitlinkbe.support.security.SecurityUser;
+import spring.fitlinkbe.support.utils.HeaderUtils;
+
+
+@RequiredArgsConstructor
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final AuthTokenProvider tokenProvider;
+    private final PersonalDetailRepository personalDetailRepository;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasLoginAnnotation = parameter.hasParameterAnnotation(Login.class);
+        boolean hasUserType = SecurityUser.class.isAssignableFrom(parameter.getParameterType());
+        return hasLoginAnnotation && hasUserType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String accessToken = HeaderUtils.getAccessToken(request);
+        Long personalDetailId = tokenProvider.getPersonalDetailIdFromAccessToken(accessToken);
+
+        return new SecurityUser(personalDetailRepository.getById(personalDetailId));
+    }
+}

--- a/src/main/java/spring/fitlinkbe/support/config/SecurityConfig.java
+++ b/src/main/java/spring/fitlinkbe/support/config/SecurityConfig.java
@@ -7,7 +7,13 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.stereotype.Component;
+import spring.fitlinkbe.domain.common.PersonalDetailRepository;
+import spring.fitlinkbe.support.security.AuthTokenProvider;
+import spring.fitlinkbe.support.security.RestAuthenticationEntryPoint;
+import spring.fitlinkbe.support.security.filter.ExceptionHandlerFilter;
+import spring.fitlinkbe.support.security.filter.JwtAuthFilter;
 import spring.fitlinkbe.support.security.handler.CustomOauth2FailureHandler;
 import spring.fitlinkbe.support.security.handler.CustomOauth2SuccessHandler;
 
@@ -17,6 +23,8 @@ public class SecurityConfig {
 
     private final CustomOauth2SuccessHandler customOauth2SuccessHandler;
     private final CustomOauth2FailureHandler customOauth2FailureHandler;
+    private final AuthTokenProvider authTokenProvider;
+    private final PersonalDetailRepository personalDetailRepository;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -29,12 +37,16 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/oauth2/authorization/**").permitAll()
-                        .anyRequest().permitAll()
+                        .anyRequest().authenticated()
                 )
+                .exceptionHandling(e -> e.authenticationEntryPoint(new RestAuthenticationEntryPoint()))
                 .oauth2Login(oauth2 -> oauth2
                         .successHandler(customOauth2SuccessHandler)
                         .failureHandler(customOauth2FailureHandler)
                 );
+
+        http.addFilterBefore(new JwtAuthFilter(authTokenProvider, personalDetailRepository), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(new ExceptionHandlerFilter(), JwtAuthFilter.class);
         return http.build();
     }
 }

--- a/src/main/java/spring/fitlinkbe/support/config/WebConfig.java
+++ b/src/main/java/spring/fitlinkbe/support/config/WebConfig.java
@@ -1,0 +1,23 @@
+package spring.fitlinkbe.support.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import spring.fitlinkbe.domain.common.PersonalDetailRepository;
+import spring.fitlinkbe.support.argumentresolver.LoginMemberArgumentResolver;
+import spring.fitlinkbe.support.security.AuthTokenProvider;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+	private final AuthTokenProvider tokenProvider;
+	private final PersonalDetailRepository personalDetailRepository;
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(new LoginMemberArgumentResolver(tokenProvider, personalDetailRepository));
+	}
+}

--- a/src/main/java/spring/fitlinkbe/support/security/RestAuthenticationEntryPoint.java
+++ b/src/main/java/spring/fitlinkbe/support/security/RestAuthenticationEntryPoint.java
@@ -1,0 +1,25 @@
+package spring.fitlinkbe.support.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import spring.fitlinkbe.support.utils.ResponseUtils;
+
+import java.io.IOException;
+
+@Slf4j
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+        log.info("request url: {}", request.getRequestURI());
+        log.info("Responding with unauthorized error. Message := {}", authException.getMessage());
+        ResponseUtils.setErrorResponse(response, HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/spring/fitlinkbe/support/security/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/spring/fitlinkbe/support/security/filter/ExceptionHandlerFilter.java
@@ -1,6 +1,7 @@
 package spring.fitlinkbe.support.security.filter;
 
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -24,13 +25,17 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
         try {
             filterChain.doFilter(request, response);
         } catch (ExpiredJwtException e) {
+            log.error("Token is expired", e);
             ResponseUtils.setErrorResponse(response, ErrorCode.EXPIRED_TOKEN);
+        } catch (JwtException | IllegalArgumentException e) {
+            log.error("Token is invalid", e);
+            ResponseUtils.setErrorResponse(response, HttpStatus.UNAUTHORIZED);
         } catch (CustomException e) {
+            log.error("CustomException is occurred!", e);
             ResponseUtils.setErrorResponse(response, e.getErrorCode());
         } catch (Exception e) {
+            log.error("Exception is occurred!", e);
             ResponseUtils.setErrorResponse(response, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
-
-
 }

--- a/src/main/java/spring/fitlinkbe/support/security/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/spring/fitlinkbe/support/security/filter/ExceptionHandlerFilter.java
@@ -1,0 +1,36 @@
+package spring.fitlinkbe.support.security.filter;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.filter.OncePerRequestFilter;
+import spring.fitlinkbe.domain.common.exception.CustomException;
+import spring.fitlinkbe.domain.common.exception.ErrorCode;
+import spring.fitlinkbe.support.utils.ResponseUtils;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException e) {
+            ResponseUtils.setErrorResponse(response, ErrorCode.EXPIRED_TOKEN);
+        } catch (CustomException e) {
+            ResponseUtils.setErrorResponse(response, e.getErrorCode());
+        } catch (Exception e) {
+            ResponseUtils.setErrorResponse(response, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+
+}

--- a/src/main/java/spring/fitlinkbe/support/security/filter/JwtAuthFilter.java
+++ b/src/main/java/spring/fitlinkbe/support/security/filter/JwtAuthFilter.java
@@ -1,0 +1,54 @@
+package spring.fitlinkbe.support.security.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.web.filter.OncePerRequestFilter;
+import spring.fitlinkbe.domain.common.PersonalDetailRepository;
+import spring.fitlinkbe.domain.common.exception.CustomException;
+import spring.fitlinkbe.domain.common.exception.ErrorCode;
+import spring.fitlinkbe.domain.common.model.PersonalDetail;
+import spring.fitlinkbe.domain.common.model.PersonalDetail.Status;
+import spring.fitlinkbe.support.security.AuthTokenProvider;
+import spring.fitlinkbe.support.security.SecurityUser;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final AuthTokenProvider tokenProvider;
+    private final PersonalDetailRepository personalDetailRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String tokenHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (tokenHeader == null || !tokenHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        OAuth2AuthenticationToken authentication = validate(tokenHeader);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        filterChain.doFilter(request, response);
+    }
+
+    private OAuth2AuthenticationToken validate(String tokenHeader) {
+        String accessToken = tokenHeader.substring(7);
+        Status status = tokenProvider.getStatusFromAccessToken(accessToken);
+
+        if (!status.equals(Status.NORMAL)) {
+            throw new CustomException(ErrorCode.USER_STATUS_NOT_ALLOWED);
+        }
+        Long personalDetailId = tokenProvider.getPersonalDetailIdFromAccessToken(accessToken);
+        PersonalDetail personalDetail = personalDetailRepository.getById(personalDetailId);
+
+        SecurityUser securityUser = new SecurityUser(personalDetail);
+        return new OAuth2AuthenticationToken(securityUser, securityUser.getAuthorities(), personalDetail.getOauthProvider().name());
+    }
+}

--- a/src/main/java/spring/fitlinkbe/support/security/filter/JwtAuthFilter.java
+++ b/src/main/java/spring/fitlinkbe/support/security/filter/JwtAuthFilter.java
@@ -5,7 +5,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -16,6 +15,7 @@ import spring.fitlinkbe.domain.common.model.PersonalDetail;
 import spring.fitlinkbe.domain.common.model.PersonalDetail.Status;
 import spring.fitlinkbe.support.security.AuthTokenProvider;
 import spring.fitlinkbe.support.security.SecurityUser;
+import spring.fitlinkbe.support.utils.HeaderUtils;
 
 import java.io.IOException;
 
@@ -27,19 +27,18 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        String tokenHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        String accessToken = HeaderUtils.getAccessToken(request);
 
-        if (tokenHeader == null || !tokenHeader.startsWith("Bearer ")) {
+        if (accessToken == null) {
             filterChain.doFilter(request, response);
             return;
         }
-        OAuth2AuthenticationToken authentication = validate(tokenHeader);
+        OAuth2AuthenticationToken authentication = validate(accessToken);
         SecurityContextHolder.getContext().setAuthentication(authentication);
         filterChain.doFilter(request, response);
     }
 
-    private OAuth2AuthenticationToken validate(String tokenHeader) {
-        String accessToken = tokenHeader.substring(7);
+    private OAuth2AuthenticationToken validate(String accessToken) {
         Status status = tokenProvider.getStatusFromAccessToken(accessToken);
 
         if (!status.equals(Status.NORMAL)) {

--- a/src/main/java/spring/fitlinkbe/support/utils/HeaderUtils.java
+++ b/src/main/java/spring/fitlinkbe/support/utils/HeaderUtils.java
@@ -1,0 +1,22 @@
+package spring.fitlinkbe.support.utils;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpHeaders;
+
+public class HeaderUtils {
+
+    /**
+     * Get access token from request header
+     *
+     * @param request
+     * @return access token, null if not found
+     */
+    public static String getAccessToken(HttpServletRequest request) {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header == null || !header.startsWith("Bearer ")) {
+            return null;
+        }
+
+        return header.substring(7);
+    }
+}

--- a/src/main/java/spring/fitlinkbe/support/utils/ResponseUtils.java
+++ b/src/main/java/spring/fitlinkbe/support/utils/ResponseUtils.java
@@ -15,11 +15,18 @@ import java.nio.charset.StandardCharsets;
 public class ResponseUtils {
     public static void setErrorResponse(HttpServletResponse response, HttpStatus status) {
         ObjectMapper objectMapper = new ObjectMapper();
-        response.setStatus(status.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
 
-        ApiResultResponse<Object> apiResultResponse = ApiResultResponse.of(status, false, status.getReasonPhrase(), null);
+        ApiResultResponse<Object> apiResultResponse;
+        if (status == HttpStatus.INTERNAL_SERVER_ERROR) {
+            response.setStatus(status.value());
+            apiResultResponse = ApiResultResponse.of(status, false, status.getReasonPhrase(), null);
+        } else {
+            response.setStatus(HttpStatus.OK.value());
+            apiResultResponse = ApiResultResponse.of(status, false, status.getReasonPhrase(), null);
+        }
+
         try {
             response.getWriter().write(objectMapper.writeValueAsString(apiResultResponse));
         } catch (IOException e) {
@@ -29,12 +36,18 @@ public class ResponseUtils {
 
     public static void setErrorResponse(HttpServletResponse response, ErrorCode errorCode) {
         ObjectMapper objectMapper = new ObjectMapper();
-        response.setStatus(errorCode.getStatus());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
 
-        ApiResultResponse<Object> apiResultResponse = ApiResultResponse.of(HttpStatus.valueOf(errorCode.getStatus()),
-                false, errorCode.getMsg(), null);
+        ApiResultResponse<Object> apiResultResponse;
+        if (errorCode.getStatus() == HttpStatus.INTERNAL_SERVER_ERROR.value()) {
+            response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+            apiResultResponse = ApiResultResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, false, errorCode.getMsg(), null);
+        } else {
+            response.setStatus(HttpStatus.OK.value());
+            apiResultResponse = ApiResultResponse.of(HttpStatus.valueOf(errorCode.getStatus()), false, errorCode.getMsg(), null);
+        }
+
         try {
             response.getWriter().write(objectMapper.writeValueAsString(apiResultResponse));
         } catch (IOException e) {

--- a/src/main/java/spring/fitlinkbe/support/utils/ResponseUtils.java
+++ b/src/main/java/spring/fitlinkbe/support/utils/ResponseUtils.java
@@ -1,0 +1,44 @@
+package spring.fitlinkbe.support.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import spring.fitlinkbe.domain.common.exception.ErrorCode;
+import spring.fitlinkbe.interfaces.controller.common.dto.ApiResultResponse;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+public class ResponseUtils {
+    public static void setErrorResponse(HttpServletResponse response, HttpStatus status) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.setStatus(status.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        ApiResultResponse<Object> apiResultResponse = ApiResultResponse.of(status, false, status.getReasonPhrase(), null);
+        try {
+            response.getWriter().write(objectMapper.writeValueAsString(apiResultResponse));
+        } catch (IOException e) {
+            log.error("Error while writing response", e);
+        }
+    }
+
+    public static void setErrorResponse(HttpServletResponse response, ErrorCode errorCode) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.setStatus(errorCode.getStatus());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        ApiResultResponse<Object> apiResultResponse = ApiResultResponse.of(HttpStatus.valueOf(errorCode.getStatus()),
+                false, errorCode.getMsg(), null);
+        try {
+            response.getWriter().write(objectMapper.writeValueAsString(apiResultResponse));
+        } catch (IOException e) {
+            log.error("Error while writing response", e);
+        }
+    }
+}


### PR DESCRIPTION
### 사용 예시
```
@GetMapping("{trainerId}/me")
public ApiResultResponse<TrainerDto.Response> getTrainerInfo(@PathVariable("trainerId")
                                                             @NotNull(message = "유저 ID는 필수값 입니다.")
                                                             Long trainerId,
                                                             @Login SecurityUser user
                                                             ) {
    
    return ApiResultResponse.ok(TrainerDto.Response.of(trainerService.getTrainerInfo(trainerId)));

}
```

- Controller에서 @Login 어노테이션 붙여서 다음과 같이 SecurityUser 타입 주입받을 수 있습니다

### 추가사항
- JwtAuthFilter 새로 추가하여서 이제 모든 요청이 인증 통과된것만 가능하도록 했습니다
- 소셜 로그인 후에 AccessToken을 요청 Authorization 헤더에 넣어야 요청이 정상적으로 처리됩니다.
- 로그인 유저는 status가 Normal 이여야만 정상적으로 인증, 인가 통과합니다. 그 외의 status는 인가가 되지 않도록 추가했습니다

### 예외 처리 건의
- 지금 ApiControllerAdvice 보면 무조건 응답 status가 200OK로 나가고 있는데 isSuccess 값이 false인거는 조금 모순같다는 생각이 듭니다. ErrorCode에 따라서 적절하게 응답 status를 내주도록 수정하는건 어떨까요?
