### PR TITLE
Fliz-58-be-예약 상세 조회 api

### DIFF
--- a/docker/mysql/initdb.d/create_table.sql
+++ b/docker/mysql/initdb.d/create_table.sql
@@ -132,7 +132,7 @@ CREATE TABLE session
 -- 예약 정보 테이블
 CREATE TABLE reservation
 (
-    reservation_id   BIGINT       NOT NULL AUTO_INCREMENT,
+    reservation_id   BIGINT      NOT NULL AUTO_INCREMENT,
     member_id        BIGINT,
     trainer_id       BIGINT,
     session_info_id  BIGINT,
@@ -141,7 +141,7 @@ CREATE TABLE reservation
     change_date      DATETIME(6),
     status           ENUM ('CANCEL', 'RESERVATION_REQUEST', 'CHANGE_REQUEST', 'CANCEL_REQUEST', 'COMPLETED'),
     cancel_reason    VARCHAR(255),
-    approved_cancel  BOOLEAN,
+    is_approved      BOOLEAN,
     priority         INT,
     is_fixed         BOOLEAN,
     is_disabled      BOOLEAN,

--- a/docker/mysql/initdb.d/create_table.sql
+++ b/docker/mysql/initdb.d/create_table.sql
@@ -98,8 +98,8 @@ CREATE TABLE available_time
     trainer_id        BIGINT,
     is_holiday        BOOLEAN,
     unavailable       BOOLEAN,
-    start_time        DATETIME(12),
-    end_time          DATETIME(12),
+    start_time        DATETIME(6),
+    end_time          DATETIME(6),
     created_at        DATETIME(6),
     updated_at        DATETIME(6),
     PRIMARY KEY (available_time_id)
@@ -137,8 +137,8 @@ CREATE TABLE reservation
     trainer_id       BIGINT,
     session_info_id  BIGINT,
     name             VARCHAR(255),
-    reservation_date DATETIME(12) NOT NULL,
-    change_date      DATETIME(12),
+    reservation_date DATETIME(6) NOT NULL,
+    change_date      DATETIME(6),
     status           ENUM ('CANCEL', 'RESERVATION_REQUEST', 'CHANGE_REQUEST', 'CANCEL_REQUEST', 'COMPLETED'),
     cancel_reason    VARCHAR(255),
     approved_cancel  BOOLEAN,
@@ -185,6 +185,6 @@ CREATE TABLE notification
     is_sent            BOOLEAN,
     is_read            BOOLEAN,
     is_processed       BOOLEAN,
-    send_date          DATETIME(12),
+    send_date          DATETIME(6),
     PRIMARY KEY (notification_id)
 );

--- a/src/main/java/spring/fitlinkbe/application/reservation/ReservationFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/reservation/ReservationFacade.java
@@ -2,21 +2,43 @@ package spring.fitlinkbe.application.reservation;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import spring.fitlinkbe.domain.common.model.PersonalDetail;
+import spring.fitlinkbe.domain.member.MemberService;
 import spring.fitlinkbe.domain.reservation.Reservation;
 import spring.fitlinkbe.domain.reservation.ReservationService;
