### PR TITLE
[FLIZ-90] 트레이너 연결 요청 API 작업

### DIFF
--- a/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
@@ -1,0 +1,32 @@
+package spring.fitlinkbe.application.member;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import spring.fitlinkbe.domain.common.model.ConnectingInfo;
+import spring.fitlinkbe.domain.common.model.PersonalDetail;
+import spring.fitlinkbe.domain.member.Member;
+import spring.fitlinkbe.domain.member.MemberService;
+import spring.fitlinkbe.domain.notification.NotificationService;
+import spring.fitlinkbe.domain.trainer.Trainer;
+import spring.fitlinkbe.domain.trainer.TrainerService;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class MemberFacade {
+    private final MemberService memberService;
+    private final TrainerService trainerService;
+    private final NotificationService notificationService;
+
+    public void connectTrainer(Long memberId, String trainerCode) {
+        memberService.checkMemberAlreadyConnected(memberId);
+
+        Trainer trainer = trainerService.getTrainerByCode(trainerCode);
+        Member member = memberService.getMember(memberId);
+
+        ConnectingInfo connectingInfo = memberService.requestConnectTrainer(trainer, member);
+        PersonalDetail trainerDetail = trainerService.getTrainerDetail(trainer.getTrainerId());
+        notificationService.sendConnectRequestNotification(trainerDetail, member.getName(), connectingInfo.getConnectingInfoId());
+    }
+}

--- a/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
@@ -13,12 +13,12 @@ import spring.fitlinkbe.domain.trainer.TrainerService;
 
 @Component
 @RequiredArgsConstructor
