### PR TITLE
[FLIZ-100] 내 정보 수정 API 작업

### DIFF
--- a/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
@@ -61,4 +61,18 @@ public class MemberFacade {
 
         return MemberInfoResult.Response.of(me, trainer, sessionInfo.orElse(null));
     }
+
+    @Transactional
+    public MemberInfoResult.MemberUpdateResponse updateMyInfo(Long memberId, String name, String phoneNumber) {
+        Member me = memberService.getMember(memberId);
+        me.update(name, phoneNumber);
+
+        PersonalDetail personalDetail = memberService.getMemberDetail(memberId);
+        personalDetail.update(name, phoneNumber);
+
+        memberService.saveMember(me);
+        memberService.savePersonalDetail(personalDetail);
+
+        return MemberInfoResult.MemberUpdateResponse.from(me);
+    }
 }

--- a/src/main/java/spring/fitlinkbe/application/member/criteria/MemberInfoResult.java
+++ b/src/main/java/spring/fitlinkbe/application/member/criteria/MemberInfoResult.java
@@ -42,5 +42,19 @@ public class MemberInfoResult {
                     .build();
         }
     }
-}
 
+    @Builder
+    public record MemberUpdateResponse(
+            Long memberId,
+            String name,
+            String phoneNumber
+    ) {
+        public static MemberUpdateResponse from(Member me) {
+            return MemberUpdateResponse.builder()
+                    .memberId(me.getMemberId())
+                    .name(me.getName())
+                    .phoneNumber(me.getPhoneNumber())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/spring/fitlinkbe/domain/common/model/PersonalDetail.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/model/PersonalDetail.java
@@ -19,13 +19,9 @@ public class PersonalDetail {
 
     private String name;
 
-    private Trainer trainer;
-
-    private Member member;
+    private Long memberId;
 
     private Long trainerId;
-
-    private Long memberId;
 
     private String profilePictureUrl;
 
@@ -54,13 +50,13 @@ public class PersonalDetail {
     public void registerMember(String name, LocalDate birthDate, PhoneNumber phoneNumber,
                                String profileUrl, Gender gender, Member member) {
         register(name, birthDate, phoneNumber, profileUrl, gender);
-        this.member = member;
+        this.memberId = member.getMemberId();
     }
 
     public void registerTrainer(String name, LocalDate birthDate, PhoneNumber phoneNumber,
                                 String profileUrl, Gender gender, Trainer trainer) {
         register(name, birthDate, phoneNumber, profileUrl, gender);
-        this.trainer = trainer;
+        this.trainerId = trainer.getTrainerId();
     }
 
     private void register(String name, LocalDate birthDate, PhoneNumber phoneNumber, String profileUrl, Gender gender) {
@@ -70,6 +66,15 @@ public class PersonalDetail {
         this.profilePictureUrl = profileUrl;
         this.gender = gender;
         this.status = Status.NORMAL;
+    }
+
+    public void update(String name, String phoneNumber) {
+        if (name != null) {
+            this.name = name;
+        }
+        if (phoneNumber != null) {
+            this.phoneNumber = new PhoneNumber(phoneNumber);
+        }
     }
 
     public enum Gender {

--- a/src/main/java/spring/fitlinkbe/domain/member/Member.java
+++ b/src/main/java/spring/fitlinkbe/domain/member/Member.java
@@ -45,4 +45,13 @@ public class Member {
         }
         return phoneNumber.getPhoneNumber();
     }
+
+    public void update(String name, String phoneNumber) {
+        if (name != null) {
+            this.name = name;
+        }
+        if (phoneNumber != null) {
+            this.phoneNumber = new PhoneNumber(phoneNumber);
+        }
+    }
 }

--- a/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
+++ b/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
@@ -103,4 +103,8 @@ public class MemberService {
     public Optional<SessionInfo> findSessionInfo(Long memberId) {
         return sessionInfoRepository.getSessionInfo(memberId);
     }
+
+    public void savePersonalDetail(PersonalDetail personalDetail) {
+        personalDetailRepository.savePersonalDetail(personalDetail);
+    }
 }

--- a/src/main/java/spring/fitlinkbe/infra/common/personaldetail/PersonalDetailEntity.java
+++ b/src/main/java/spring/fitlinkbe/infra/common/personaldetail/PersonalDetailEntity.java
@@ -69,13 +69,12 @@ public class PersonalDetailEntity {
                 .build();
     }
 
-    public static PersonalDetailEntity from(PersonalDetail personalDetail) {
+    public static PersonalDetailEntity of(PersonalDetail personalDetail, EntityManager em) {
         return PersonalDetailEntity.builder()
                 .personalDetailId(personalDetail.getPersonalDetailId() != null ? personalDetail.getPersonalDetailId() : null)
                 .name(personalDetail.getName())
-                .trainer(personalDetail.getTrainer() != null ? TrainerEntity.from(personalDetail.getTrainer()) : null)
-                .member(personalDetail.getMember() != null ? MemberEntity.from(personalDetail.getMember())
-                        : null)
+                .trainer(personalDetail.getTrainerId() != null ? em.getReference(TrainerEntity.class, personalDetail.getTrainerId()) : null)
+                .member(personalDetail.getMemberId() != null ? em.getReference(MemberEntity.class, personalDetail.getMemberId()) : null)
                 .profilePictureUrl(personalDetail.getProfilePictureUrl())
                 .gender(personalDetail.getGender())
                 .birthDate(personalDetail.getBirthDate())
@@ -85,5 +84,10 @@ public class PersonalDetailEntity {
                 .providerId(personalDetail.getProviderId())
                 .status(personalDetail.getStatus())
                 .build();
+    }
+
+    public void assignMemberAndTrainer(MemberEntity member, TrainerEntity trainer) {
+        this.member = member;
+        this.trainer = trainer;
     }
 }

--- a/src/main/java/spring/fitlinkbe/infra/common/personaldetail/PersonalDetailRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/common/personaldetail/PersonalDetailRepositoryImpl.java
@@ -1,5 +1,6 @@
 package spring.fitlinkbe.infra.common.personaldetail;
 
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import spring.fitlinkbe.domain.common.PersonalDetailRepository;
@@ -14,12 +15,13 @@ import java.util.Optional;
 public class PersonalDetailRepositoryImpl implements PersonalDetailRepository {
 
     private final PersonalDetailJpaRepository personalDetailJpaRepository;
+    private final EntityManager em;
 
     @Override
     public Optional<PersonalDetail> savePersonalDetail(PersonalDetail personalDetail) {
-        PersonalDetailEntity entity = personalDetailJpaRepository.save(PersonalDetailEntity.from(personalDetail));
+        PersonalDetailEntity personalDetailEntity = PersonalDetailEntity.of(personalDetail, em);
 
-        return Optional.of(entity.toDomain());
+        return Optional.of(personalDetailJpaRepository.save(personalDetailEntity).toDomain());
 
     }
 
@@ -31,7 +33,7 @@ public class PersonalDetailRepositoryImpl implements PersonalDetailRepository {
         if (optionalEntity.isPresent()) {
             return optionalEntity.get().toDomain();
         } else {
-            PersonalDetailEntity entity = personalDetailJpaRepository.save(PersonalDetailEntity.from(personalDetail));
+            PersonalDetailEntity entity = personalDetailJpaRepository.save(PersonalDetailEntity.of(personalDetail, em));
             return entity.toDomain();
         }
     }

--- a/src/main/java/spring/fitlinkbe/infra/notification/NotificationEntity.java
+++ b/src/main/java/spring/fitlinkbe/infra/notification/NotificationEntity.java
@@ -39,12 +39,12 @@ public class NotificationEntity {
 
     private LocalDateTime sendDate;
 
-    public static NotificationEntity from(Notification notification) {
+    public static NotificationEntity of(Notification notification, EntityManager em) {
         return NotificationEntity.builder()
                 .notificationId(notification.getNotificationId())
                 .refId(notification.getRefId())
                 .refType(notification.getRefType())
-                .personalDetail(PersonalDetailEntity.from(notification.getPersonalDetail()))
+                .personalDetail(PersonalDetailEntity.of(notification.getPersonalDetail(), em))
                 .name(notification.getName())
                 .content(notification.getContent())
                 .isSent(notification.getIsSent())

--- a/src/main/java/spring/fitlinkbe/infra/notification/NotificationRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/notification/NotificationRepositoryImpl.java
@@ -1,5 +1,6 @@
 package spring.fitlinkbe.infra.notification;
 
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import spring.fitlinkbe.domain.common.exception.CustomException;
@@ -12,6 +13,7 @@ import spring.fitlinkbe.domain.notification.NotificationRepository;
 public class NotificationRepositoryImpl implements NotificationRepository {
 
     private final NotificationJpaRepository notificationJpaRepository;
+    private final EntityManager em;
 
     @Override
     public Notification getNotification(Long personalDetailId) {
@@ -29,6 +31,6 @@ public class NotificationRepositoryImpl implements NotificationRepository {
 
     @Override
     public void save(Notification notification) {
-        notificationJpaRepository.save(NotificationEntity.from(notification));
+        notificationJpaRepository.save(NotificationEntity.of(notification, em));
     }
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/MemberController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/MemberController.java
@@ -41,4 +41,13 @@ public class MemberController {
         return ApiResultResponse.ok(MemberInfoDto.Response.from(result));
     }
 
+    @PatchMapping("/me")
+    public ApiResultResponse<MemberInfoDto.MemberUpdateResponse> updateMyInfo(
+            @Login SecurityUser user,
+            @RequestBody @Valid MemberInfoDto.MemberUpdateRequest requestBody) {
+        MemberInfoResult.MemberUpdateResponse result = memberFacade
+                .updateMyInfo(user.getMemberId(), requestBody.name(), requestBody.phoneNumber());
+
+        return ApiResultResponse.ok(MemberInfoDto.MemberUpdateResponse.from(result));
+    }
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/MemberInfoDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/MemberInfoDto.java
@@ -1,5 +1,6 @@
 package spring.fitlinkbe.interfaces.controller.member.dto;
 
+import jakarta.validation.constraints.AssertTrue;
 import lombok.Builder;
 import spring.fitlinkbe.application.member.criteria.MemberInfoResult;
 
@@ -38,6 +39,25 @@ public class MemberInfoDto {
                     result.remainingCount()
             );
         }
+    }
+
+
+    public record MemberUpdateRequest(
+            String name,
+            String phoneNumber
+    ) {
+
+        @AssertTrue(message = "이름, 전화번호 중 하나는 반드시 입력해야 합니다.")
+        public boolean isValid() {
+            return name != null || phoneNumber != null;
+        }
+    }
+
+    public record MemberUpdateResponse(
+            Long memberId,
+            String name,
+            String phoneNumber
+    ) {
     }
 }
 

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/MemberInfoDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/MemberInfoDto.java
@@ -1,5 +1,6 @@
 package spring.fitlinkbe.interfaces.controller.member.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.validation.constraints.AssertTrue;
 import lombok.Builder;
 import spring.fitlinkbe.application.member.criteria.MemberInfoResult;
@@ -48,16 +49,25 @@ public class MemberInfoDto {
     ) {
 
         @AssertTrue(message = "이름, 전화번호 중 하나는 반드시 입력해야 합니다.")
+        @JsonIgnore
         public boolean isValid() {
             return name != null || phoneNumber != null;
         }
     }
 
+    @Builder
     public record MemberUpdateResponse(
             Long memberId,
             String name,
             String phoneNumber
     ) {
+        public static MemberUpdateResponse from(MemberInfoResult.MemberUpdateResponse result) {
+            return MemberUpdateResponse.builder()
+                    .memberId(result.memberId())
+                    .name(result.name())
+                    .phoneNumber(result.phoneNumber())
+                    .build();
+        }
     }
 }
 

--- a/src/test/java/spring/fitlinkbe/domain/common/model/PhoneNumberUnitTest.java
+++ b/src/test/java/spring/fitlinkbe/domain/common/model/PhoneNumberUnitTest.java
@@ -1,0 +1,103 @@
+package spring.fitlinkbe.domain.common.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import spring.fitlinkbe.domain.common.exception.CustomException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class PhoneNumberUnitTest {
+
+    @Nested
+    @DisplayName("Phone 객체 생성 성공 테스트")
+    class CreatePhone {
+        @Test
+        @DisplayName("Phone 객체 생성 성공 테스트 - 10자리")
+        void createPhoneWith10() {
+            // given
+            String phoneNumber = "0101234567";
+
+            // when
+            PhoneNumber phone = new PhoneNumber(phoneNumber);
+
+            // then
+            assertThat(phone.getPhoneNumber()).isEqualTo(phoneNumber);
+        }
+
+        @Test
+        @DisplayName("Phone 객체 생성 성공 테스트 - 11자리")
+        void createPhoneWith11() {
+            // given
+            String phoneNumber = "01012345678";
+
+            // when
+            PhoneNumber phone = new PhoneNumber(phoneNumber);
+
+            // then
+            assertThat(phone.getPhoneNumber()).isEqualTo(phoneNumber);
+        }
+
+        @Test
+        @DisplayName("Phone 객체 생성 성공 테스트 - null")
+        void createPhoneWithNull() {
+            // given
+            String phoneNumber = null;
+
+            // when
+            PhoneNumber phone = new PhoneNumber(phoneNumber);
+
+            // then
+            assertThat(phone.getPhoneNumber()).isEqualTo(phoneNumber);
+        }
+    }
+
+    @Nested
+    @DisplayName("Phone 객체 생성 실패 테스트")
+    class CreatePhoneFail {
+        @Test
+        @DisplayName("Phone 객체 생성 실패 테스트 - 빈 문자열")
+        void createPhoneWithEmpty() {
+            // given
+            String phoneNumber = "";
+
+            // when & then
+            assertThatThrownBy(() -> new PhoneNumber(phoneNumber))
+                    .isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        @DisplayName("Phone 객체 생성 실패 테스트 - 10자리 미만")
+        void createPhoneWithLessThan10() {
+            // given
+            String phoneNumber = "010123456";
+
+            // when & then
+            assertThatThrownBy(() -> new PhoneNumber(phoneNumber))
+                    .isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        @DisplayName("Phone 객체 생성 실패 테스트 - 11자리 초과")
+        void createPhoneWithMoreThan11() {
+            // given
+            String phoneNumber = "010123456789";
+
+            // when & then
+            assertThatThrownBy(() -> new PhoneNumber(phoneNumber))
+                    .isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        @DisplayName("Phone 객체 생성 실패 테스트 - 숫자가 아닌 문자 포함")
+        void createPhoneWithNonNumeric() {
+            // given
+            String phoneNumber = "0101234a678";
+
+            // when & then
+            assertThatThrownBy(() -> new PhoneNumber(phoneNumber))
+                    .isInstanceOf(CustomException.class);
+        }
+    }
+}

--- a/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
@@ -46,7 +46,7 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
             String trainerCode = "AB1423";
             Member member = testDataHandler.createMember();
             Trainer trainer = testDataHandler.createTrainer(trainerCode);
-            PersonalDetail trainerPersonalDetail = testDataHandler.getPersonalDetail(trainer.getTrainerId());
+            PersonalDetail trainerPersonalDetail = testDataHandler.getTrainerPersonalDetail(trainer.getTrainerId());
             String token = testDataHandler.createTokenFromMember(member);
 
             // when
@@ -171,7 +171,7 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
 
 
                 // 알림 정보가 생성되었는지 확인
-                PersonalDetail trainerPersonalDetail = testDataHandler.getPersonalDetail(trainer.getTrainerId());
+                PersonalDetail trainerPersonalDetail = testDataHandler.getTrainerPersonalDetail(trainer.getTrainerId());
                 Notification notification = notificationRepository.getNotification(trainerPersonalDetail.getPersonalDetailId(),
                         Notification.NotificationType.DISCONNECT);
                 softly.assertThat(notification).isNotNull();
@@ -311,6 +311,10 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
                 softly.assertThat(data.memberId()).isEqualTo(member.getMemberId());
                 softly.assertThat(data.name()).isEqualTo(newName);
                 softly.assertThat(data.phoneNumber()).isEqualTo(newPhoneNumber);
+
+                PersonalDetail personalDetail = testDataHandler.getMemberPersonalDetail(member.getMemberId());
+                softly.assertThat(personalDetail.getName()).isEqualTo(newName);
+                softly.assertThat(personalDetail.getPhoneNumber()).isEqualTo(newPhoneNumber);
             });
         }
 

--- a/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
+++ b/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
@@ -75,7 +75,7 @@ public class TestDataHandler {
                 .name("홍길동")
                 .email("test@testcode.co.kr")
                 .status(PersonalDetail.Status.NORMAL)
-                .trainer(trainer)
+                .trainerId(trainer.getTrainerId())
                 .oauthProvider(PersonalDetail.OauthProvider.GOOGLE)
                 .providerId(UUID.randomUUID().toString())
                 .build();
@@ -87,7 +87,7 @@ public class TestDataHandler {
                 .name("홍길동")
                 .email("test@testcode.co.kr")
                 .status(PersonalDetail.Status.NORMAL)
-                .member(member)
+                .memberId(member.getMemberId())
                 .oauthProvider(PersonalDetail.OauthProvider.GOOGLE)
                 .providerId(UUID.randomUUID().toString())
                 .build();
@@ -125,13 +125,13 @@ public class TestDataHandler {
         personalDetailRepository.savePersonalDetail(PersonalDetail.builder()
                 .providerId("1")
                 .oauthProvider(PersonalDetail.OauthProvider.GOOGLE)
-                .trainer(savedTrainer)
-                .member(null)
+                .trainerId(savedTrainer.getTrainerId())
+                .memberId(null)
                 .build());
 
         personalDetailRepository.savePersonalDetail(PersonalDetail.builder()
-                .member(savedMember1)
-                .trainer(null)
+                .memberId(savedMember1.getMemberId())
+                .trainerId(null)
                 .providerId("1")
                 .oauthProvider(PersonalDetail.OauthProvider.GOOGLE)
                 .build());
@@ -155,8 +155,12 @@ public class TestDataHandler {
         return authTokenProvider.createAccessToken(personalDetail.getStatus(), personalDetail.getPersonalDetailId());
     }
 
-    public PersonalDetail getPersonalDetail(Long trainerId) {
+    public PersonalDetail getTrainerPersonalDetail(Long trainerId) {
         return personalDetailRepository.getTrainerDetail(trainerId).orElseThrow();
+    }
+
+    public PersonalDetail getMemberPersonalDetail(Long memberId) {
+        return personalDetailRepository.getMemberDetail(memberId).orElseThrow();
     }
 
     public void connectMemberAndTrainer(Member member, Trainer trainer) {


### PR DESCRIPTION
### 작업 사항
- PATCH `/v1/members/me` api 작업했습니다
- 기존 PersonalDetail에 있던 member, trainer obejct 제거하고 id만 가지고 있도록 수정했습니다
  - 이 값들이 제대로 domain -entity간 변형이 안되서 저장시 연관관계가 깨지는 현상 발견

**96번 머지하고 pr 진행하겠습니다**