+import spring.fitlinkbe.domain.reservation.Session;
 import spring.fitlinkbe.support.security.SecurityUser;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class ReservationFacade {
 
     private final ReservationService reservationService;
+    private final MemberService memberService;
 
-    public List<Reservation> getReservations(LocalDate date, SecurityUser user) {
+    public ReservationResult.Reservations getReservations(LocalDate date, SecurityUser user) {
 
-        return reservationService.getReservations(date, user.getUserRole(), user.getUserId());
+        return ReservationResult.Reservations.from(reservationService
+                .getReservations(date, user.getUserRole(), user.getUserId()));
+    }
+
+
+    @Transactional(readOnly = true)
+    public ReservationResult.ReservationDetail getReservation(Long reservationId) {
+        //예약 상세 정보 조회
+        Reservation reservation = reservationService.getReservation(reservationId);
+
+        //세션 정보 조회
+        Session session = reservationService.getSession(reservation.isApproved(),
+                reservationId);
+
+        // 개인 정보 조회
+        PersonalDetail personalDetail = memberService.getMemberDetail(reservation.getMember().getMemberId());
+
+        // 조합해서 리턴
+        return ReservationResult.ReservationDetail.from(reservation, session, personalDetail);
     }
 }

--- a/src/main/java/spring/fitlinkbe/application/reservation/ReservationResult.java
+++ b/src/main/java/spring/fitlinkbe/application/reservation/ReservationResult.java
@@ -1,0 +1,35 @@
+package spring.fitlinkbe.application.reservation;
+
+import lombok.Builder;
+import spring.fitlinkbe.domain.common.model.PersonalDetail;
+import spring.fitlinkbe.domain.reservation.Reservation;
+import spring.fitlinkbe.domain.reservation.Session;
+
+import java.util.List;
+
+public class ReservationResult {
+
+    @Builder(toBuilder = true)
+    public record ReservationDetail(Reservation reservation, Session session, PersonalDetail personalDetail) {
+
+        public static ReservationDetail from(Reservation reservation, Session session, PersonalDetail personalDetail) {
+
+            return ReservationResult.ReservationDetail.builder()
+                    .reservation(reservation)
+                    .session(session)
+                    .personalDetail(personalDetail)
+                    .build();
+        }
+    }
+
+    @Builder(toBuilder = true)
+    public record Reservations(List<Reservation> reservations) {
+
+        public static Reservations from(List<Reservation> reservations) {
+
+            return ReservationResult.Reservations.builder()
+                    .reservations(reservations)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
@@ -11,11 +11,15 @@ public enum ErrorCode {
     TRAINER_IS_NOT_FOUND("트레이너 정보가 존재하지 않습니다.", 404),
 
     // Member 관련 ErrorCode
+    MEMBER_DETAIL_NOT_FOUND("멤버 상세 정보를 찾지 못하였습니다", 404),
+
 
     // Reservation 관련 ErrorCode
     RESERVATION_IS_FAILED("예약에 실패하였습니다.", 400),
+    RESERVATION_NOT_FOUND("예약 정보를 찾지 못하였습니다.", 404),
 
     // Session 관련 ErrorCode
+    SESSION_NOT_FOUND("세션 정보를 찾지 못하였습니다.", 404),
 
     // Notification 관련 ErrorCode
 

--- a/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
+++ b/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
@@ -1,0 +1,23 @@
+package spring.fitlinkbe.domain.member;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import spring.fitlinkbe.domain.common.PersonalDetailRepository;
+import spring.fitlinkbe.domain.common.exception.CustomException;
+import spring.fitlinkbe.domain.common.model.PersonalDetail;
+
+import static spring.fitlinkbe.domain.common.exception.ErrorCode.MEMBER_DETAIL_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+    private final PersonalDetailRepository personalDetailRepository;
+
+
+    public PersonalDetail getMemberDetail(Long memberId) {
+        return personalDetailRepository.getMemberDetail(memberId)
+                .orElseThrow(() -> new CustomException(MEMBER_DETAIL_NOT_FOUND,
+                        "멤버 상세 정보를 찾을 수 없습니다. [memberId: %d]".formatted(memberId)));
+    }
+}

--- a/src/main/java/spring/fitlinkbe/domain/reservation/Reservation.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/Reservation.java
@@ -31,8 +31,8 @@ public class Reservation {
     private DayOfWeek dayOfWeek;
     private Status status;
     private String cancelReason;
-    private boolean approvedCancel;
     private int priority;
+    private boolean isApproved;
     private boolean isFixed;
     private boolean isDisabled;
     private boolean isDayOff;
@@ -41,7 +41,7 @@ public class Reservation {
 
     public enum Status {
         RESERVATION_WAITING, // 예약 대기
-        RESERVATION_COMPLETED, // 예약 확정
+        RESERVATION_APPROVED, // 예약 확정
         RESERVATION_CANCELLED, // 예약 취소
         RESERVATION_REJECTED,  // 예약 거부
         RESERVATION_CHANGE_REQUEST //예약 변경 요청

--- a/src/main/java/spring/fitlinkbe/domain/reservation/ReservationRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/ReservationRepository.java
@@ -12,7 +12,11 @@ public interface ReservationRepository {
     List<Reservation> getReservations(
             LocalDateTime startDate, LocalDateTime endDate, UserRole role, Long userId);
 
+    Optional<Reservation> getReservation(Long reservationId);
+
     Optional<Reservation> saveReservation(Reservation reservation);
 
+    Optional<Session> getSession(Long reservationId);
 
+    Optional<Session> saveSession(Session session);
 }

--- a/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
@@ -6,10 +6,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import spring.fitlinkbe.domain.common.enums.UserRole;
+import spring.fitlinkbe.domain.common.exception.CustomException;
+import spring.fitlinkbe.domain.common.exception.ErrorCode;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -25,5 +28,24 @@ public class ReservationService {
         LocalDateTime endDate = Reservation.getEndDate(startDate, role);
 
         return reservationRepository.getReservations(startDate, endDate, role, userId);
+    }
+
+    @Transactional(readOnly = true)
+    public Reservation getReservation(Long reservationId) {
+        return reservationRepository.getReservation(reservationId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_NOT_FOUND,
+                        "예약 정보를 찾을 수 없습니다. [reservationId: %d]".formatted(reservationId)));
+    }
+
+    @Transactional(readOnly = true)
+    public Session getSession(boolean isApproved, Long reservationId) {
+        Optional<Session> getSession = reservationRepository.getSession(reservationId);
+        // 예약 승낙 전에는 세션 정보는 없다.
+        if (!isApproved) {
+            return null;
+        }
+
+        return getSession.orElseThrow(() -> new CustomException(ErrorCode.SESSION_NOT_FOUND,
+                "세션 정보를 찾을 수 없습니다. [reservationId: %d]".formatted(reservationId)));
     }
 }

--- a/src/main/java/spring/fitlinkbe/domain/reservation/Session.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/Session.java
@@ -1,0 +1,25 @@
+package spring.fitlinkbe.domain.reservation;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder(toBuilder = true)
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Session {
+    private Long sessionId;
+    private Reservation reservation;
+    private Status status;
+    private String cancelReason;
+    private boolean isCompleted;
+
+    public enum Status {
+        SESSION_CANCELLED, // 세션 취소
+        SESSION_PROCESSING, // 세션 진행
+        SESSION_COMPLETED, // 세션 완료
+    }
+}

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationEntity.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationEntity.java
@@ -49,9 +49,9 @@ public class ReservationEntity extends BaseTimeEntity {
 
     private String cancelReason;
 
-    private boolean approvedCancel;
-
     private int priority;
+
+    private boolean isApproved;
 
     private boolean isFixed;
 
@@ -75,7 +75,7 @@ public class ReservationEntity extends BaseTimeEntity {
                 .dayOfWeek(reservation.getDayOfWeek())
                 .status(reservation.getStatus())
                 .cancelReason(reservation.getCancelReason())
-                .approvedCancel(reservation.isApprovedCancel())
+                .isApproved(reservation.isApproved())
                 .priority(reservation.getPriority())
                 .isFixed(reservation.isFixed())
                 .isDayOff(reservation.isDayOff())
@@ -87,6 +87,7 @@ public class ReservationEntity extends BaseTimeEntity {
         return Reservation.builder()
                 .reservationId(reservationId)
                 .member((isDayOff || isDisabled) ? null : member.toDomain())
+                .trainer(trainer.toDomain())
                 .sessionInfo((isDayOff || isDisabled) ? null : sessionInfo.toDomain())
                 .name(name)
                 .reservationDate(reservationDate)
@@ -94,8 +95,8 @@ public class ReservationEntity extends BaseTimeEntity {
                 .dayOfWeek(dayOfWeek)
                 .status(status)
                 .cancelReason(cancelReason)
-                .approvedCancel(approvedCancel)
                 .priority(priority)
+                .isApproved(isApproved)
                 .isFixed(isFixed)
                 .isDayOff(isDayOff)
                 .isDisabled(isDisabled)

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationJpaRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface ReservationJpaRepository extends JpaRepository<ReservationEntity, Long> {
 
@@ -22,4 +23,10 @@ public interface ReservationJpaRepository extends JpaRepository<ReservationEntit
             @Param("memberId") Long memberId,
             @Param("startDate") LocalDateTime startDate,
             @Param("endDate") LocalDateTime endDate);
+
+    @Query("SELECT r FROM ReservationEntity r " +
+            "LEFT JOIN FETCH r.member " +
+            "LEFT JOIN FETCH r.trainer " +
+            "WHERE r.reservationId = :reservationId")
+    Optional<ReservationEntity> findByIdJoinFetch(Long reservationId);
 }

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationRepositoryImpl.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Repository;
 import spring.fitlinkbe.domain.common.enums.UserRole;
 import spring.fitlinkbe.domain.reservation.Reservation;
 import spring.fitlinkbe.domain.reservation.ReservationRepository;
+import spring.fitlinkbe.domain.reservation.Session;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,6 +18,7 @@ import static spring.fitlinkbe.domain.common.enums.UserRole.MEMBER;
 public class ReservationRepositoryImpl implements ReservationRepository {
 
     private final ReservationJpaRepository reservationJpaRepository;
+    private final SessionJpaRepository sessionJpaRepository;
 
     @Override
     public List<Reservation> getReservations(LocalDateTime startDate, LocalDateTime endDate,
@@ -38,9 +40,34 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     }
 
     @Override
+    public Optional<Reservation> getReservation(Long reservationId) {
+        Optional<ReservationEntity> findEntity = reservationJpaRepository.findByIdJoinFetch(reservationId);
+        if (findEntity.isPresent()) {
+            return findEntity.map(ReservationEntity::toDomain);
+        }
+        return Optional.empty();
+    }
+
+    @Override
     public Optional<Reservation> saveReservation(Reservation reservation) {
         ReservationEntity reservationEntity = reservationJpaRepository.save(ReservationEntity.from(reservation));
 
         return Optional.of(reservationEntity.toDomain());
+    }
+
+    @Override
+    public Optional<Session> getSession(Long reservationId) {
+        Optional<SessionEntity> findEntity = sessionJpaRepository.findByReservation_ReservationId(reservationId);
+        if (findEntity.isPresent()) {
+            return findEntity.map(SessionEntity::toDomain);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Session> saveSession(Session session) {
+        SessionEntity savedEntity = sessionJpaRepository.save(SessionEntity.from(session));
+
+        return Optional.of(savedEntity.toDomain());
     }
 }

--- a/src/main/java/spring/fitlinkbe/infra/reservation/SessionEntity.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/SessionEntity.java
@@ -1,0 +1,53 @@
+package spring.fitlinkbe.infra.reservation;
+
+import jakarta.persistence.*;
+import lombok.*;
+import spring.fitlinkbe.domain.reservation.Session;
+import spring.fitlinkbe.infra.common.model.BaseTimeEntity;
+
+import static spring.fitlinkbe.domain.reservation.Session.Status;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // proxy 객체 생성을 위해
+@AllArgsConstructor // 빌더 패턴 사용을 위해
+@Table(name = "session")
+public class SessionEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long sessionId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reservation_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private ReservationEntity reservation;
+
+    private Status status;
+
+    private String cancelReason;
+
+    private boolean isCompleted;
+
+    public static SessionEntity from(Session session) {
+
+        return SessionEntity.builder()
+                .sessionId(session.getSessionId() != null
+                        ? session.getSessionId() : null)
+                .reservation(ReservationEntity.from(session.getReservation()))
+                .status(session.getStatus())
+                .cancelReason(session.getCancelReason())
+                .isCompleted(session.isCompleted())
+                .build();
+    }
+
+    public Session toDomain() {
+        return Session.builder()
+                .sessionId(sessionId)
+                .reservation(reservation.toDomain())
+                .status(status)
+                .cancelReason(cancelReason)
+                .isCompleted(isCompleted)
+                .build();
+    }
+}

--- a/src/main/java/spring/fitlinkbe/infra/reservation/SessionJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/SessionJpaRepository.java
@@ -1,0 +1,10 @@
+package spring.fitlinkbe.infra.reservation;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SessionJpaRepository extends JpaRepository<SessionEntity, Long> {
+
+    Optional<SessionEntity> findByReservation_ReservationId(Long reservationId);
+}

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
@@ -33,11 +33,10 @@ public class ReservationController {
 
     @GetMapping("/{reservationId}")
     public ApiResultResponse<ReservationDetailDto.Response> getReservation(@PathVariable("reservationId")
-                                                                           @NotNull Long reservationId,
-                                                                           @Login SecurityUser user) {
+                                                                           @NotNull Long reservationId) {
 
         return ApiResultResponse.ok(ReservationDetailDto.Response.of(
-                reservationFacade.getReservation(reservationId, user)));
+                reservationFacade.getReservation(reservationId)));
 
     }
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
@@ -1,13 +1,12 @@
 package spring.fitlinkbe.interfaces.controller.reservation;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import spring.fitlinkbe.application.reservation.ReservationFacade;
 import spring.fitlinkbe.interfaces.controller.common.dto.ApiResultResponse;
+import spring.fitlinkbe.interfaces.controller.reservation.dto.ReservationDetailDto;
 import spring.fitlinkbe.interfaces.controller.reservation.dto.ReservationDto;
 import spring.fitlinkbe.support.argumentresolver.Login;
 import spring.fitlinkbe.support.security.SecurityUser;
@@ -27,8 +26,18 @@ public class ReservationController {
     public ApiResultResponse<List<ReservationDto.Response>> getReservations(@RequestParam LocalDate date,
                                                                             @Login SecurityUser user) {
 
-        return ApiResultResponse.ok(reservationFacade.getReservations(date, user).stream()
+        return ApiResultResponse.ok(reservationFacade.getReservations(date, user).reservations().stream()
                 .map(ReservationDto.Response::of).toList());
+
+    }
+
+    @GetMapping("/{reservationId}")
+    public ApiResultResponse<ReservationDetailDto.Response> getReservation(@PathVariable("reservationId")
+                                                                           @NotNull Long reservationId,
+                                                                           @Login SecurityUser user) {
+
+        return ApiResultResponse.ok(ReservationDetailDto.Response.of(
+                reservationFacade.getReservation(reservationId, user)));
 
     }
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationDetailDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationDetailDto.java
@@ -1,0 +1,38 @@
+package spring.fitlinkbe.interfaces.controller.reservation.dto;
+
+import lombok.Builder;
+import spring.fitlinkbe.application.reservation.ReservationResult;
+import spring.fitlinkbe.domain.reservation.Reservation;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class ReservationDetailDto {
+
+    @Builder(toBuilder = true)
+    public record Response(Long reservationId, Long sessionId,
+                           DayOfWeek dayOfWeek, LocalDateTime reservationDate,
+                           Reservation.Status status, PersonalInfo memberInfo) {
+
+        public static ReservationDetailDto.Response of(ReservationResult.ReservationDetail result) {
+
+            return Response.builder()
+                    .reservationId(result.reservation().getReservationId())
+                    .sessionId(result.session() != null ? result.session().getSessionId() : null)
+                    .dayOfWeek(result.reservation().getDayOfWeek())
+                    .reservationDate(result.reservation().getReservationDate())
+                    .status(result.reservation().getStatus())
+                    .memberInfo(new PersonalInfo(result.personalDetail().getMemberId(),
+                            result.reservation().getName(),
+                            result.reservation().getMember().getBirthDate(),
+                            result.personalDetail().getPhoneNumber(),
+                            result.personalDetail().getProfilePictureUrl()))
+                    .build();
+        }
+    }
+
+    private record PersonalInfo(Long memberId, String name, LocalDate birthDate, String phoneNumber,
+                                String profilePictureUrl) {
+    }
+}

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationDto.java
@@ -11,7 +11,7 @@ public class ReservationDto {
     @Builder(toBuilder = true)
     public record Response(Long reservationId, Long sessionInfoId,
                            boolean isDayOff, DayOfWeek dayOfWeek, LocalDateTime reservationDate,
-                           Reservation.Status status, int priority, MemberInfo memberInfo) {
+                           Reservation.Status status, MemberInfo memberInfo) {
 
         public static ReservationDto.Response of(Reservation reservation) {
 
@@ -22,7 +22,6 @@ public class ReservationDto {
                     .isDayOff(reservation.isDayOff())
                     .dayOfWeek(reservation.getDayOfWeek())
                     .reservationDate(reservation.getReservationDate())
-                    .priority(reservation.getPriority())
                     .status(reservation.getStatus())
                     .memberInfo(reservation.isReservationNotAllowed() ? null :
                             new MemberInfo(reservation.getMember().getMemberId(), reservation.getName()))

--- a/src/main/java/spring/fitlinkbe/support/config/ApplicationYmlRead.java
+++ b/src/main/java/spring/fitlinkbe/support/config/ApplicationYmlRead.java
@@ -10,10 +10,10 @@ import java.util.Map;
 @Setter
 @ConfigurationProperties(prefix = "app")
 public class ApplicationYmlRead {
-	private Map<String, String> front;
+    private Map<String, String> front;
 
-	public String getFrontUrl() {
-		return front.get("url");
-	}
+    public String getFrontUrl() {
+        return front.get("url");
+    }
 
 }

--- a/src/main/java/spring/fitlinkbe/support/security/handler/CustomOauth2SuccessHandler.java
+++ b/src/main/java/spring/fitlinkbe/support/security/handler/CustomOauth2SuccessHandler.java
@@ -12,9 +12,9 @@ import org.springframework.web.util.UriComponentsBuilder;
 import spring.fitlinkbe.domain.common.TokenRepository;
 import spring.fitlinkbe.domain.common.model.PersonalDetail.Status;
 import spring.fitlinkbe.domain.common.model.Token;
+import spring.fitlinkbe.support.config.ApplicationYmlRead;
 import spring.fitlinkbe.support.security.AuthTokenProvider;
 import spring.fitlinkbe.support.security.SecurityUser;
-import spring.fitlinkbe.support.config.ApplicationYmlRead;
 
 import java.io.IOException;
 

--- a/src/test/java/spring/fitlinkbe/domain/member/MemberServiceTest.java
+++ b/src/test/java/spring/fitlinkbe/domain/member/MemberServiceTest.java
@@ -1,0 +1,74 @@
+package spring.fitlinkbe.domain.member;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import spring.fitlinkbe.domain.common.PersonalDetailRepository;
+import spring.fitlinkbe.domain.common.exception.CustomException;
+import spring.fitlinkbe.domain.common.model.PersonalDetail;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static spring.fitlinkbe.domain.common.exception.ErrorCode.MEMBER_DETAIL_NOT_FOUND;
+
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PersonalDetailRepository personalDetailRepository;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("멤버의 상세 정보를 반환한다.")
+    void getMemberDetail() {
+        //given
+        PersonalDetail memberDetail = PersonalDetail.builder()
+                .memberId(1L)
+                .personalDetailId(1L)
+                .name("홍길동")
+                .build();
+
+        when(personalDetailRepository.getMemberDetail(memberDetail.getMemberId()))
+                .thenReturn(Optional.of(memberDetail));
+
+        //when
+        PersonalDetail result = memberService.getMemberDetail(memberDetail.getMemberId());
+
+        //then
+        Assertions.assertThat(result.getMemberId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("멤버의 상세 정보가 없으면 PERSONAL_DETAIL_NOT_FOUND 예외를 반환한다..")
+    void getMemberDetailWithNotFound() {
+        //given
+        Long memberId = 1L;
+
+        when(personalDetailRepository.getMemberDetail(any(Long.class))).thenThrow(
+                new CustomException(MEMBER_DETAIL_NOT_FOUND,
+                        MEMBER_DETAIL_NOT_FOUND.getMsg()));
+
+        //when & then
+        assertThatThrownBy(() -> memberService.getMemberDetail(memberId))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(MEMBER_DETAIL_NOT_FOUND);
+    }
+
+}

--- a/src/test/java/spring/fitlinkbe/domain/reservation/ReservationTest.java
+++ b/src/test/java/spring/fitlinkbe/domain/reservation/ReservationTest.java
@@ -1,0 +1,40 @@
+package spring.fitlinkbe.domain.reservation;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ReservationTest {
+
+    @Test
+    @DisplayName("연차 정보가 있으면 true를 반환한다.")
+    void isReservationNotAllowedWithDayOff() {
+        //given
+        Reservation reservation = Reservation.builder()
+                .reservationId(1L)
+                .isDayOff(true)
+                .build();
+
+        //when
+        boolean result = reservation.isReservationNotAllowed();
+
+        //then
+        Assertions.assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("예약 불가 설정 정보가 있으면 true를 반환한다.")
+    void isReservationNotAllowedWithDisabled() {
+        //given
+        Reservation reservation = Reservation.builder()
+                .reservationId(1L)
+                .isDisabled(true)
+                .build();
+
+        //when
+        boolean result = reservation.isReservationNotAllowed();
+
+        //then
+        Assertions.assertThat(result).isTrue();
+    }
+}

--- a/src/test/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationControllerTest.java
+++ b/src/test/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationControllerTest.java
@@ -335,7 +335,7 @@ class ReservationControllerTest {
         ReservationResult.ReservationDetail result = ReservationResult.ReservationDetail
                 .from(reservation, session, personalDetail);
 
-        when(reservationFacade.getReservation(any(Long.class), any(SecurityUser.class))).thenReturn(result);
+        when(reservationFacade.getReservation(any(Long.class))).thenReturn(result);
 
         //when & then
         mockMvc.perform(get("/v1/reservations/%s".formatted(reservation.getReservationId()))
@@ -365,7 +365,7 @@ class ReservationControllerTest {
         String accessToken = getAccessToken(personalDetail);
 
         //when
-        when(reservationFacade.getReservation(any(Long.class), any(SecurityUser.class))).thenThrow(
+        when(reservationFacade.getReservation(any(Long.class))).thenThrow(
                 new CustomException(RESERVATION_NOT_FOUND,
                         RESERVATION_NOT_FOUND.getMsg())
         );


### PR DESCRIPTION
### 구현 기능

- "/v1/reservations/{reservationId}" 예약 상세 조회

### 세부 사항

- 예약 상세 조회 API 개발 완료
- 관련 entity 추가
- 테스트 코드 추가
- ddl문 수정
- 라인 정리

### DB 변동사항

- LocalDateTime 크기 변경 12 -> 6
    - 12로 하면 사이즈 over 에러 남
- Reservation 에 approved_cancel → is_approved 로 파라미터명 변경