-@Transactional
 public class MemberFacade {
     private final MemberService memberService;
     private final TrainerService trainerService;
     private final NotificationService notificationService;
 
+    @Transactional
     public void connectTrainer(Long memberId, String trainerCode) {
         memberService.checkMemberAlreadyConnected(memberId);
 

--- a/src/main/java/spring/fitlinkbe/domain/common/ConnectingInfoRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/ConnectingInfoRepository.java
@@ -1,0 +1,9 @@
+package spring.fitlinkbe.domain.common;
+
+import spring.fitlinkbe.domain.common.model.ConnectingInfo;
+
+public interface ConnectingInfoRepository {
+    ConnectingInfo getConnectingInfo(Long memberId, Long trainerId);
+
+    void save(ConnectingInfo connectingInfo);
+}

--- a/src/main/java/spring/fitlinkbe/domain/common/ConnectingInfoRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/ConnectingInfoRepository.java
@@ -2,8 +2,12 @@ package spring.fitlinkbe.domain.common;
 
 import spring.fitlinkbe.domain.common.model.ConnectingInfo;
 
+import java.util.Optional;
+
 public interface ConnectingInfoRepository {
     ConnectingInfo getConnectingInfo(Long memberId, Long trainerId);
 
-    void save(ConnectingInfo connectingInfo);
+    ConnectingInfo save(ConnectingInfo connectingInfo);
+
+    Optional<ConnectingInfo> getExistConnectingInfo(Long memberId);
 }

--- a/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     SESSION_IS_ALREADY_COMPLETED("이미 끝난 세션은 취소할 수 없습니다.", 400),
 
     // Notification 관련 ErrorCode
+    NOTIFICATION_NOT_FOUND("알림 정보를 찾지 못하였습니다.", 404),
 
     // Auth 관련 ErrorCode
     UNSUPPORTED_OAUTH_PROVIDER("지원하지 않는 OAuth 제공자입니다.", 400),
@@ -41,6 +42,7 @@ public enum ErrorCode {
     // Common ErrorCode
     INVALID_PHONE_NUMBER_FORMAT("유효하지 않은 전화번호 형식입니다.", 400),
     PERSONAL_DETAIL_NOT_FOUND("Personal Detail 정보가 존재하지 않습니다.", 404),
+    CONNECTING_INFO_NOT_FOUND("Connecting Info 정보가 존재하지 않습니다.", 404),
     ;
 
     private final String msg;

--- a/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
 
     // Member 관련 ErrorCode
     MEMBER_DETAIL_NOT_FOUND("멤버 상세 정보를 찾지 못하였습니다", 404),
+    MEMBER_NOT_FOUND("멤버 정보를 찾지 못하였습니다.", 404),
 
 
     // Reservation 관련 ErrorCode
@@ -43,6 +44,7 @@ public enum ErrorCode {
     INVALID_PHONE_NUMBER_FORMAT("유효하지 않은 전화번호 형식입니다.", 400),
     PERSONAL_DETAIL_NOT_FOUND("Personal Detail 정보가 존재하지 않습니다.", 404),
     CONNECTING_INFO_NOT_FOUND("Connecting Info 정보가 존재하지 않습니다.", 404),
+    MEMBER_CONNECTED_TRAINER_ALREADY("이미 연결 요청중 또는 연결된 트레이너가 존재합니다.", 409),
     ;
 
     private final String msg;

--- a/src/main/java/spring/fitlinkbe/domain/common/model/ConnectingInfo.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/model/ConnectingInfo.java
@@ -1,0 +1,29 @@
+package spring.fitlinkbe.domain.common.model;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import spring.fitlinkbe.domain.member.Member;
+import spring.fitlinkbe.domain.trainer.Trainer;
+
+import java.time.LocalDateTime;
+
+
+@Builder(toBuilder = true)
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConnectingInfo {
+    private Long connectingInfoId;
+    private Trainer trainer;
+    private Member member;
+    private ConnectingStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public enum ConnectingStatus {
+        REQUESTED, CONNECTED, REJECTED
+    }
+}

--- a/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
+++ b/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
@@ -4,11 +4,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import spring.fitlinkbe.domain.auth.command.AuthCommand;
+import spring.fitlinkbe.domain.common.ConnectingInfoRepository;
 import spring.fitlinkbe.domain.common.PersonalDetailRepository;
 import spring.fitlinkbe.domain.common.exception.CustomException;
+import spring.fitlinkbe.domain.common.exception.ErrorCode;
+import spring.fitlinkbe.domain.common.model.ConnectingInfo;
 import spring.fitlinkbe.domain.common.model.PersonalDetail;
+import spring.fitlinkbe.domain.trainer.Trainer;
 
 import java.util.List;
+import java.util.Optional;
 
 import static spring.fitlinkbe.domain.common.exception.ErrorCode.MEMBER_DETAIL_NOT_FOUND;
 
@@ -20,6 +25,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final WorkoutScheduleRepository workoutScheduleRepository;
     private final PersonalDetailRepository personalDetailRepository;
+    private final ConnectingInfoRepository connectingInfoRepository;
 
     public PersonalDetail registerMember(Long personalDetailId, AuthCommand.MemberRegisterRequest command, Member savedMember) {
         PersonalDetail personalDetail = personalDetailRepository.getById(personalDetailId);
@@ -41,5 +47,34 @@ public class MemberService {
 
     public void saveWorkoutSchedules(List<WorkoutSchedule> workoutSchedules) {
         workoutScheduleRepository.saveAll(workoutSchedules);
+    }
+
+    /**
+     * 멤버가 이미 연결되어 있는지 확인 </br>
+     * 해당 회원의 이미 존재하는, REJECTED 되지 않은 ConnectingInfo 가 있는지 확인
+     *
+     * @param memberId
+     * @throws CustomException 이미 연결되어 있을 경우
+     */
+    public void checkMemberAlreadyConnected(Long memberId) {
+        Optional<ConnectingInfo> existsConnectingInfo = connectingInfoRepository.getExistConnectingInfo(memberId);
+        if (existsConnectingInfo.isPresent()) {
+            throw new CustomException(ErrorCode.MEMBER_CONNECTED_TRAINER_ALREADY);
+        }
+    }
+
+    public Member getMember(Long memberId) {
+        return memberRepository.getMember(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    public ConnectingInfo requestConnectTrainer(Trainer trainer, Member member) {
+        ConnectingInfo connectingInfo = ConnectingInfo.builder()
+                .member(member)
+                .trainer(trainer)
+                .status(ConnectingInfo.ConnectingStatus.REQUESTED)
+                .build();
+
+        return connectingInfoRepository.save(connectingInfo);
     }
 }

--- a/src/main/java/spring/fitlinkbe/domain/notification/Dummy.java
+++ b/src/main/java/spring/fitlinkbe/domain/notification/Dummy.java
@@ -1,4 +1,0 @@
-package spring.fitlinkbe.domain.notification;
-
-public class Dummy {
-}

--- a/src/main/java/spring/fitlinkbe/domain/notification/Notification.java
+++ b/src/main/java/spring/fitlinkbe/domain/notification/Notification.java
@@ -21,10 +21,30 @@ public class Notification {
     private Boolean isProcessed;
     private LocalDateTime sendDate;
 
+    public static Notification connectRequestNotification(PersonalDetail trainerDetail,
+                                                          String memberName, Long connectingInfoId) {
+        String content = memberName + " 님에게 연동 요청이 왔습니다.";
+
+        return Notification.builder()
+                .refId(connectingInfoId)
+                .refType(NotificationType.CONNECT)
+                .personalDetail(trainerDetail)
+                .name(NotificationType.CONNECT.getName())
+                .content(content)
+                .isSent(true)
+                .isRead(false)
+                .isProcessed(false)
+                .sendDate(LocalDateTime.now())
+                .build();
+    }
+
     @RequiredArgsConstructor
+    @Getter
     public enum NotificationType {
-        CONNECT("트레이너 연동 요청");
+        CONNECT("트레이너 연동 요청", "트레이너와 연동 요청이 왔습니다."),
+        ;
 
         private final String description;
+        private final String name;
     }
 }

--- a/src/main/java/spring/fitlinkbe/domain/notification/Notification.java
+++ b/src/main/java/spring/fitlinkbe/domain/notification/Notification.java
@@ -1,0 +1,30 @@
+package spring.fitlinkbe.domain.notification;
+
+import lombok.*;
+import spring.fitlinkbe.domain.common.model.PersonalDetail;
+
+import java.time.LocalDateTime;
+
+@Builder(toBuilder = true)
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Notification {
+    private Long notificationId;
+    private Long refId;
+    private NotificationType refType;
+    private PersonalDetail personalDetail;
+    private String name;
+    private String content;
+    private Boolean isSent;
+    private Boolean isRead;
+    private Boolean isProcessed;
+    private LocalDateTime sendDate;
+
+    @RequiredArgsConstructor
+    public enum NotificationType {
+        CONNECT("트레이너 연동 요청");
+
+        private final String description;
+    }
+}

--- a/src/main/java/spring/fitlinkbe/domain/notification/NotificationRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/notification/NotificationRepository.java
@@ -1,0 +1,5 @@
+package spring.fitlinkbe.domain.notification;
+
+public interface NotificationRepository {
+    Notification getNotification(Long personalDetailId);
+}

--- a/src/main/java/spring/fitlinkbe/domain/notification/NotificationRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/notification/NotificationRepository.java
@@ -2,4 +2,6 @@ package spring.fitlinkbe.domain.notification;
 
 public interface NotificationRepository {
     Notification getNotification(Long personalDetailId);
+
+    void save(Notification notification);
 }

--- a/src/main/java/spring/fitlinkbe/domain/notification/NotificationService.java
+++ b/src/main/java/spring/fitlinkbe/domain/notification/NotificationService.java
@@ -1,0 +1,18 @@
+package spring.fitlinkbe.domain.notification;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import spring.fitlinkbe.domain.common.model.PersonalDetail;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class NotificationService {
+    private final NotificationRepository notificationRepository;
+
+    public void sendConnectRequestNotification(PersonalDetail trainerDetail, String memberName, Long connectingInfoId) {
+        Notification notification = Notification.connectRequestNotification(trainerDetail, memberName, connectingInfoId);
+        notificationRepository.save(notification);
+    }
+}

--- a/src/main/java/spring/fitlinkbe/domain/trainer/TrainerRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/trainer/TrainerRepository.java
@@ -18,4 +18,6 @@ public interface TrainerRepository {
     Optional<DayOff> saveDayOff(DayOff dayOff);
 
     void saveAvailableTimes(List<AvailableTime> availableTimes);
+
+    Trainer getTrainerByCode(String trainerCode);
 }

--- a/src/main/java/spring/fitlinkbe/domain/trainer/TrainerService.java
+++ b/src/main/java/spring/fitlinkbe/domain/trainer/TrainerService.java
@@ -43,4 +43,14 @@ public class TrainerService {
     public void saveAvailableTimes(List<AvailableTime> availableTimes) {
         trainerRepository.saveAvailableTimes(availableTimes);
     }
+
+    public Trainer getTrainerByCode(String trainerCode) {
+        return trainerRepository.getTrainerByCode(trainerCode);
+    }
+
+    public PersonalDetail getTrainerDetail(Long trainerId) {
+        return personalDetailRepository.getTrainerDetail(trainerId)
+                .orElseThrow(() -> new CustomException(TRAINER_IS_NOT_FOUND,
+                        "트레이너 상세 정보를 찾을 수 없습니다. [trainerId: %d]".formatted(trainerId)));
+    }
 }

--- a/src/main/java/spring/fitlinkbe/infra/common/connectingInfo/ConnectingInfoEntity.java
+++ b/src/main/java/spring/fitlinkbe/infra/common/connectingInfo/ConnectingInfoEntity.java
@@ -19,11 +19,11 @@ public class ConnectingInfoEntity extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long connectingInfoId;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "trainer_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private TrainerEntity trainer;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private MemberEntity member;
 

--- a/src/main/java/spring/fitlinkbe/infra/common/connectingInfo/ConnectingInfoEntity.java
+++ b/src/main/java/spring/fitlinkbe/infra/common/connectingInfo/ConnectingInfoEntity.java
@@ -1,0 +1,52 @@
+package spring.fitlinkbe.infra.common.connectingInfo;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import spring.fitlinkbe.domain.common.model.ConnectingInfo;
+import spring.fitlinkbe.infra.common.model.BaseTimeEntity;
+import spring.fitlinkbe.infra.member.MemberEntity;
+import spring.fitlinkbe.infra.trainer.TrainerEntity;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "connecting_info")
+public class ConnectingInfoEntity extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long connectingInfoId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trainer_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private TrainerEntity trainer;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private MemberEntity member;
+
+    @Enumerated(EnumType.STRING)
+    private ConnectingInfo.ConnectingStatus status;
+
+    public static ConnectingInfoEntity from(ConnectingInfo connectingInfo) {
+        return ConnectingInfoEntity.builder()
+                .connectingInfoId(connectingInfo.getConnectingInfoId())
+                .trainer(TrainerEntity.from(connectingInfo.getTrainer()))
+                .member(MemberEntity.from(connectingInfo.getMember()))
+                .status(connectingInfo.getStatus())
+                .build();
+    }
+
+    public ConnectingInfo toDomain() {
+        return ConnectingInfo.builder()
+                .connectingInfoId(connectingInfoId)
+                .trainer(trainer.toDomain())
+                .member(member.toDomain())
+                .status(status)
+                .createdAt(getCreatedAt())
+                .updatedAt(getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/spring/fitlinkbe/infra/common/connectingInfo/ConnectingInfoJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/common/connectingInfo/ConnectingInfoJpaRepository.java
@@ -1,0 +1,13 @@
+package spring.fitlinkbe.infra.common.connectingInfo;
+
+
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ConnectingInfoJpaRepository extends JpaRepository<ConnectingInfoEntity, Long> {
+
+    @EntityGraph(attributePaths = {"member", "trainer"})
+    Optional<ConnectingInfoEntity> findByMember_MemberIdAndTrainer_TrainerId(Long memberId, Long trainerId);
+}

--- a/src/main/java/spring/fitlinkbe/infra/common/connectingInfo/ConnectingInfoJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/common/connectingInfo/ConnectingInfoJpaRepository.java
@@ -3,6 +3,7 @@ package spring.fitlinkbe.infra.common.connectingInfo;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -10,4 +11,13 @@ public interface ConnectingInfoJpaRepository extends JpaRepository<ConnectingInf
 
     @EntityGraph(attributePaths = {"member", "trainer"})
     Optional<ConnectingInfoEntity> findByMember_MemberIdAndTrainer_TrainerId(Long memberId, Long trainerId);
+
+    /**
+     * 해당 회원의 이미 존재하는 REJECTED 되지 않은 ConnectingInfoEntity 를 조회한다.
+     *
+     * @param memberId
+     * @return
+     */
+    @Query("select c from ConnectingInfoEntity c join fetch c.member m where m.memberId = :memberId and c.status != 'REJECTED'")
+    Optional<ConnectingInfoEntity> findExistMemberConnectingInfo(Long memberId);
 }

--- a/src/main/java/spring/fitlinkbe/infra/common/connectingInfo/ConnectingInfoRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/common/connectingInfo/ConnectingInfoRepositoryImpl.java
@@ -1,0 +1,28 @@
+package spring.fitlinkbe.infra.common.connectingInfo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import spring.fitlinkbe.domain.common.ConnectingInfoRepository;
+import spring.fitlinkbe.domain.common.exception.CustomException;
+import spring.fitlinkbe.domain.common.exception.ErrorCode;
+import spring.fitlinkbe.domain.common.model.ConnectingInfo;
+
+
+@Repository
+@RequiredArgsConstructor
+public class ConnectingInfoRepositoryImpl implements ConnectingInfoRepository {
+
+    private final ConnectingInfoJpaRepository connectingInfoJpaRepository;
+
+    @Override
+    public ConnectingInfo getConnectingInfo(Long memberId, Long trainerId) {
+        return connectingInfoJpaRepository.findByMember_MemberIdAndTrainer_TrainerId(memberId, trainerId)
+                .map(ConnectingInfoEntity::toDomain)
+                .orElseThrow(() -> new CustomException(ErrorCode.CONNECTING_INFO_NOT_FOUND));
+    }
+
+    @Override
+    public void save(ConnectingInfo connectingInfo) {
+        connectingInfoJpaRepository.save(ConnectingInfoEntity.from(connectingInfo));
+    }
+}

--- a/src/main/java/spring/fitlinkbe/infra/common/connectingInfo/ConnectingInfoRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/common/connectingInfo/ConnectingInfoRepositoryImpl.java
@@ -7,6 +7,8 @@ import spring.fitlinkbe.domain.common.exception.CustomException;
 import spring.fitlinkbe.domain.common.exception.ErrorCode;
 import spring.fitlinkbe.domain.common.model.ConnectingInfo;
 
+import java.util.Optional;
+
 
 @Repository
 @RequiredArgsConstructor
@@ -22,7 +24,13 @@ public class ConnectingInfoRepositoryImpl implements ConnectingInfoRepository {
     }
 
     @Override
-    public void save(ConnectingInfo connectingInfo) {
-        connectingInfoJpaRepository.save(ConnectingInfoEntity.from(connectingInfo));
+    public ConnectingInfo save(ConnectingInfo connectingInfo) {
+        return connectingInfoJpaRepository.save(ConnectingInfoEntity.from(connectingInfo)).toDomain();
+    }
+
+    @Override
+    public Optional<ConnectingInfo> getExistConnectingInfo(Long memberId) {
+        return connectingInfoJpaRepository.findExistMemberConnectingInfo(memberId)
+                .map(ConnectingInfoEntity::toDomain);
     }
 }

--- a/src/main/java/spring/fitlinkbe/infra/notification/Dummy.java
+++ b/src/main/java/spring/fitlinkbe/infra/notification/Dummy.java
@@ -1,4 +1,0 @@
-package spring.fitlinkbe.infra.notification;
-
-public class Dummy {
-}

--- a/src/main/java/spring/fitlinkbe/infra/notification/NotificationEntity.java
+++ b/src/main/java/spring/fitlinkbe/infra/notification/NotificationEntity.java
@@ -1,0 +1,71 @@
+package spring.fitlinkbe.infra.notification;
+
+import jakarta.persistence.*;
+import lombok.*;
+import spring.fitlinkbe.domain.notification.Notification;
+import spring.fitlinkbe.infra.common.personaldetail.PersonalDetailEntity;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class NotificationEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long notificationId;
+
+    private Long refId;
+
+    @Enumerated(EnumType.STRING)
+    private Notification.NotificationType refType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "personal_detail_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private PersonalDetailEntity personalDetail;
+
+    private String name;
+
+    private String content;
+
+    private Boolean isSent;
+
+    private Boolean isRead;
+
+    private Boolean isProcessed;
+
+    private LocalDateTime sendDate;
+
+    public static NotificationEntity from(Notification notification) {
+        return NotificationEntity.builder()
+                .notificationId(notification.getNotificationId())
+                .refId(notification.getRefId())
+                .refType(notification.getRefType())
+                .personalDetail(PersonalDetailEntity.from(notification.getPersonalDetail()))
+                .name(notification.getName())
+                .content(notification.getContent())
+                .isSent(notification.getIsSent())
+                .isRead(notification.getIsRead())
+                .isProcessed(notification.getIsProcessed())
+                .sendDate(notification.getSendDate())
+                .build();
+    }
+
+    public Notification toDomain() {
+        return Notification.builder()
+                .notificationId(notificationId)
+                .refId(refId)
+                .refType(refType)
+                .personalDetail(personalDetail.toDomain())
+                .name(name)
+                .content(content)
+                .isSent(isSent)
+                .isRead(isRead)
+                .isProcessed(isProcessed)
+                .sendDate(sendDate)
+                .build();
+    }
+
+}

--- a/src/main/java/spring/fitlinkbe/infra/notification/NotificationEntity.java
+++ b/src/main/java/spring/fitlinkbe/infra/notification/NotificationEntity.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 @Builder(toBuilder = true)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(name = "notification")
 public class NotificationEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/spring/fitlinkbe/infra/notification/NotificationJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/notification/NotificationJpaRepository.java
@@ -1,0 +1,13 @@
+package spring.fitlinkbe.infra.notification;
+
+
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface NotificationJpaRepository extends JpaRepository<NotificationEntity, Long> {
+
+    @EntityGraph(attributePaths = {"personalDetail"})
+    Optional<NotificationEntity> findByPersonalDetail_PersonalDetailId(Long personalDetailId);
+}

--- a/src/main/java/spring/fitlinkbe/infra/notification/NotificationRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/notification/NotificationRepositoryImpl.java
@@ -19,4 +19,9 @@ public class NotificationRepositoryImpl implements NotificationRepository {
                 .map(NotificationEntity::toDomain)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND));
     }
+
+    @Override
+    public void save(Notification notification) {
+        notificationJpaRepository.save(NotificationEntity.from(notification));
+    }
 }

--- a/src/main/java/spring/fitlinkbe/infra/notification/NotificationRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/notification/NotificationRepositoryImpl.java
@@ -1,0 +1,22 @@
+package spring.fitlinkbe.infra.notification;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import spring.fitlinkbe.domain.common.exception.CustomException;
+import spring.fitlinkbe.domain.common.exception.ErrorCode;
+import spring.fitlinkbe.domain.notification.Notification;
+import spring.fitlinkbe.domain.notification.NotificationRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationRepositoryImpl implements NotificationRepository {
+
+    private final NotificationJpaRepository notificationJpaRepository;
+
+    @Override
+    public Notification getNotification(Long personalDetailId) {
+        return notificationJpaRepository.findByPersonalDetail_PersonalDetailId(personalDetailId)
+                .map(NotificationEntity::toDomain)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND));
+    }
+}

--- a/src/main/java/spring/fitlinkbe/infra/trainer/TrainerJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/trainer/TrainerJpaRepository.java
@@ -2,5 +2,9 @@ package spring.fitlinkbe.infra.trainer;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TrainerJpaRepository extends JpaRepository<TrainerEntity, Long> {
+
+    Optional<TrainerEntity> findByTrainerCode(String trainerCode);
 }

--- a/src/main/java/spring/fitlinkbe/infra/trainer/TrainerRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/trainer/TrainerRepositoryImpl.java
@@ -2,6 +2,8 @@ package spring.fitlinkbe.infra.trainer;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import spring.fitlinkbe.domain.common.exception.CustomException;
+import spring.fitlinkbe.domain.common.exception.ErrorCode;
 import spring.fitlinkbe.domain.trainer.AvailableTime;
 import spring.fitlinkbe.domain.trainer.DayOff;
 import spring.fitlinkbe.domain.trainer.Trainer;
@@ -73,5 +75,11 @@ public class TrainerRepositoryImpl implements TrainerRepository {
         availableTimeJpaRepository.saveAll(availableTimes.stream()
                 .map(AvailableTimeEntity::from)
                 .toList());
+    }
+
+    @Override
+    public Trainer getTrainerByCode(String trainerCode) {
+        return trainerJpaRepository.findByTrainerCode(trainerCode)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRAINER_IS_NOT_FOUND)).toDomain();
     }
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/Dummy.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/Dummy.java
@@ -1,4 +1,0 @@
-package spring.fitlinkbe.interfaces.controller.member;
-
-public class Dummy {
-}

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/MemberController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/MemberController.java
@@ -1,0 +1,31 @@
+package spring.fitlinkbe.interfaces.controller.member;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import spring.fitlinkbe.application.member.MemberFacade;
+import spring.fitlinkbe.interfaces.controller.common.dto.ApiResultResponse;
+import spring.fitlinkbe.interfaces.controller.member.dto.MemberDto;
+import spring.fitlinkbe.support.argumentresolver.Login;
+import spring.fitlinkbe.support.security.SecurityUser;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/members")
+public class MemberController {
+
+    private final MemberFacade memberFacade;
+
+    @PostMapping("/connect")
+    public ApiResultResponse<Object> connectTrainer(
+            @Login SecurityUser user,
+            @RequestBody @Valid MemberDto.MemberConnectRequest requestBody) {
+        memberFacade.connectTrainer(user.getMemberId(), requestBody.trainerCode());
+
+        return ApiResultResponse.ok(null);
+    }
+
+}

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/MemberDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/MemberDto.java
@@ -1,0 +1,11 @@
+package spring.fitlinkbe.interfaces.controller.member.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public class MemberDto {
+
+    public record MemberConnectRequest(
+            @NotNull String trainerCode
+    ) {
+    }
+}

