### PR TITLE
[FLIZ-96] 회원 내정보 조회 API 작업

### DIFF
--- a/src/main/java/spring/fitlinkbe/application/auth/AuthFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/auth/AuthFacade.java
@@ -17,7 +17,6 @@ import static spring.fitlinkbe.support.utils.RandomStringGenerator.generateRando
 
 @Component
 @RequiredArgsConstructor
-@Transactional
 public class AuthFacade {
 
     private final MemberService memberService;
@@ -25,6 +24,7 @@ public class AuthFacade {
     private final AuthService authService;
     private final AuthTokenProvider authTokenProvider;
 
+    @Transactional
     public AuthCommand.Response registerTrainer(Long personalDetailId, AuthCommand.TrainerRegisterRequest command) {
         // trainer 저장
         Trainer savedTrainer = trainerService.saveTrainer(new Trainer(generateRandomString(6), command.name()));
@@ -47,6 +47,7 @@ public class AuthFacade {
         return AuthCommand.Response.of(accessToken, refreshToken);
     }
 
+    @Transactional
     public AuthCommand.Response registerMember(Long personalDetailId, AuthCommand.MemberRegisterRequest command) {
         Member savedMember = memberService.saveMember(command.toMember());
 

--- a/src/main/java/spring/fitlinkbe/application/auth/AuthFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/auth/AuthFacade.java
@@ -27,7 +27,7 @@ public class AuthFacade {
 
     public AuthCommand.Response registerTrainer(Long personalDetailId, AuthCommand.TrainerRegisterRequest command) {
         // trainer 저장
-        Trainer savedTrainer = trainerService.saveTrainer(new Trainer(generateRandomString(6)));
+        Trainer savedTrainer = trainerService.saveTrainer(new Trainer(generateRandomString(6), command.name()));
 
         // personalDetail 업데이트
         PersonalDetail personalDetail = trainerService.registerTrainer(personalDetailId, command, savedTrainer);

--- a/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
@@ -19,12 +19,12 @@ import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
-@Transactional
 public class MemberFacade {
     private final MemberService memberService;
     private final TrainerService trainerService;
     private final NotificationService notificationService;
 
+    @Transactional
     public void connectTrainer(Long memberId, String trainerCode) {
         memberService.checkMemberAlreadyConnected(memberId);
 
@@ -36,6 +36,7 @@ public class MemberFacade {
         notificationService.sendConnectRequestNotification(trainerDetail, member.getName(), connectingInfo.getConnectingInfoId());
     }
 
+    @Transactional
     public void disconnectTrainer(Long memberId) {
         ConnectingInfo connectingInfo = memberService.getConnectedInfo(memberId);
         if (connectingInfo.isPending()) {

--- a/src/main/java/spring/fitlinkbe/application/member/criteria/MemberInfoResult.java
+++ b/src/main/java/spring/fitlinkbe/application/member/criteria/MemberInfoResult.java
@@ -1,0 +1,46 @@
+package spring.fitlinkbe.application.member.criteria;
+
+import lombok.Builder;
+import spring.fitlinkbe.domain.common.model.SessionInfo;
+import spring.fitlinkbe.domain.member.Member;
+import spring.fitlinkbe.domain.trainer.Trainer;
+
+public class MemberInfoResult {
+
+    @Builder
+    public record Response(
+            Long memberId,
+            String name,
+            Long trainerId,
+            String trainerName,
+            String profilePictureUrl,
+            SessionInfoResponse sessionInfo
+    ) {
+        public static Response of(Member me, Trainer trainer, SessionInfo sessionInfo) {
+            return Response.builder()
+                    .memberId(me.getMemberId())
+                    .name(me.getName())
+                    .trainerId(trainer != null ? trainer.getTrainerId() : null)
+                    .trainerName(trainer != null ? trainer.getName() : null)
+                    .profilePictureUrl(me.getProfilePictureUrl())
+                    .sessionInfo(sessionInfo != null ? SessionInfoResponse.from(sessionInfo) : null)
+                    .build();
+        }
+    }
+
+    @Builder
+    public record SessionInfoResponse(
+            Long sessionInfoId,
+            int totalCount,
+            int remainingCount
+    ) {
+        public static SessionInfoResponse from(SessionInfo sessionInfo) {
+            return SessionInfoResponse.builder()
+                    .sessionInfoId(sessionInfo.getSessionInfoId())
+                    .totalCount(sessionInfo.getTotalCount())
+                    .remainingCount(sessionInfo.getRemainingCount())
+                    .build();
+        }
+    }
+}
+

--- a/src/main/java/spring/fitlinkbe/domain/auth/command/AuthCommand.java
+++ b/src/main/java/spring/fitlinkbe/domain/auth/command/AuthCommand.java
@@ -77,6 +77,7 @@ public class AuthCommand {
                     .name(name)
                     .birthDate(birthDate)
                     .phoneNumber(phoneNumber)
+                    .profilePictureUrl(profileUrl)
                     .isRequest(false)
                     .isConnected(false)
                     .build();

--- a/src/main/java/spring/fitlinkbe/domain/common/SessionInfoRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/SessionInfoRepository.java
@@ -9,4 +9,6 @@ public interface SessionInfoRepository {
     Optional<SessionInfo> saveSessionInfo(SessionInfo sessionInfo);
 
     Optional<SessionInfo> getSessionInfo(long sessionInfoId);
+
+    Optional<SessionInfo> findSessionInfo(Long memberId);
 }

--- a/src/main/java/spring/fitlinkbe/domain/common/model/SessionInfo.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/model/SessionInfo.java
@@ -18,5 +18,5 @@ public class SessionInfo {
     private Member member;
     private Trainer trainer;
     private int totalCount;
-    private int remainCount;
+    private int remainingCount;
 }

--- a/src/main/java/spring/fitlinkbe/domain/member/Member.java
+++ b/src/main/java/spring/fitlinkbe/domain/member/Member.java
@@ -27,6 +27,8 @@ public class Member {
 
     private LocalDate birthDate;
 
+    private String profilePictureUrl;
+
     private PhoneNumber phoneNumber;
 
     private Boolean isRequest;

--- a/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
+++ b/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
@@ -6,10 +6,12 @@ import org.springframework.transaction.annotation.Transactional;
 import spring.fitlinkbe.domain.auth.command.AuthCommand;
 import spring.fitlinkbe.domain.common.ConnectingInfoRepository;
 import spring.fitlinkbe.domain.common.PersonalDetailRepository;
+import spring.fitlinkbe.domain.common.SessionInfoRepository;
 import spring.fitlinkbe.domain.common.exception.CustomException;
 import spring.fitlinkbe.domain.common.exception.ErrorCode;
 import spring.fitlinkbe.domain.common.model.ConnectingInfo;
 import spring.fitlinkbe.domain.common.model.PersonalDetail;
+import spring.fitlinkbe.domain.common.model.SessionInfo;
 import spring.fitlinkbe.domain.trainer.Trainer;
 
 import java.util.List;
@@ -26,6 +28,7 @@ public class MemberService {
     private final WorkoutScheduleRepository workoutScheduleRepository;
     private final PersonalDetailRepository personalDetailRepository;
     private final ConnectingInfoRepository connectingInfoRepository;
+    private final SessionInfoRepository sessionInfoRepository;
 
     public PersonalDetail registerMember(Long personalDetailId, AuthCommand.MemberRegisterRequest command, Member savedMember) {
         PersonalDetail personalDetail = personalDetailRepository.getById(personalDetailId);
@@ -80,6 +83,7 @@ public class MemberService {
     /**
      * 해당 회원의 트레이너 연결 정보 조회 </br>
      * 요청 상태거나 연결된 상태만 조회
+     *
      * @param memberId
      * @return
      */
@@ -88,7 +92,15 @@ public class MemberService {
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_CONNECTED_TRAINER));
     }
 
+    public Optional<ConnectingInfo> findConnectedInfo(Long memberId) {
+        return connectingInfoRepository.getConnectedInfo(memberId);
+    }
+
     public void saveConnectingInfo(ConnectingInfo connectingInfo) {
         connectingInfoRepository.save(connectingInfo);
+    }
+
+    public Optional<SessionInfo> findSessionInfo(Long memberId) {
+        return sessionInfoRepository.getSessionInfo(memberId);
     }
 }

--- a/src/main/java/spring/fitlinkbe/domain/trainer/Trainer.java
+++ b/src/main/java/spring/fitlinkbe/domain/trainer/Trainer.java
@@ -18,6 +18,8 @@ public class Trainer {
 
     private Long trainerId;
 
+    private String name;
+
     private Long sessionInfoId;
 
     private SessionInfo sessionInfo;

--- a/src/main/java/spring/fitlinkbe/domain/trainer/Trainer.java
+++ b/src/main/java/spring/fitlinkbe/domain/trainer/Trainer.java
@@ -30,7 +30,8 @@ public class Trainer {
 
     private LocalDateTime updatedAt;
 
-    public Trainer(String trainerCode) {
+    public Trainer(String trainerCode, String name) {
         this.trainerCode = trainerCode;
+        this.name = name;
     }
 }

--- a/src/main/java/spring/fitlinkbe/infra/common/sessioninfo/SessionInfoEntity.java
+++ b/src/main/java/spring/fitlinkbe/infra/common/sessioninfo/SessionInfoEntity.java
@@ -19,7 +19,7 @@ public class SessionInfoEntity extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long sessionInfoId;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "trainer_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private TrainerEntity trainer;
 
@@ -29,7 +29,7 @@ public class SessionInfoEntity extends BaseTimeEntity {
 
     private int totalCount;
 
-    private int remainCount;
+    private int remainingCount;
 
     public static SessionInfoEntity from(SessionInfo sessionInfo) {
 
@@ -42,7 +42,7 @@ public class SessionInfoEntity extends BaseTimeEntity {
                 .trainer(TrainerEntity.from(sessionInfo.getTrainer()))
                 .member(MemberEntity.from(sessionInfo.getMember()))
                 .totalCount(sessionInfo.getTotalCount())
-                .remainCount(sessionInfo.getRemainCount())
+                .remainingCount(sessionInfo.getRemainingCount())
                 .build();
     }
 
@@ -52,7 +52,7 @@ public class SessionInfoEntity extends BaseTimeEntity {
                 .trainer(trainer.toDomain())
                 .member(member.toDomain())
                 .totalCount(totalCount)
-                .remainCount(remainCount)
+                .remainingCount(remainingCount)
                 .build();
     }
 }

--- a/src/main/java/spring/fitlinkbe/infra/common/sessioninfo/SessionInfoJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/common/sessioninfo/SessionInfoJpaRepository.java
@@ -10,6 +10,12 @@ public interface SessionInfoJpaRepository extends JpaRepository<SessionInfoEntit
     @Query("SELECT si FROM SessionInfoEntity si " +
             "LEFT JOIN FETCH si.trainer " +
             "LEFT JOIN FETCH si.member " +
-            "WHERE si.sessionInfoId = :memberId")
-    Optional<SessionInfoEntity> findByIdJoinFetch(Long memberId);
+            "WHERE si.sessionInfoId = :sessionInfoId")
+    Optional<SessionInfoEntity> findByIdJoinFetch(Long sessionInfoId);
+
+    @Query("SELECT si FROM SessionInfoEntity si " +
+            "LEFT JOIN FETCH si.trainer " +
+            "LEFT JOIN FETCH si.member " +
+            "WHERE si.member.memberId = :memberId")
+    Optional<SessionInfoEntity> findByMemberIdJoinFetch(Long memberId);
 }

--- a/src/main/java/spring/fitlinkbe/infra/common/sessioninfo/SessionInfoRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/common/sessioninfo/SessionInfoRepositoryImpl.java
@@ -32,4 +32,16 @@ public class SessionInfoRepositoryImpl implements SessionInfoRepository {
 
         return Optional.empty();
     }
+
+    @Override
+    public Optional<SessionInfo> findSessionInfo(Long memberId) {
+
+        Optional<SessionInfoEntity> findEntity = sessionInfoJpaRepository.findByMemberIdJoinFetch(memberId);
+
+        if (findEntity.isPresent()) {
+            return findEntity.map(SessionInfoEntity::toDomain);
+        }
+
+        return Optional.empty();
+    }
 }

--- a/src/main/java/spring/fitlinkbe/infra/member/MemberEntity.java
+++ b/src/main/java/spring/fitlinkbe/infra/member/MemberEntity.java
@@ -28,6 +28,8 @@ public class MemberEntity extends BaseTimeEntity {
 
     private LocalDate birthDate;
 
+    private String profilePictureUrl;
+
     private String phoneNumber;
 
     private Boolean isRequest;
@@ -41,6 +43,7 @@ public class MemberEntity extends BaseTimeEntity {
                 .trainer(member.getTrainer() != null ? TrainerEntity.from(member.getTrainer()) : null)
                 .name(member.getName())
                 .birthDate(member.getBirthDate())
+                .profilePictureUrl(member.getProfilePictureUrl())
                 .phoneNumber(member.getPhoneNumber())
                 .isRequest(member.getIsRequest())
                 .isConnected(member.getIsConnected())
@@ -53,6 +56,7 @@ public class MemberEntity extends BaseTimeEntity {
                 .trainer(trainer != null ? trainer.toDomain() : null)
                 .name(name)
                 .birthDate(birthDate)
+                .profilePictureUrl(profilePictureUrl)
                 .phoneNumber(new PhoneNumber(phoneNumber))
                 .isRequest(isRequest)
                 .isConnected(isConnected)

--- a/src/main/java/spring/fitlinkbe/infra/trainer/TrainerEntity.java
+++ b/src/main/java/spring/fitlinkbe/infra/trainer/TrainerEntity.java
@@ -19,10 +19,13 @@ public class TrainerEntity extends BaseTimeEntity {
 
     private String trainerCode;
 
+    private String name;
+
     public static TrainerEntity from(Trainer trainer) {
         return TrainerEntity.builder()
                 .trainerId(trainer.getTrainerId() != null ? trainer.getTrainerId() : null)
                 .trainerCode(trainer.getTrainerCode())
+                .name(trainer.getName())
                 .build();
     }
 
@@ -30,6 +33,7 @@ public class TrainerEntity extends BaseTimeEntity {
         return Trainer.builder()
                 .trainerId(trainerId)
                 .trainerCode(trainerCode)
+                .name(name)
                 .createdAt(getCreatedAt())
                 .updatedAt(getUpdatedAt())
                 .build();

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/common/exception/ApiControllerAdvice.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/common/exception/ApiControllerAdvice.java
@@ -51,6 +51,7 @@ public class ApiControllerAdvice {
     @ExceptionHandler(Exception.class)
     public ApiResultResponse<Object> handlerException(Exception e) {
         log.error("Exception is occurred! {}", e.getMessage());
+        log.error("Exception is occurred!", e);
         return ApiResultResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, false, e.getMessage(), null);
     }
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/common/exception/ApiControllerAdvice.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/common/exception/ApiControllerAdvice.java
@@ -51,7 +51,6 @@ public class ApiControllerAdvice {
     @ExceptionHandler(Exception.class)
     public ApiResultResponse<Object> handlerException(Exception e) {
         log.error("Exception is occurred! {}", e.getMessage());
-        log.error("Exception is occurred!", e);
         return ApiResultResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, false, e.getMessage(), null);
     }
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/MemberController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/MemberController.java
@@ -2,13 +2,12 @@ package spring.fitlinkbe.interfaces.controller.member;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import spring.fitlinkbe.application.member.MemberFacade;
+import spring.fitlinkbe.application.member.criteria.MemberInfoResult;
 import spring.fitlinkbe.interfaces.controller.common.dto.ApiResultResponse;
 import spring.fitlinkbe.interfaces.controller.member.dto.MemberDto;
+import spring.fitlinkbe.interfaces.controller.member.dto.MemberInfoDto;
 import spring.fitlinkbe.support.argumentresolver.Login;
 import spring.fitlinkbe.support.security.SecurityUser;
 
@@ -33,6 +32,13 @@ public class MemberController {
         memberFacade.disconnectTrainer(user.getMemberId());
 
         return ApiResultResponse.ok(null);
+    }
+
+    @GetMapping("/me")
+    public ApiResultResponse<MemberInfoDto.Response> getMyInfo(@Login SecurityUser user) {
+        MemberInfoResult.Response result = memberFacade.getMyInfo(user.getMemberId());
+
+        return ApiResultResponse.ok(MemberInfoDto.Response.from(result));
     }
 
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/MemberInfoDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/MemberInfoDto.java
@@ -1,7 +1,11 @@
 package spring.fitlinkbe.interfaces.controller.member.dto;
 
+import lombok.Builder;
+import spring.fitlinkbe.application.member.criteria.MemberInfoResult;
+
 public class MemberInfoDto {
 
+    @Builder
     public record Response(
             Long memberId,
             String name,
@@ -10,6 +14,16 @@ public class MemberInfoDto {
             String profilePictureUrl,
             SessionInfoResponse sessionInfo
     ) {
+        public static Response from(MemberInfoResult.Response result) {
+            return Response.builder()
+                    .memberId(result.memberId())
+                    .name(result.name())
+                    .trainerId(result.trainerId())
+                    .trainerName(result.trainerName())
+                    .profilePictureUrl(result.profilePictureUrl())
+                    .sessionInfo(result.sessionInfo() != null ? SessionInfoResponse.from(result.sessionInfo()) : null)
+                    .build();
+        }
     }
 
     public record SessionInfoResponse(
@@ -17,6 +31,13 @@ public class MemberInfoDto {
             int totalCount,
             int remainingCount
     ) {
+        public static SessionInfoResponse from(MemberInfoResult.SessionInfoResponse result) {
+            return new SessionInfoResponse(
+                    result.sessionInfoId(),
+                    result.totalCount(),
+                    result.remainingCount()
+            );
+        }
     }
 }
 

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/MemberInfoDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/MemberInfoDto.java
@@ -4,6 +4,7 @@ public class MemberInfoDto {
 
     public record Response(
             Long memberId,
+            String name,
             Long trainerId,
             String trainerName,
             String profilePictureUrl,

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/MemberInfoDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/MemberInfoDto.java
@@ -1,0 +1,21 @@
+package spring.fitlinkbe.interfaces.controller.member.dto;
+
+public class MemberInfoDto {
+
+    public record Response(
+            Long memberId,
+            Long trainerId,
+            String trainerName,
+            String profilePictureUrl,
+            SessionInfoResponse sessionInfo
+    ) {
+    }
+
+    public record SessionInfoResponse(
+            Long sessionInfoId,
+            int totalCount,
+            int remainingCount
+    ) {
+    }
+}
+

--- a/src/test/java/spring/fitlinkbe/integration/AuthIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/AuthIntegrationTest.java
@@ -102,6 +102,7 @@ public class AuthIntegrationTest extends BaseIntegrationTest {
                 softly.assertThat(member.getName()).isEqualTo(request.name());
                 softly.assertThat(member.getBirthDate()).isEqualTo(request.birthDate());
                 softly.assertThat(member.getPhoneNumber()).isEqualTo(request.phoneNumber());
+                softly.assertThat(member.getProfilePictureUrl()).isEqualTo(request.profileUrl());
 
                 List<WorkoutSchedule> workoutSchedules = new ArrayList<>(workoutScheduleRepository.findAllByMemberId(member.getMemberId()));
                 workoutSchedules.sort(Comparator.comparing(WorkoutSchedule::getDayOfWeek));
@@ -370,6 +371,7 @@ public class AuthIntegrationTest extends BaseIntegrationTest {
                 Trainer trainer = trainerRepository.getTrainerInfo(updatedPersonalDetail.getTrainerId()).orElseThrow();
                 softly.assertThat(trainer).isNotNull();
                 softly.assertThat(trainer.getTrainerCode()).isNotNull();
+                softly.assertThat(trainer.getName()).isEqualTo(request.name());
 
                 List<AvailableTime> availableTimes = trainerRepository.getTrainerAvailableTimes(trainer.getTrainerId());
                 softly.assertThat(availableTimes).hasSize(request.availableTimes().size());

--- a/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
@@ -264,6 +264,7 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
                 softly.assertThat(response.success()).isTrue();
                 softly.assertThat(response.status()).isEqualTo(200);
                 softly.assertThat(data.memberId()).isEqualTo(member.getMemberId());
+                softly.assertThat(data.name()).isEqualTo(member.getName());
                 softly.assertThat(data.trainerId()).isEqualTo(trainer.getTrainerId());
                 softly.assertThat(data.sessionInfo().sessionInfoId()).isEqualTo(sessionInfo.getSessionInfoId());
                 softly.assertThat(data.sessionInfo().remainingCount()).isEqualTo(sessionInfo.getRemainCount());

--- a/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
@@ -241,7 +241,7 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
         @DisplayName("멤버 내 정보 조회 성공")
         public void memberInfoSuccess() throws Exception {
             // given
-            // NORMAL 상태의 멤버가 있을 때
+            // NORMAL 상태의 멤버, 트레이너, 세션 정보가 있을 때
             Member member = testDataHandler.createMember();
             Trainer trainer = testDataHandler.createTrainer("AB1423");
             SessionInfo sessionInfo = testDataHandler.createSessionInfo(member, trainer);
@@ -269,7 +269,7 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
                 softly.assertThat(data.trainerName()).isEqualTo(trainer.getName());
                 softly.assertThat(data.trainerId()).isEqualTo(trainer.getTrainerId());
                 softly.assertThat(data.sessionInfo().sessionInfoId()).isEqualTo(sessionInfo.getSessionInfoId());
-                softly.assertThat(data.sessionInfo().remainingCount()).isEqualTo(sessionInfo.getRemainCount());
+                softly.assertThat(data.sessionInfo().remainingCount()).isEqualTo(sessionInfo.getRemainingCount());
                 softly.assertThat(data.sessionInfo().totalCount()).isEqualTo(sessionInfo.getTotalCount());
             });
         }

--- a/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
@@ -265,11 +265,12 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
                 softly.assertThat(response.status()).isEqualTo(200);
                 softly.assertThat(data.memberId()).isEqualTo(member.getMemberId());
                 softly.assertThat(data.name()).isEqualTo(member.getName());
+                softly.assertThat(data.profilePictureUrl()).isEqualTo(member.getProfilePictureUrl());
+                softly.assertThat(data.trainerName()).isEqualTo(trainer.getName());
                 softly.assertThat(data.trainerId()).isEqualTo(trainer.getTrainerId());
                 softly.assertThat(data.sessionInfo().sessionInfoId()).isEqualTo(sessionInfo.getSessionInfoId());
                 softly.assertThat(data.sessionInfo().remainingCount()).isEqualTo(sessionInfo.getRemainCount());
                 softly.assertThat(data.sessionInfo().totalCount()).isEqualTo(sessionInfo.getTotalCount());
-                // todo: trainer 에 name 추가, member 에 profilePictureUrl 추가
             });
         }
     }

--- a/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
+++ b/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
@@ -176,4 +176,15 @@ public class TestDataHandler {
                 .build();
         connectingInfoRepository.save(connectingInfo);
     }
+
+    public SessionInfo createSessionInfo(Member member, Trainer trainer) {
+        SessionInfo sessionInfo = SessionInfo.builder()
+                .member(member)
+                .trainer(trainer)
+                .remainCount(10)
+                .totalCount(10)
+                .build();
+
+        return sessionInfoRepository.saveSessionInfo(sessionInfo).orElseThrow();
+    }
 }

--- a/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
+++ b/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
@@ -181,7 +181,7 @@ public class TestDataHandler {
         SessionInfo sessionInfo = SessionInfo.builder()
                 .member(member)
                 .trainer(trainer)
-                .remainCount(10)
+                .remainingCount(10)
                 .totalCount(10)
                 .build();
 


### PR DESCRIPTION
### 작업사항
- GET `/v1/members/me` API 작업했습니다
- DB 컬럼을 member, trainer 에 추가함에 따라서 등록 API에서 추가된 컬럼에도 값 업데이트 해주도록 수정했습니다

### DB 수정사항
- **session_info**
  - session - trainer 1 : n 관계로 수정
  - remainCount -> remainingCount 컬럼명 수정
- **member**
  - profilePictureUrl 추가
- **trainer**
  - name 추가