--- a/src/test/java/spring/fitlinkbe/integration/MemberControllerTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/MemberControllerTest.java
@@ -1,0 +1,147 @@
+package spring.fitlinkbe.integration;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import spring.fitlinkbe.domain.common.ConnectingInfoRepository;
+import spring.fitlinkbe.domain.common.model.ConnectingInfo;
+import spring.fitlinkbe.domain.common.model.PersonalDetail;
+import spring.fitlinkbe.domain.member.Member;
+import spring.fitlinkbe.domain.member.MemberRepository;
+import spring.fitlinkbe.domain.notification.Notification;
+import spring.fitlinkbe.domain.notification.NotificationRepository;
+import spring.fitlinkbe.domain.trainer.Trainer;
+import spring.fitlinkbe.integration.common.BaseIntegrationTest;
+import spring.fitlinkbe.integration.common.TestDataHandler;
+import spring.fitlinkbe.interfaces.controller.common.dto.ApiResultResponse;
+import spring.fitlinkbe.interfaces.controller.member.dto.MemberDto;
+
+public class MemberControllerTest extends BaseIntegrationTest {
+
+    @Autowired
+    TestDataHandler testDataHandler;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    ConnectingInfoRepository connectingInfoRepository;
+
+    @Autowired
+    NotificationRepository notificationRepository;
+
+    @Nested
+    @DisplayName("멤버 트레이너 연결 요청 성공")
+    public class MemberConnectTest {
+        private static final String MEMBER_CONNECT_API = "/v1/members/connect";
+
+        @Test
+        @DisplayName("멤버 트레이너 연결 요청 성공")
+        public void memberConnectSuccess() throws Exception {
+            // given
+            // 멤버와 트레이너가 있을 때
+            String trainerCode = "AB1423";
+            Member member = testDataHandler.createMember();
+            Trainer trainer = testDataHandler.createTrainer(trainerCode);
+            PersonalDetail trainerPersonalDetail = testDataHandler.getPersonalDetail(trainer.getTrainerId());
+            String token = testDataHandler.createTokenFromMember(member);
+
+            // when
+            // 멤버가 트레이너와 연결 요청을 보낼 때
+            MemberDto.MemberConnectRequest request = new MemberDto.MemberConnectRequest(trainerCode);
+            String requestBody = writeValueAsString(request);
+            ExtractableResponse<Response> result = post(MEMBER_CONNECT_API, requestBody, token);
+
+            // then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.statusCode()).isEqualTo(200);
+                ApiResultResponse<Object> response = readValue(result.body().jsonPath().prettify(), new TypeReference<>() {
+                });
+                softly.assertThat(response).isNotNull();
+
+                // 멤버의 연결 상태가 true 로 변경되었는지 확인
+                Member updatedMember = memberRepository.getMember(member.getMemberId()).orElseThrow();
+                softly.assertThat(updatedMember.getIsConnected()).isTrue();
+
+                // 연결 정보가 저장되었는지 확인
+                ConnectingInfo connectingInfo = connectingInfoRepository.getConnectingInfo(member.getMemberId(), trainer.getTrainerId());
+                softly.assertThat(connectingInfo).isNotNull();
+                softly.assertThat(connectingInfo.getTrainer().getTrainerId()).isEqualTo(trainer.getTrainerId());
+                softly.assertThat(connectingInfo.getMember().getMemberId()).isEqualTo(member.getMemberId());
+                softly.assertThat(connectingInfo.getStatus()).isEqualTo(ConnectingInfo.ConnectingStatus.REQUESTED);
+
+                // 알림 정보가 생성되었는지 확인
+                Notification notification = notificationRepository.getNotification(trainerPersonalDetail.getPersonalDetailId());
+                softly.assertThat(notification).isNotNull();
+                softly.assertThat(notification.getRefType()).isEqualTo(Notification.NotificationType.CONNECT);
+                softly.assertThat(notification.getRefId()).isEqualTo(connectingInfo.getConnectingInfoId());
+                softly.assertThat(notification.getIsRead()).isFalse();
+                softly.assertThat(notification.getIsSent()).isTrue();
+            });
+        }
+
+        @Test
+        @DisplayName("멤버 트레이너 연결 요청 실패 - 트레이너 코드가 올바르지 않을 때")
+        public void memberConnectFailByInvalidTrainerCode() throws Exception {
+            // given
+            // 멤버와 트레이너가 있을 때
+            String trainerCode = "AB1423";
+            Member member = testDataHandler.createMember();
+            testDataHandler.createTrainer(trainerCode);
+            String token = testDataHandler.createTokenFromMember(member);
+
+            // when
+            // 멤버가 트레이너와 연결 요청을 보낼 때
+            MemberDto.MemberConnectRequest request = new MemberDto.MemberConnectRequest("AB1234");
+            String requestBody = writeValueAsString(request);
+            ExtractableResponse<Response> result = post(MEMBER_CONNECT_API, requestBody, token);
+
+            // then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.statusCode()).isEqualTo(200);
+                ApiResultResponse<Object> response = readValue(result.body().jsonPath().prettify(), new TypeReference<>() {
+                });
+                softly.assertThat(response).isNotNull();
+                softly.assertThat(response.success()).isFalse();
+                softly.assertThat(response.status()).isEqualTo(400);
+                softly.assertThat(response.data()).isNull();
+            });
+        }
+
+        @Test
+        @DisplayName("멤버 트레이너 연결 요청 실패 - 멤버가 이미 연결된 트레이너가 있을 때")
+        public void memberConnectFailByAlreadyConnected() throws Exception {
+            // given
+            // 멤버와 트레이너가 있을 때
+            String trainerCode = "AB1423";
+            Member member = testDataHandler.createMember();
+            Trainer trainer = testDataHandler.createTrainer(trainerCode);
+            testDataHandler.connectMemberAndTrainer(member, trainer);
+            String token = testDataHandler.createTokenFromMember(member);
+
+            // when
+            // 멤버가 트레이너와 연결 요청을 보낼 때
+            MemberDto.MemberConnectRequest request = new MemberDto.MemberConnectRequest(trainerCode);
+            String requestBody = writeValueAsString(request);
+            ExtractableResponse<Response> result = post(MEMBER_CONNECT_API, requestBody, token);
+
+            // then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.statusCode()).isEqualTo(200);
+                ApiResultResponse<Object> response = readValue(result.body().jsonPath().prettify(), new TypeReference<>() {
+                });
+                softly.assertThat(response).isNotNull();
+                softly.assertThat(response.success()).isFalse();
+                softly.assertThat(response.status()).isEqualTo(409);
+                softly.assertThat(response.data()).isNull();
+            });
+        }
+
+
+    }
+}

--- a/src/test/java/spring/fitlinkbe/integration/MemberControllerTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/MemberControllerTest.java
@@ -64,10 +64,6 @@ public class MemberControllerTest extends BaseIntegrationTest {
                 });
                 softly.assertThat(response).isNotNull();
 
-                // 멤버의 연결 상태가 true 로 변경되었는지 확인
-                Member updatedMember = memberRepository.getMember(member.getMemberId()).orElseThrow();
-                softly.assertThat(updatedMember.getIsConnected()).isTrue();
-
                 // 연결 정보가 저장되었는지 확인
                 ConnectingInfo connectingInfo = connectingInfoRepository.getConnectingInfo(member.getMemberId(), trainer.getTrainerId());
                 softly.assertThat(connectingInfo).isNotNull();
@@ -108,7 +104,7 @@ public class MemberControllerTest extends BaseIntegrationTest {
                 });
                 softly.assertThat(response).isNotNull();
                 softly.assertThat(response.success()).isFalse();
-                softly.assertThat(response.status()).isEqualTo(400);
+                softly.assertThat(response.status()).isEqualTo(404);
                 softly.assertThat(response.data()).isNull();
             });
         }

--- a/src/test/java/spring/fitlinkbe/integration/MemberControllerTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/MemberControllerTest.java
@@ -12,7 +12,6 @@ import spring.fitlinkbe.domain.common.ConnectingInfoRepository;
 import spring.fitlinkbe.domain.common.model.ConnectingInfo;
 import spring.fitlinkbe.domain.common.model.PersonalDetail;
 import spring.fitlinkbe.domain.member.Member;
-import spring.fitlinkbe.domain.member.MemberRepository;
 import spring.fitlinkbe.domain.notification.Notification;
 import spring.fitlinkbe.domain.notification.NotificationRepository;
 import spring.fitlinkbe.domain.trainer.Trainer;
@@ -25,9 +24,6 @@ public class MemberControllerTest extends BaseIntegrationTest {
 
     @Autowired
     TestDataHandler testDataHandler;
-
-    @Autowired
-    MemberRepository memberRepository;
 
     @Autowired
     ConnectingInfoRepository connectingInfoRepository;

--- a/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
@@ -20,7 +20,7 @@ import spring.fitlinkbe.integration.common.TestDataHandler;
 import spring.fitlinkbe.interfaces.controller.common.dto.ApiResultResponse;
 import spring.fitlinkbe.interfaces.controller.member.dto.MemberDto;
 
-public class MemberControllerTest extends BaseIntegrationTest {
+public class MemberIntegrationTest extends BaseIntegrationTest {
 
     @Autowired
     TestDataHandler testDataHandler;


### PR DESCRIPTION
### 작업 내용
- `/v1/members/connect` POST api 작업했습니다
- 연결 요청시 Connecting info에서 status를 requested로 생성시켰습니다
- Notification 레코드도 추가하여 트레이너에게 알림 요청 알림이 왔다는 것을 알리도록 했습니다

### DB 변동사항
- connecting-info - member 간의 관계를 1 : N 으로 수정했습니다.
  - 연결 요청이 reject되면 그냥 레코드를 삭제하는 식으로 해서 1:1 관계를 유지할까도 생각했지만 연결 요청 히스토리를 가지고 있으면 나중에 쓸 수도 있을 것 같아서 1:N으로 수정했고 각 멤버마다 status가 requested 이거나 또는 connected 인 connection-info를 갖도록 보장하게 구현했습니다.