### PR TITLE
[Fliz-109] BE 예약 상세 대기 조회 API

### DIFF
--- a/docker/mysql/initdb.d/create_table.sql
+++ b/docker/mysql/initdb.d/create_table.sql
@@ -87,7 +87,7 @@ CREATE TABLE workout_schedule
 (
     workout_schedule_id BIGINT NOT NULL AUTO_INCREMENT,
     member_id           BIGINT,
-    preference_times    VARCHAR(255),
+    preference_times    JSON,
     created_at          DATETIME(6),
     updated_at          DATETIME(6),
     PRIMARY KEY (workout_schedule_id)
@@ -140,12 +140,11 @@ CREATE TABLE reservation
     trainer_id       BIGINT,
     session_info_id  BIGINT,
     name             VARCHAR(255),
-    reservation_date DATETIME(6) NOT NULL,
+    reservation_dates JSON NOT NULL,
     change_date      DATETIME(6),
     status           ENUM ('FIXED_RESERVATION','DISABLED_TIME_RESERVATION', 'RESERVATION_WAITING','RESERVATION_APPROVED',
         'RESERVATION_CANCELLED', 'RESERVATION_REJECTED', 'RESERVATION_CHANGE_REQUEST'),
     cancel_reason    VARCHAR(255),
-    priority         INT,
     is_day_off       BOOLEAN,
     created_at       DATETIME(6),
     updated_at       DATETIME(6),

--- a/src/main/java/spring/fitlinkbe/application/reservation/ReservationFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/reservation/ReservationFacade.java
@@ -102,9 +102,10 @@ public class ReservationFacade {
     }
 
     @Transactional
-    public List<ReservationResult.ReservationWaitingMember> getWaitingMembers(LocalDateTime reservationDate) {
+    public List<ReservationResult.ReservationWaitingMember> getWaitingMembers(LocalDateTime reservationDate,
+                                                                              SecurityUser user) {
         // 예약 조회
-        List<Reservation> reservations = reservationService.getReservations();
+        List<Reservation> reservations = reservationService.getReservationsWithWaitingStatus(user.getTrainerId());
         // 예약 날짜 일치하는거 필터
         List<Reservation> filteredList = reservations.stream()
                 .filter((r) -> r.isReservationDateSame(r.getReservationDates(), reservationDate))

--- a/src/main/java/spring/fitlinkbe/application/reservation/ReservationFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/reservation/ReservationFacade.java
@@ -18,6 +18,7 @@ import spring.fitlinkbe.support.security.SecurityUser;
 import java.time.LocalDate;
 import java.util.List;
 
+import static spring.fitlinkbe.domain.common.enums.UserRole.MEMBER;
 import static spring.fitlinkbe.domain.common.enums.UserRole.TRAINER;
 import static spring.fitlinkbe.domain.notification.Notification.Reason;
 
@@ -42,14 +43,11 @@ public class ReservationFacade {
 
         //예약 상세 정보 조회
         Reservation reservation = reservationService.getReservation(reservationId);
-
         //세션 정보 조회
         Session session = reservationService.getSession(reservation.getStatus(),
                 reservationId);
-
         // 개인 정보 조회
         PersonalDetail personalDetail = memberService.getMemberDetail(reservation.getMember().getMemberId());
-
         // 조합해서 리턴
         return ReservationResult.ReservationDetail.from(reservation, session, personalDetail);
     }
@@ -57,11 +55,11 @@ public class ReservationFacade {
     @Transactional
     public Reservation setDisabledReservation(ReservationCriteria.SetDisabledTime criteria, SecurityUser user) {
         String cancelMessage = "예약 불가 설정";
-        //1.  현재 시간보다 뒤에 있는 모든 예약 조회
+        //1. 모든 예약 조회
         List<Reservation> reservations = reservationService.getReservations();
-        //2. 예약 불가능한 시간대에 예약이 있나 확인
-        List<Reservation> duplicatedReservations = reservations
-                .stream()
+        //2. 예약 불가능한 시간대나 현시간보다 뒤에 예약이 있나 확인
+        List<Reservation> duplicatedReservations = reservations.stream()
+                .filter(reservation -> reservation.isReservationAfterToday(reservation))
                 .map(reservation -> reservation.checkStatus() ? reservation : null)
                 .toList();
         //2-1. 만약 그러한 예약들이 있다면 모두 취소 시킴
@@ -80,30 +78,25 @@ public class ReservationFacade {
     }
 
     @Transactional
-    public ReservationResult.Reservations reserveSession(List<ReservationCriteria.ReserveSession> criteria
+    public Reservation reserveSession(ReservationCriteria.ReserveSession criteria
             , SecurityUser user) {
-        List<Reservation> reservations = criteria.stream()
-                .map(reserveSession -> reserveSession.
-                        toDomain(memberService.getSessionInfo(reserveSession.trainerId(),
-                                        reserveSession.memberId()),
-                                user))
-                .toList();
-        List<Reservation> savedReservation = reservationService.reserveSession(reservations);
-        //만약 트레이너가 예약을 했다면, 바로 세션 생성
-        reservationService.createSessions(savedReservation);
-        // 알람 전송
-        savedReservation.forEach(reservation -> {
-            if (user.getUserRole() == TRAINER) {
-                // 트레이너가 예약했다면 멤버에게 예약이 됐다는 알람 전송
-                PersonalDetail memberDetail = memberService.getMemberDetail(reservation.getMember().getMemberId());
-                notificationService.sendApproveReservationNotification(reservation.getReservationId(), memberDetail);
-            } else {
-                // 멤버가 예약했다면 트레이너에게 예약 요청을 했다는 알람 전송
-                PersonalDetail trainerDetail = trainerService.getTrainerDetail(reservation.getTrainer().getTrainerId());
-                notificationService.sendRequestReservationNotification(reservation, trainerDetail);
-            }
-        });
-        return ReservationResult.Reservations.from(savedReservation);
-    }
+        Reservation reservation = criteria.toDomain(memberService.getSessionInfo(criteria.trainerId(),
+                criteria.memberId()), user);
+        Reservation savedReservation = reservationService.reserveSession(reservation);
 
+        if (user.getUserRole() == TRAINER) {
+            //만약 트레이너가 예약을 했다면, 바로 세션 생성
+            reservationService.createSession(savedReservation);
+            // 트레이너가 예약했다면 멤버에게 예약이 됐다는 알람 전송
+            PersonalDetail memberDetail = memberService.getMemberDetail(reservation.getMember().getMemberId());
+            notificationService.sendApproveReservationNotification(savedReservation.getReservationId(), memberDetail);
+        }
+
+        if (user.getUserRole() == MEMBER) {
+            // 멤버가 예약했다면 트레이너에게 예약 요청을 했다는 알람 전송
+            PersonalDetail trainerDetail = trainerService.getTrainerDetail(reservation.getTrainer().getTrainerId());
+            notificationService.sendRequestReservationNotification(savedReservation, trainerDetail);
+        }
+        return savedReservation;
+    }
 }

--- a/src/main/java/spring/fitlinkbe/application/reservation/ReservationFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/reservation/ReservationFacade.java
@@ -59,7 +59,7 @@ public class ReservationFacade {
         List<Reservation> reservations = reservationService.getReservations();
         //2. 예약 불가능한 시간대나 현시간보다 뒤에 예약이 있나 확인
         List<Reservation> duplicatedReservations = reservations.stream()
-                .filter(reservation -> reservation.isReservationAfterToday(reservation))
+                .filter(Reservation::isReservationAfterToday)
                 .map(reservation -> reservation.checkStatus() ? reservation : null)
                 .toList();
         //2-1. 만약 그러한 예약들이 있다면 모두 취소 시킴

--- a/src/main/java/spring/fitlinkbe/application/reservation/criteria/ReservationCriteria.java
+++ b/src/main/java/spring/fitlinkbe/application/reservation/criteria/ReservationCriteria.java
@@ -9,6 +9,7 @@ import spring.fitlinkbe.domain.trainer.Trainer;
 import spring.fitlinkbe.support.security.SecurityUser;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static spring.fitlinkbe.domain.common.enums.UserRole.MEMBER;
 
@@ -25,7 +26,7 @@ public class ReservationCriteria {
     }
 
     @Builder(toBuilder = true)
-    public record ReserveSession(Long trainerId, Long memberId, String name, LocalDateTime date, int priority) {
+    public record ReserveSession(Long trainerId, Long memberId, String name, List<LocalDateTime> dates) {
         public Reservation toDomain(SessionInfo sessionInfo, SecurityUser user) {
 
             return Reservation.builder()
@@ -33,11 +34,10 @@ public class ReservationCriteria {
                     .member(Member.builder().memberId(memberId).build())
                     .sessionInfo(sessionInfo)
                     .name(name)
-                    .reservationDate(date)
-                    .dayOfWeek(date.getDayOfWeek())
+                    .reservationDates(dates)
+                    .dayOfWeek(dates.get(0).getDayOfWeek())
                     .status(user.getUserRole() == MEMBER ? Reservation.Status.RESERVATION_WAITING
                             : Reservation.Status.RESERVATION_APPROVED)
-                    .priority(priority)
                     .build();
         }
     }

--- a/src/main/java/spring/fitlinkbe/application/reservation/criteria/ReservationResult.java
+++ b/src/main/java/spring/fitlinkbe/application/reservation/criteria/ReservationResult.java
@@ -23,6 +23,18 @@ public class ReservationResult {
     }
 
     @Builder(toBuilder = true)
+    public record ReservationWaitingMember(Reservation reservation, PersonalDetail personalDetail) {
+
+        public static ReservationWaitingMember from(Reservation reservation, PersonalDetail personalDetail) {
+
+            return ReservationResult.ReservationWaitingMember.builder()
+                    .reservation(reservation)
+                    .personalDetail(personalDetail)
+                    .build();
+        }
+    }
+
+    @Builder(toBuilder = true)
     public record Reservations(List<Reservation> reservations) {
 
         public static Reservations from(List<Reservation> reservations) {

--- a/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
@@ -19,16 +19,22 @@ public enum ErrorCode {
     CONNECT_AVAILABLE_AFTER_DISCONNECTED("이미 연결 요청중 또는 연결된 트레이너가 존재합니다.", 409),
 
     // Reservation 관련 ErrorCode
+
     RESERVATION_IS_FAILED("예약에 실패하였습니다.", 400),
+    RESERVATION_DATE_CAN_NOT_EMPTY("예약 요청 날짜는 비어있을 수 없습니다.", 400),
+    RESERVATION_DATE_CAN_NOT_SET_BEFORE_DAY("현재 날짜보다 이전 날짜는 설정이 불가능 합니다.", 400),
     SET_DISABLE_DATE_FAILED("예약 불가 설정에 실패하였습니다.", 400),
     RESERVATION_IS_ALREADY_CANCEL("이미 예약이 취소되었습니다.", 400),
     RESERVATION_CANCEL_NOT_ALLOWED("예약 취소를 할 수 없는 상태입니다.", 400),
     RESERVATION_NOT_FOUND("예약 정보를 찾지 못하였습니다.", 404),
+    FAILED_TO_CONVERT_JSON("Failed to convert LocalDateTime list to JSON", 400),
+    FAILED_TO_CONVERT_LIST("Failed to convert LocalDateTime list to List", 400),
 
     // Session 관련 ErrorCode
+    SESSION_CREATE_FAILED("세션 생성에 실패하였습니다.", 400),
     SESSION_NOT_FOUND("세션 정보를 찾지 못하였습니다.", 404),
     SESSION_IS_ALREADY_CANCEL("이미 세션이 취소되었습니다.", 400),
-    SESSION_IS_ALREADY_COMPLETED("이미 끝난 세션은 취소할 수 없습니다.", 400),
+    SESSION_IS_ALREADY_END("이미 세션이 종료되었습니다.", 400),
 
     // Notification 관련 ErrorCode
     NOTIFICATION_NOT_FOUND("알림 정보를 찾지 못하였습니다.", 404),
@@ -41,7 +47,6 @@ public enum ErrorCode {
     NEED_REQUIRED_SMS_STATUS("유저의 상태가 소셜 로그인만 진행된 상태어야 합니다", 403),
 
     TOKEN_NOT_FOUND("토큰 정보를 찾지 못하였습니다.", 404),
-
 
     // Common ErrorCode
     INVALID_PHONE_NUMBER_FORMAT("유효하지 않은 전화번호 형식입니다.", 400),

--- a/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
@@ -21,10 +21,9 @@ public enum ErrorCode {
     // Reservation 관련 ErrorCode
 
     RESERVATION_IS_FAILED("예약에 실패하였습니다.", 400),
-    RESERVATION_DATE_CAN_NOT_EMPTY("예약 요청 날짜는 비어있을 수 없습니다.", 400),
-    RESERVATION_DATE_CAN_NOT_SET_BEFORE_DAY("현재 날짜보다 이전 날짜는 설정이 불가능 합니다.", 400),
     SET_DISABLE_DATE_FAILED("예약 불가 설정에 실패하였습니다.", 400),
     RESERVATION_IS_ALREADY_CANCEL("이미 예약이 취소되었습니다.", 400),
+    RESERVATION_IS_NOT_WAITING_STATUS("예약 상태가 대기 상태가 아닙니다.", 400),
     RESERVATION_CANCEL_NOT_ALLOWED("예약 취소를 할 수 없는 상태입니다.", 400),
     RESERVATION_NOT_FOUND("예약 정보를 찾지 못하였습니다.", 404),
     FAILED_TO_CONVERT_JSON("Failed to convert LocalDateTime list to JSON", 400),

--- a/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     SET_DISABLE_DATE_FAILED("예약 불가 설정에 실패하였습니다.", 400),
     RESERVATION_IS_ALREADY_CANCEL("이미 예약이 취소되었습니다.", 400),
     RESERVATION_IS_NOT_WAITING_STATUS("예약 상태가 대기 상태가 아닙니다.", 400),
+    RESERVATION_WAITING_MEMBERS_EMPTY("이 날짜에 예약 대기자가 없습니다.", 400),
     RESERVATION_CANCEL_NOT_ALLOWED("예약 취소를 할 수 없는 상태입니다.", 400),
     RESERVATION_NOT_FOUND("예약 정보를 찾지 못하였습니다.", 404),
     FAILED_TO_CONVERT_JSON("Failed to convert LocalDateTime list to JSON", 400),

--- a/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
+++ b/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
@@ -38,10 +38,12 @@ public class MemberService {
         return personalDetail;
     }
 
+    @Transactional(readOnly = true)
     public List<WorkoutSchedule> getWorkoutSchedules(Long memberId) {
         return workoutScheduleRepository.findAllByMemberId(memberId);
     }
 
+    @Transactional(readOnly = true)
     public PersonalDetail getMemberDetail(Long memberId) {
         return personalDetailRepository.getMemberDetail(memberId)
                 .orElseThrow(() -> new CustomException(MEMBER_DETAIL_NOT_FOUND,

--- a/src/main/java/spring/fitlinkbe/domain/notification/Notification.java
+++ b/src/main/java/spring/fitlinkbe/domain/notification/Notification.java
@@ -88,7 +88,7 @@ public class Notification {
                 .refType(ReferenceType.RESERVATION)
                 .notificationType(NotificationType.RESERVATION_APPROVE)
                 .personalDetail(memberDetail)
-                .name(NotificationType.RESERVATION_CANCEL.name)
+                .name(NotificationType.RESERVATION_APPROVE.name)
                 .content(content)
                 .isSent(true)
                 .isRead(false)

--- a/src/main/java/spring/fitlinkbe/domain/reservation/Reservation.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/Reservation.java
@@ -14,6 +14,7 @@ import spring.fitlinkbe.support.utils.DateUtils;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static spring.fitlinkbe.domain.common.enums.UserRole.MEMBER;
 import static spring.fitlinkbe.domain.common.exception.ErrorCode.RESERVATION_CANCEL_NOT_ALLOWED;
@@ -29,12 +30,11 @@ public class Reservation {
     private Trainer trainer;
     private SessionInfo sessionInfo;
     private String name;
-    private LocalDateTime reservationDate;
+    private List<LocalDateTime> reservationDates;
     private LocalDateTime changeDate;
     private DayOfWeek dayOfWeek;
     private Status status;
     private String cancelReason;
-    private int priority;
     private boolean isDayOff;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -59,6 +59,33 @@ public class Reservation {
     public static LocalDateTime getEndDate(LocalDateTime startDate, UserRole userRole) {
         return (userRole == MEMBER) ? DateUtils.getOneMonthAfterDate(startDate)
                 : DateUtils.getTwoWeekAfterDate(startDate);
+    }
+
+    public boolean isReservationAfterToday() {
+        LocalDateTime nowDate = LocalDateTime.now();
+
+        LocalDateTime reservationDate = getReservationDate();
+
+        return reservationDate.isAfter(nowDate);
+    }
+
+    public boolean isReservationInRange(LocalDateTime startDate, LocalDateTime endDate) {
+        LocalDateTime reservationDate = getReservationDate();
+
+        return reservationDate.isAfter(startDate)
+                && reservationDate.isBefore(endDate);
+    }
+
+    public LocalDateTime getReservationDate() {
+
+        if(reservationDates == null) return LocalDateTime.now().minusYears(1);
+
+        return reservationDates.size() == 1 ? reservationDates.get(0)
+                : findEarlierDate(reservationDates);
+    }
+
+    private LocalDateTime findEarlierDate(List<LocalDateTime> dates) {
+        return dates.get(0).isAfter(dates.get(1)) ? dates.get(1) : dates.get(0);
     }
 
     public void cancel(String message) {

--- a/src/main/java/spring/fitlinkbe/domain/reservation/Reservation.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/Reservation.java
@@ -14,11 +14,11 @@ import spring.fitlinkbe.support.utils.DateUtils;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static spring.fitlinkbe.domain.common.enums.UserRole.MEMBER;
-import static spring.fitlinkbe.domain.common.exception.ErrorCode.RESERVATION_CANCEL_NOT_ALLOWED;
-import static spring.fitlinkbe.domain.common.exception.ErrorCode.RESERVATION_IS_ALREADY_CANCEL;
+import static spring.fitlinkbe.domain.common.exception.ErrorCode.*;
 
 @Builder(toBuilder = true)
 @Getter
@@ -69,6 +69,22 @@ public class Reservation {
         return reservationDate.isAfter(nowDate);
     }
 
+    public boolean isReservationDateSame(List<LocalDateTime> reservationDates, LocalDateTime requestDate) {
+
+        LocalDateTime truncatedRequestDate = requestDate.truncatedTo(ChronoUnit.HOURS);
+        return reservationDates.stream()
+                .map(date -> date.truncatedTo(ChronoUnit.HOURS))
+                .anyMatch(truncatedRequestDate::isEqual);
+    }
+
+    public boolean isWaitingStatus() {
+        if (status != Status.RESERVATION_WAITING) {
+            throw new CustomException(RESERVATION_IS_NOT_WAITING_STATUS, "예약 상태가 대기 상태가 아닙니다.");
+        }
+
+        return true;
+    }
+
     public boolean isReservationInRange(LocalDateTime startDate, LocalDateTime endDate) {
         LocalDateTime reservationDate = getReservationDate();
 
@@ -78,7 +94,7 @@ public class Reservation {
 
     public LocalDateTime getReservationDate() {
 
-        if(reservationDates == null) return LocalDateTime.now().minusYears(1);
+        if (reservationDates == null) return LocalDateTime.now().minusYears(1);
 
         return reservationDates.size() == 1 ? reservationDates.get(0)
                 : findEarlierDate(reservationDates);

--- a/src/main/java/spring/fitlinkbe/domain/reservation/ReservationRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/ReservationRepository.java
@@ -23,7 +23,4 @@ public interface ReservationRepository {
 
     List<Session> cancelSessions(List<Session> sessions);
 
-    List<Session> createSessions(List<Session> sessions);
-
-
 }

--- a/src/main/java/spring/fitlinkbe/domain/reservation/ReservationRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/ReservationRepository.java
@@ -9,6 +9,8 @@ public interface ReservationRepository {
 
     List<Reservation> getReservations();
 
+    List<Reservation> getReservationsWithWaitingStatus(Reservation.Status status, Long trainerId);
+
     List<Reservation> getReservations(UserRole role, Long userId);
 
     List<Reservation> cancelReservations(List<Reservation> canceledReservations);

--- a/src/main/java/spring/fitlinkbe/domain/reservation/ReservationRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/ReservationRepository.java
@@ -2,7 +2,6 @@ package spring.fitlinkbe.domain.reservation;
 
 import spring.fitlinkbe.domain.common.enums.UserRole;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -10,24 +9,21 @@ public interface ReservationRepository {
 
     List<Reservation> getReservations();
 
-    List<Reservation> getReservations(
-            LocalDateTime startDate, LocalDateTime endDate, UserRole role, Long userId);
+    List<Reservation> getReservations(UserRole role, Long userId);
 
     List<Reservation> cancelReservations(List<Reservation> canceledReservations);
 
     Optional<Reservation> getReservation(Long reservationId);
 
-    Optional<Reservation> saveReservation(Reservation reservation);
-
-    List<Reservation> reserveSession(List<Reservation> reservations);
-
+    Optional<Reservation> reserveSession(Reservation reservations);
 
     Optional<Session> getSession(Long reservationId);
 
-    Optional<Session> saveSession(Session session);
+    Optional<Session> createSession(Session session);
 
     List<Session> cancelSessions(List<Session> sessions);
 
     List<Session> createSessions(List<Session> sessions);
+
 
 }

--- a/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
@@ -117,17 +117,4 @@ public class ReservationService {
         return reservationRepository.createSession(session)
                 .orElseThrow(() -> new CustomException(SESSION_CREATE_FAILED));
     }
-
-    @Transactional
-    public List<Session> createSessions(List<Reservation> savedReservation) {
-
-        List<Session> sessions = savedReservation
-                .stream().map(reservation -> Session.builder()
-                        .reservationId(reservation.getReservationId())
-                        .status(Session.Status.SESSION_WAITING)
-                        .build())
-                .toList();
-
-        return reservationRepository.createSessions(sessions);
-    }
 }

--- a/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static spring.fitlinkbe.domain.common.exception.ErrorCode.RESERVATION_WAITING_MEMBERS_EMPTY;
 import static spring.fitlinkbe.domain.common.exception.ErrorCode.SESSION_CREATE_FAILED;
 import static spring.fitlinkbe.domain.reservation.Reservation.Status;
 import static spring.fitlinkbe.domain.reservation.Reservation.Status.DISABLED_TIME_RESERVATION;
@@ -46,6 +47,18 @@ public class ReservationService {
         return reservations.stream()
                 .filter(reservation -> reservation.isReservationInRange(startDate, endDate))
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<Reservation> getReservationsWithWaitingStatus(Long trainerId) {
+        List<Reservation> WaitingMembers = reservationRepository.getReservationsWithWaitingStatus(RESERVATION_WAITING,
+                trainerId);
+
+        if (WaitingMembers.isEmpty()) {
+            throw new CustomException(RESERVATION_WAITING_MEMBERS_EMPTY);
+        }
+
+        return WaitingMembers;
     }
 
     @Transactional(readOnly = true)
@@ -117,4 +130,6 @@ public class ReservationService {
         return reservationRepository.createSession(session)
                 .orElseThrow(() -> new CustomException(SESSION_CREATE_FAILED));
     }
+
+
 }

--- a/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static spring.fitlinkbe.domain.common.exception.ErrorCode.SESSION_CREATE_FAILED;
 import static spring.fitlinkbe.domain.reservation.Reservation.Status;
 import static spring.fitlinkbe.domain.reservation.Reservation.Status.DISABLED_TIME_RESERVATION;
 import static spring.fitlinkbe.domain.reservation.Reservation.Status.RESERVATION_WAITING;
@@ -40,7 +41,11 @@ public class ReservationService {
         LocalDateTime startDate = date.atStartOfDay();
         LocalDateTime endDate = getEndDate(startDate, role);
 
-        return reservationRepository.getReservations(startDate, endDate, role, userId);
+        List<Reservation> reservations = reservationRepository.getReservations(role, userId);
+
+        return reservations.stream()
+                .filter(reservation -> reservation.isReservationInRange(startDate, endDate))
+                .toList();
     }
 
     @Transactional(readOnly = true)
@@ -84,18 +89,33 @@ public class ReservationService {
 
         Reservation reservation = Reservation.builder()
                 .trainer(trainerInfo)
-                .reservationDate(command.date())
+                .reservationDates(List.of(command.date()))
                 .status(DISABLED_TIME_RESERVATION)
                 .build();
 
-        return reservationRepository.saveReservation(reservation).orElseThrow(() ->
+        return reservationRepository.reserveSession(reservation).orElseThrow(() ->
                 new CustomException(ErrorCode.SET_DISABLE_DATE_FAILED,
                         "예약 불가 설정을 할 수 없습니다."));
     }
 
     @Transactional
-    public List<Reservation> reserveSession(List<Reservation> reservations) {
-        return reservationRepository.reserveSession(reservations);
+    public Reservation reserveSession(Reservation reservation) {
+        return reservationRepository.reserveSession(reservation)
+                .orElseThrow(() ->
+                        new CustomException(ErrorCode.RESERVATION_IS_FAILED,
+                                "예약에 실패하였습니다."));
+    }
+
+    @Transactional
+    public Session createSession(Reservation savedReservation) {
+
+        Session session = Session.builder()
+                .reservationId(savedReservation.getReservationId())
+                .status(Session.Status.SESSION_WAITING)
+                .build();
+
+        return reservationRepository.createSession(session)
+                .orElseThrow(() -> new CustomException(SESSION_CREATE_FAILED));
     }
 
     @Transactional

--- a/src/main/java/spring/fitlinkbe/domain/reservation/Session.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/Session.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 import spring.fitlinkbe.domain.common.exception.CustomException;
 
 import static spring.fitlinkbe.domain.common.exception.ErrorCode.SESSION_IS_ALREADY_CANCEL;
-import static spring.fitlinkbe.domain.common.exception.ErrorCode.SESSION_IS_ALREADY_COMPLETED;
+import static spring.fitlinkbe.domain.common.exception.ErrorCode.SESSION_IS_ALREADY_END;
 
 @Builder(toBuilder = true)
 @Getter
@@ -25,6 +25,7 @@ public class Session {
 
         SESSION_CANCELLED, // 세션 취소
         SESSION_WAITING, // 세션 대기
+        SESSION_NOT_ATTEND, // 세션 불참석
         SESSION_COMPLETED, // 세션 완료
     }
 
@@ -32,8 +33,8 @@ public class Session {
         if (status == Status.SESSION_CANCELLED) {
             throw new CustomException(SESSION_IS_ALREADY_CANCEL);
         }
-        if (status == Status.SESSION_COMPLETED) {
-            throw new CustomException(SESSION_IS_ALREADY_COMPLETED);
+        if (status == Status.SESSION_NOT_ATTEND || status == Status.SESSION_COMPLETED) {
+            throw new CustomException(SESSION_IS_ALREADY_END);
         }
         cancelReason = message;
         status = Status.SESSION_CANCELLED;

--- a/src/main/java/spring/fitlinkbe/infra/reservation/LocalDateTimeListConverter.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/LocalDateTimeListConverter.java
@@ -1,0 +1,53 @@
+package spring.fitlinkbe.infra.reservation;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import spring.fitlinkbe.domain.common.exception.CustomException;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static spring.fitlinkbe.domain.common.exception.ErrorCode.FAILED_TO_CONVERT_JSON;
+import static spring.fitlinkbe.domain.common.exception.ErrorCode.FAILED_TO_CONVERT_LIST;
+
+@Converter(autoApply = true)
+public class LocalDateTimeListConverter implements AttributeConverter<List<LocalDateTime>, String> {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule()) // Java 8 LocalDateTime 지원
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 포맷 유지
+
+    @Override
+    public String convertToDatabaseColumn(List<LocalDateTime> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return "[]"; // 빈 리스트는 빈 JSON 배열로 저장
+        }
+        try {
+            return objectMapper.writeValueAsString(attribute); // JSON 문자열 변환
+        } catch (Exception e) {
+            throw new CustomException(FAILED_TO_CONVERT_JSON, e.getMessage());
+        }
+    }
+
+    @Override
+    public List<LocalDateTime> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return Collections.emptyList(); // null 또는 빈 문자열이면 빈 리스트 반환
+        }
+        try {
+            // DB에서 가져온 값이 이스케이프된 문자열이면 다시 JSON으로 변환
+            if (dbData.startsWith("\"") && dbData.endsWith("\"")) {
+                dbData = objectMapper.readValue(dbData, String.class); // 이스케이프 제거
+            }
+            return objectMapper.readValue(dbData, new TypeReference<>() {
+            });
+        } catch (Exception e) {
+            throw new CustomException(FAILED_TO_CONVERT_LIST, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationEntity.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationEntity.java
@@ -10,6 +10,7 @@ import spring.fitlinkbe.infra.trainer.TrainerEntity;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -37,7 +38,9 @@ public class ReservationEntity extends BaseTimeEntity {
 
     private String name;
 
-    private LocalDateTime reservationDate;
+    @Column(columnDefinition = "JSON")
+    @Convert(converter = LocalDateTimeListConverter.class)
+    private List<LocalDateTime> reservationDates;
 
     private LocalDateTime changeDate;
 
@@ -48,8 +51,6 @@ public class ReservationEntity extends BaseTimeEntity {
     private Reservation.Status status;
 
     private String cancelReason;
-
-    private int priority;
 
     private boolean isDayOff;
 
@@ -64,31 +65,11 @@ public class ReservationEntity extends BaseTimeEntity {
                 .sessionInfo(reservation.isReservationNotAllowed() ? null
                         : SessionInfoEntity.from(reservation.getSessionInfo()))
                 .name(reservation.getName())
-                .reservationDate(reservation.getReservationDate())
+                .reservationDates(reservation.getReservationDates())
                 .changeDate(reservation.getChangeDate())
                 .dayOfWeek(reservation.getDayOfWeek())
                 .status(reservation.getStatus())
                 .cancelReason(reservation.getCancelReason())
-                .priority(reservation.getPriority())
-                .isDayOff(reservation.isDayOff())
-                .build();
-    }
-
-    public static ReservationEntity fromWithId(Reservation reservation, EntityManager em) {
-
-        return ReservationEntity.builder()
-                .reservationId(reservation.getReservationId() != null
-                        ? reservation.getReservationId() : null)
-                .trainer(em.getReference(TrainerEntity.class, reservation.getTrainer().getTrainerId()))
-                .member(em.getReference(MemberEntity.class, reservation.getMember().getMemberId()))
-                .sessionInfo(em.getReference(SessionInfoEntity.class, reservation.getSessionInfo().getSessionInfoId()))
-                .name(reservation.getName())
-                .reservationDate(reservation.getReservationDate())
-                .changeDate(reservation.getChangeDate())
-                .dayOfWeek(reservation.getDayOfWeek())
-                .status(reservation.getStatus())
-                .cancelReason(reservation.getCancelReason())
-                .priority(reservation.getPriority())
                 .isDayOff(reservation.isDayOff())
                 .build();
     }
@@ -100,12 +81,11 @@ public class ReservationEntity extends BaseTimeEntity {
                 .trainer(trainer.toDomain())
                 .sessionInfo((sessionInfo == null || isReservationNotAllowed()) ? null : sessionInfo.toDomain())
                 .name(name)
-                .reservationDate(reservationDate)
+                .reservationDates(reservationDates)
                 .changeDate(changeDate)
                 .dayOfWeek(dayOfWeek)
                 .status(status)
                 .cancelReason(cancelReason)
-                .priority(priority)
                 .isDayOff(isDayOff)
                 .createdAt(getCreatedAt())
                 .updatedAt(getUpdatedAt())

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationJpaRepository.java
@@ -2,27 +2,45 @@ package spring.fitlinkbe.infra.reservation;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface ReservationJpaRepository extends JpaRepository<ReservationEntity, Long> {
 
-    @Query("SELECT r FROM ReservationEntity r WHERE r.trainer.trainerId = :trainerId AND " +
-            "r.reservationDate BETWEEN :startDate AND :endDate")
-    List<ReservationEntity> findByTrainerAndDateRange(
-            @Param("trainerId") Long trainerId,
-            @Param("startDate") LocalDateTime startDate,
-            @Param("endDate") LocalDateTime endDate);
+//    @Query("SELECT r FROM ReservationEntity r WHERE r.trainer.trainerId = :trainerId AND " +
+//            "r.reservationDate BETWEEN :startDate AND :endDate")
+//    List<ReservationEntity> findByTrainerAndDateRange(
+//            @Param("trainerId") Long trainerId,
+//            @Param("startDate") LocalDateTime startDate,
+//            @Param("endDate") LocalDateTime endDate);
+//
+//    @Query("SELECT r FROM ReservationEntity r WHERE r.member.memberId = :memberId AND " +
+//            "r.reservationDate BETWEEN :startDate AND :endDate")
+//    List<ReservationEntity> findByMemberAndDateRange(
+//            @Param("memberId") Long memberId,
+//            @Param("startDate") LocalDateTime startDate,
+//            @Param("endDate") LocalDateTime endDate);
 
-    @Query("SELECT r FROM ReservationEntity r WHERE r.member.memberId = :memberId AND " +
-            "r.reservationDate BETWEEN :startDate AND :endDate")
-    List<ReservationEntity> findByMemberAndDateRange(
-            @Param("memberId") Long memberId,
-            @Param("startDate") LocalDateTime startDate,
-            @Param("endDate") LocalDateTime endDate);
+//    @Query(value = "SELECT * FROM reservation r " +
+//            "WHERE r.trainer_id = :trainerId AND " +
+//            "(r.reservation_dates LIKE CONCAT('[\"', :startDate, '%') " +
+//            "OR r.reservation_dates LIKE CONCAT('[\"', :endDate, '%'))",
+//            nativeQuery = true)
+//    List<ReservationEntity> findByTrainerAndDateRange(
+//            @Param("trainerId") Long trainerId,
+//            @Param("startDate") String startDate,
+//            @Param("endDate") String endDate);
+//
+//    @Query(value = "SELECT * FROM reservation r " +
+//            "WHERE r.member_id = :memberId AND " +
+//            "(r.reservation_dates LIKE CONCAT('[\"', :startDate, '%') " +
+//            "OR r.reservation_dates LIKE CONCAT('[\"', :endDate, '%'))",
+//            nativeQuery = true)
+//    List<ReservationEntity> findByMemberAndDateRange(
+//            @Param("memberId") Long memberId,
+//            @Param("startDate") String startDate,
+//            @Param("endDate") String endDate);
 
     @Query("SELECT r FROM ReservationEntity r " +
             "LEFT JOIN FETCH r.member " +
@@ -30,7 +48,17 @@ public interface ReservationJpaRepository extends JpaRepository<ReservationEntit
             "WHERE r.reservationId = :reservationId")
     Optional<ReservationEntity> findByIdJoinFetch(Long reservationId);
 
-    @Query("SELECT r FROM ReservationEntity r " +
-            "WHERE r.reservationDate > :nowDate")
-    List<ReservationEntity> findAllReservation(@Param("nowDate") LocalDateTime nowDate);
+//    @Query(value = "SELECT * FROM reservation r " +
+//            "WHERE r.reservation_dates LIKE CONCAT('%', :nowDate, '%')", nativeQuery = true)
+//    List<ReservationEntity> findAllReservation(@Param("nowDate") String nowDate);
+
+    List<ReservationEntity> findByMember_MemberId(Long userId);
+
+    List<ReservationEntity> findByTrainer_TrainerId(Long userId);
+
+//    List<ReservationEntity> findAllReservation();
+
+//    @Query("SELECT r FROM ReservationEntity r " +
+//            "WHERE r.reservationDates > :nowDate")
+//    List<ReservationEntity> findAllReservation(@Param("nowDate") LocalDateTime nowDate);
 }

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationJpaRepository.java
@@ -2,6 +2,7 @@ package spring.fitlinkbe.infra.reservation;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import spring.fitlinkbe.domain.reservation.Reservation;
 
 import java.util.List;
 import java.util.Optional;
@@ -29,4 +30,12 @@ public interface ReservationJpaRepository extends JpaRepository<ReservationEntit
             "WHERE r.trainer.trainerId = :userId")
     List<ReservationEntity> findByTrainer_TrainerId(Long userId);
 
+    @Query("SELECT r FROM ReservationEntity r " +
+            "LEFT JOIN FETCH r.member " +
+            "LEFT JOIN FETCH r.trainer " +
+            "LEFT JOIN FETCH r.sessionInfo " +
+            "WHERE r.trainer.trainerId = :trainerId AND " +
+            "r.status = :status")
+    List<ReservationEntity> findWaitingStatus(Reservation.Status status,
+                                              Long trainerId);
 }

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationJpaRepository.java
@@ -8,57 +8,25 @@ import java.util.Optional;
 
 public interface ReservationJpaRepository extends JpaRepository<ReservationEntity, Long> {
 
-//    @Query("SELECT r FROM ReservationEntity r WHERE r.trainer.trainerId = :trainerId AND " +
-//            "r.reservationDate BETWEEN :startDate AND :endDate")
-//    List<ReservationEntity> findByTrainerAndDateRange(
-//            @Param("trainerId") Long trainerId,
-//            @Param("startDate") LocalDateTime startDate,
-//            @Param("endDate") LocalDateTime endDate);
-//
-//    @Query("SELECT r FROM ReservationEntity r WHERE r.member.memberId = :memberId AND " +
-//            "r.reservationDate BETWEEN :startDate AND :endDate")
-//    List<ReservationEntity> findByMemberAndDateRange(
-//            @Param("memberId") Long memberId,
-//            @Param("startDate") LocalDateTime startDate,
-//            @Param("endDate") LocalDateTime endDate);
-
-//    @Query(value = "SELECT * FROM reservation r " +
-//            "WHERE r.trainer_id = :trainerId AND " +
-//            "(r.reservation_dates LIKE CONCAT('[\"', :startDate, '%') " +
-//            "OR r.reservation_dates LIKE CONCAT('[\"', :endDate, '%'))",
-//            nativeQuery = true)
-//    List<ReservationEntity> findByTrainerAndDateRange(
-//            @Param("trainerId") Long trainerId,
-//            @Param("startDate") String startDate,
-//            @Param("endDate") String endDate);
-//
-//    @Query(value = "SELECT * FROM reservation r " +
-//            "WHERE r.member_id = :memberId AND " +
-//            "(r.reservation_dates LIKE CONCAT('[\"', :startDate, '%') " +
-//            "OR r.reservation_dates LIKE CONCAT('[\"', :endDate, '%'))",
-//            nativeQuery = true)
-//    List<ReservationEntity> findByMemberAndDateRange(
-//            @Param("memberId") Long memberId,
-//            @Param("startDate") String startDate,
-//            @Param("endDate") String endDate);
+    @Query("SELECT r FROM ReservationEntity r " +
+            "LEFT JOIN FETCH r.member " +
+            "LEFT JOIN FETCH r.trainer " +
+            "LEFT JOIN FETCH r.sessionInfo " +
+            "WHERE r.reservationId = :reservationId")
+    Optional<ReservationEntity> findByIdJoinFetch(Long reservationId);
 
     @Query("SELECT r FROM ReservationEntity r " +
             "LEFT JOIN FETCH r.member " +
             "LEFT JOIN FETCH r.trainer " +
-            "WHERE r.reservationId = :reservationId")
-    Optional<ReservationEntity> findByIdJoinFetch(Long reservationId);
-
-//    @Query(value = "SELECT * FROM reservation r " +
-//            "WHERE r.reservation_dates LIKE CONCAT('%', :nowDate, '%')", nativeQuery = true)
-//    List<ReservationEntity> findAllReservation(@Param("nowDate") String nowDate);
-
+            "LEFT JOIN FETCH r.sessionInfo " +
+            "WHERE r.member.memberId = :userId")
     List<ReservationEntity> findByMember_MemberId(Long userId);
 
+    @Query("SELECT r FROM ReservationEntity r " +
+            "LEFT JOIN FETCH r.member " +
+            "LEFT JOIN FETCH r.trainer " +
+            "LEFT JOIN FETCH r.sessionInfo " +
+            "WHERE r.trainer.trainerId = :userId")
     List<ReservationEntity> findByTrainer_TrainerId(Long userId);
 
-//    List<ReservationEntity> findAllReservation();
-
-//    @Query("SELECT r FROM ReservationEntity r " +
-//            "WHERE r.reservationDates > :nowDate")
-//    List<ReservationEntity> findAllReservation(@Param("nowDate") LocalDateTime nowDate);
 }

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationRepositoryImpl.java
@@ -102,19 +102,4 @@ public class ReservationRepositoryImpl implements ReservationRepository {
                 .map(SessionEntity::toDomain)
                 .toList();
     }
-
-    @Override
-    public List<Session> createSessions(List<Session> sessions) {
-
-        List<SessionEntity> entities = sessions.stream()
-                .map(session -> SessionEntity.from(session, em))
-                .toList();
-
-        List<SessionEntity> savedEntities = sessionJpaRepository.saveAll(entities);
-
-        return savedEntities.stream()
-                .map(SessionEntity::toDomain)
-                .toList();
-    }
-
 }

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationRepositoryImpl.java
@@ -8,7 +8,6 @@ import spring.fitlinkbe.domain.reservation.Reservation;
 import spring.fitlinkbe.domain.reservation.ReservationRepository;
 import spring.fitlinkbe.domain.reservation.Session;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,26 +24,22 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     @Override
     public List<Reservation> getReservations() {
 
-        return reservationJpaRepository.findAllReservation(LocalDateTime.now())
+        return reservationJpaRepository.findAll()
                 .stream()
                 .map(ReservationEntity::toDomain)
                 .toList();
     }
 
     @Override
-    public List<Reservation> getReservations(LocalDateTime startDate, LocalDateTime endDate,
-                                             UserRole role, Long userId) {
-
+    public List<Reservation> getReservations(UserRole role, Long userId) {
         if (role == MEMBER) { //멤버의 경우
-            return reservationJpaRepository.findByMemberAndDateRange(userId,
-                            startDate, endDate)
+            return reservationJpaRepository.findByMember_MemberId(userId)
                     .stream()
                     .map(ReservationEntity::toDomain)
                     .toList();
         }
 
-        return reservationJpaRepository.findByTrainerAndDateRange(userId,
-                        startDate, endDate)
+        return reservationJpaRepository.findByTrainer_TrainerId(userId)
                 .stream()
                 .map(ReservationEntity::toDomain)
                 .toList();
@@ -73,23 +68,10 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     }
 
     @Override
-    public Optional<Reservation> saveReservation(Reservation reservation) {
+    public Optional<Reservation> reserveSession(Reservation reservation) {
         ReservationEntity reservationEntity = reservationJpaRepository.save(ReservationEntity.from(reservation));
 
         return Optional.of(reservationEntity.toDomain());
-    }
-
-    @Override
-    public List<Reservation> reserveSession(List<Reservation> reservations) {
-        List<ReservationEntity> entities = reservations.stream()
-                .map(reservation -> ReservationEntity.fromWithId(reservation, em))
-                .toList();
-
-        List<ReservationEntity> savedEntities = reservationJpaRepository.saveAll(entities);
-
-        return savedEntities.stream()
-                .map(ReservationEntity::toDomain)
-                .toList();
     }
 
     @Override
@@ -102,7 +84,7 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     }
 
     @Override
-    public Optional<Session> saveSession(Session session) {
+    public Optional<Session> createSession(Session session) {
         SessionEntity savedEntity = sessionJpaRepository.save(SessionEntity.from(session, em));
 
         return Optional.of(savedEntity.toDomain());

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationRepositoryImpl.java
@@ -31,6 +31,14 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     }
 
     @Override
+    public List<Reservation> getReservationsWithWaitingStatus(Reservation.Status status, Long trainerId) {
+        return reservationJpaRepository.findWaitingStatus(status, trainerId)
+                .stream()
+                .map(ReservationEntity::toDomain)
+                .toList();
+    }
+
+    @Override
     public List<Reservation> getReservations(UserRole role, Long userId) {
         if (role == MEMBER) { //멤버의 경우
             return reservationJpaRepository.findByMember_MemberId(userId)

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import spring.fitlinkbe.application.reservation.ReservationFacade;
+import spring.fitlinkbe.domain.reservation.Reservation;
 import spring.fitlinkbe.interfaces.controller.common.dto.ApiResultResponse;
 import spring.fitlinkbe.interfaces.controller.reservation.dto.ReservationRequestDto;
 import spring.fitlinkbe.interfaces.controller.reservation.dto.ReservationResponseDto;
@@ -34,9 +35,11 @@ public class ReservationController {
     public ApiResultResponse<List<ReservationResponseDto.GetList>> getReservations(@RequestParam LocalDate date,
                                                                                    @Login SecurityUser user) {
 
-        return ApiResultResponse.ok(reservationFacade.getReservations(date, user).reservations().stream()
-                .map(ReservationResponseDto.GetList::of).toList());
+        List<Reservation> result = reservationFacade.getReservations(date, user).reservations();
 
+        return ApiResultResponse.ok(result.stream()
+                .map(ReservationResponseDto.GetList::of)
+                .toList());
     }
 
     /**
@@ -74,20 +77,19 @@ public class ReservationController {
     /**
      * 직접 예약
      *
-     * @param request memberId, name, date, priority 정보
+     * @param request memberId, name, dates 정보
      * @return ApiResultResponse 예약이 된 reservationId 목록 정보를 반환한다.
      */
     @PostMapping
-    public ApiResultResponse<List<ReservationResponseDto.Success>> reserveSession(@RequestBody @Valid
-                                                                                  ReservationRequestDto.ReserveSessions
-                                                                                          request,
-                                                                                  @Login SecurityUser user
+    public ApiResultResponse<ReservationResponseDto.Success> reserveSession(@RequestBody @Valid
+                                                                            ReservationRequestDto.ReserveSession
+                                                                                    request,
+                                                                            @Login SecurityUser user
     ) {
 
-        return ApiResultResponse.ok(reservationFacade.reserveSession(request.reserveSessions()
-                        .stream().map(ReservationRequestDto.ReserveSessions.ReserveSession::toCriteria).toList(), user)
-                .reservations().stream().map(ReservationResponseDto.Success::of).toList());
+        Reservation result = reservationFacade.reserveSession(request.toCriteria(), user);
 
+        return ApiResultResponse.ok(ReservationResponseDto.Success.of(result));
 
     }
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import spring.fitlinkbe.application.reservation.ReservationFacade;
+import spring.fitlinkbe.application.reservation.criteria.ReservationResult;
 import spring.fitlinkbe.domain.reservation.Reservation;
 import spring.fitlinkbe.interfaces.controller.common.dto.ApiResultResponse;
 import spring.fitlinkbe.interfaces.controller.reservation.dto.ReservationRequestDto;
@@ -14,6 +15,7 @@ import spring.fitlinkbe.support.argumentresolver.Login;
 import spring.fitlinkbe.support.security.SecurityUser;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -56,6 +58,26 @@ public class ReservationController {
         return ApiResultResponse.ok(ReservationResponseDto.GetDetail.of(
                 reservationFacade.getReservation(reservationId)));
 
+    }
+
+    /**
+     * 예약 상세 대기 조회
+     *
+     * @param reservationDate reservationDate 정보
+     * @return ApiResultResponse 예약 상세 대기 멤버 정보를 반환한다.
+     */
+
+    @GetMapping("/waiting-members/{reservationDate}")
+    public ApiResultResponse<List<ReservationResponseDto.GetWaitingMember>> getWaitingMembers(@PathVariable("reservationDate")
+                                                                                              @NotNull(message = "예약 날짜는 필수입니다.")
+                                                                                              LocalDateTime reservationDate) {
+
+
+        List<ReservationResult.ReservationWaitingMember> result = reservationFacade.getWaitingMembers(reservationDate);
+
+        return ApiResultResponse.ok(result.stream()
+                .map(ReservationResponseDto.GetWaitingMember::of)
+                .toList());
     }
 
     /**

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
@@ -70,10 +70,12 @@ public class ReservationController {
     @GetMapping("/waiting-members/{reservationDate}")
     public ApiResultResponse<List<ReservationResponseDto.GetWaitingMember>> getWaitingMembers(@PathVariable("reservationDate")
                                                                                               @NotNull(message = "예약 날짜는 필수입니다.")
-                                                                                              LocalDateTime reservationDate) {
+                                                                                              LocalDateTime reservationDate,
+                                                                                              @Login SecurityUser user) {
 
 
-        List<ReservationResult.ReservationWaitingMember> result = reservationFacade.getWaitingMembers(reservationDate);
+        List<ReservationResult.ReservationWaitingMember> result = reservationFacade.getWaitingMembers(reservationDate
+                , user);
 
         return ApiResultResponse.ok(result.stream()
                 .map(ReservationResponseDto.GetWaitingMember::of)

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationRequestDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationRequestDto.java
@@ -1,7 +1,6 @@
 package spring.fitlinkbe.interfaces.controller.reservation.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -36,41 +35,33 @@ public class ReservationRequestDto {
 
     }
 
-    @Builder
-    public record ReserveSessions(
-            @NotEmpty(message = "예약 요청 리스트는 비어있을 수 없습니다.")
-            @Valid List<ReserveSession> reserveSessions) {
 
-        @Builder(toBuilder = true)
-        public record ReserveSession(
-                @NotNull(message = "유저 ID는 필수값 입니다.") Long memberId,
-                @NotNull(message = "트레이너 ID는 필수값 입니다.") Long trainerId,
-                @NotBlank(message = "이름은 필수값 입니다.") String name,
-                LocalDateTime date, int priority) {
+    @Builder(toBuilder = true)
+    public record ReserveSession(
+            @NotNull(message = "유저 ID는 필수값 입니다.") Long memberId,
+            @NotNull(message = "트레이너 ID는 필수값 입니다.") Long trainerId,
+            @NotBlank(message = "이름은 필수값 입니다.") String name,
+            @NotEmpty(message = "예약 요청 날짜는 비어있을 수 없습니다.")
+            List<LocalDateTime> dates) {
 
-            public ReservationCriteria.ReserveSession toCriteria() {
+        public ReservationCriteria.ReserveSession toCriteria() {
 
-                return ReservationCriteria.ReserveSession.builder()
-                        .trainerId(trainerId)
-                        .memberId(memberId)
-                        .name(name)
-                        .date(date)
-                        .priority(priority)
-                        .build();
+            return ReservationCriteria.ReserveSession.builder()
+                    .trainerId(trainerId)
+                    .memberId(memberId)
+                    .name(name)
+                    .dates(dates)
+                    .build();
+        }
+
+        @JsonIgnore
+        @AssertTrue(message = "현재 날짜보다 이전 날짜는 설정이 불가능 합니다.")
+        public boolean isNotAllowedBeforeDate() {
+            if (dates == null || dates.isEmpty()) {
+                return true; // 비어있는 경우는 다른 @NotEmpty에서 검증하므로 true 반환
             }
-
-            @JsonIgnore
-            @AssertTrue(message = "현재 날짜보다 이전 날짜는 설정이 불가능 합니다.")
-            private boolean isNotAllowedBeforeDate() {
-                if (date == null) {
-                    return false;
-                }
-                LocalDateTime nowDate = LocalDateTime.now();
-
-                return nowDate.isBefore(date);
-            }
+            LocalDateTime nowDate = LocalDateTime.now();
+            return dates.stream().noneMatch(date -> date.isBefore(nowDate));
         }
     }
-
-
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationResponseDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationResponseDto.java
@@ -7,6 +7,7 @@ import spring.fitlinkbe.domain.reservation.Reservation;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class ReservationResponseDto {
 
@@ -24,7 +25,7 @@ public class ReservationResponseDto {
 
     @Builder(toBuilder = true)
     public record GetList(Long reservationId, Long sessionInfoId,
-                          boolean isDayOff, DayOfWeek dayOfWeek, LocalDateTime reservationDate,
+                          boolean isDayOff, DayOfWeek dayOfWeek, List<LocalDateTime> reservationDates,
                           Reservation.Status status, MemberInfo memberInfo) {
 
         public static ReservationResponseDto.GetList of(Reservation reservation) {
@@ -35,7 +36,7 @@ public class ReservationResponseDto {
                             reservation.getSessionInfo().getSessionInfoId())
                     .isDayOff(reservation.isDayOff())
                     .dayOfWeek(reservation.getDayOfWeek())
-                    .reservationDate(reservation.getReservationDate())
+                    .reservationDates(reservation.getReservationDates())
                     .status(reservation.getStatus())
                     .memberInfo(reservation.isReservationNotAllowed() ? null :
                             new MemberInfo(reservation.getMember().getMemberId(), reservation.getName()))
@@ -49,7 +50,7 @@ public class ReservationResponseDto {
 
     @Builder(toBuilder = true)
     public record GetDetail(Long reservationId, Long sessionId,
-                            DayOfWeek dayOfWeek, LocalDateTime reservationDate,
+                            DayOfWeek dayOfWeek, List<LocalDateTime> reservationDates,
                             Reservation.Status status, PersonalInfo memberInfo) {
 
         public static ReservationResponseDto.GetDetail of(ReservationResult.ReservationDetail result) {
@@ -58,7 +59,7 @@ public class ReservationResponseDto {
                     .reservationId(result.reservation().getReservationId())
                     .sessionId(result.session() != null ? result.session().getSessionId() : null)
                     .dayOfWeek(result.reservation().getDayOfWeek())
-                    .reservationDate(result.reservation().getReservationDate())
+                    .reservationDates(result.reservation().getReservationDates())
                     .status(result.reservation().getStatus())
                     .memberInfo(new PersonalInfo(result.personalDetail().getMemberId(),
                             result.reservation().getName(),

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationResponseDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationResponseDto.java
@@ -73,4 +73,24 @@ public class ReservationResponseDto {
                                     String profilePictureUrl) {
         }
     }
+
+    @Builder(toBuilder = true)
+    public record GetWaitingMember(Long reservationId, Long memberId, String name,
+                                   LocalDate birthDate, String phoneNumber, String profilePictureUrl,
+                                   DayOfWeek dayOfWeek, List<LocalDateTime> reservationDates) {
+
+        public static ReservationResponseDto.GetWaitingMember of(ReservationResult.ReservationWaitingMember member) {
+
+            return GetWaitingMember.builder()
+                    .memberId(member.personalDetail().getMemberId())
+                    .name(member.personalDetail().getName())
+                    .birthDate(member.personalDetail().getBirthDate())
+                    .phoneNumber(member.personalDetail().getPhoneNumber())
+                    .profilePictureUrl(member.personalDetail().getProfilePictureUrl())
+                    .reservationId(member.reservation().getReservationId())
+                    .reservationDates(member.reservation().getReservationDates())
+                    .dayOfWeek(member.reservation().getReservationDates().get(0).getDayOfWeek())
+                    .build();
+        }
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,6 +64,7 @@ spring:
       driver-class-name: com.mysql.cj.jdbc.Driver
       username: root
       password: 1234
+      maximum-pool-size: 50
 
   jpa:
     hibernate:
@@ -132,6 +133,7 @@ spring:
       driver-class-name:
       username:
       password:
+      maximum-pool-size: 50
 
   jpa:
     hibernate:

--- a/src/test/java/spring/fitlinkbe/domain/reservation/ReservationServiceTest.java
+++ b/src/test/java/spring/fitlinkbe/domain/reservation/ReservationServiceTest.java
@@ -20,10 +20,8 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
-import static spring.fitlinkbe.domain.common.exception.ErrorCode.RESERVATION_IS_ALREADY_CANCEL;
-import static spring.fitlinkbe.domain.common.exception.ErrorCode.RESERVATION_NOT_FOUND;
+import static spring.fitlinkbe.domain.common.exception.ErrorCode.*;
 import static spring.fitlinkbe.domain.reservation.Reservation.Status.*;
 
 class ReservationServiceTest {
@@ -342,31 +340,30 @@ class ReservationServiceTest {
                     .sessionId(1L)
                     .build();
 
-            when(reservationRepository.createSessions(anyList()))
-                    .thenReturn(List.of(session));
+            when(reservationRepository.createSession(any(Session.class)))
+                    .thenReturn(Optional.ofNullable(session));
 
             //when
-            List<Session> result = reservationService.createSessions(List.of(reservation));
+            Session result = reservationService.createSession(reservation);
 
             //then
-            assertThat(result).hasSize(1);
-            assertThat(result.get(0).getSessionId()).isEqualTo(1L);
+            assertThat(result).isNotNull();
+            assertThat(result.getSessionId()).isEqualTo(1L);
         }
 
         @Test
         @DisplayName("세션 생성 실패 - 예약 정보가 안넘어 왔을 때")
         void createSessionNoReservationInfo() {
             //given
-            when(reservationRepository.createSessions(anyList())).thenThrow(
-                    new CustomException(RESERVATION_NOT_FOUND,
-                            RESERVATION_NOT_FOUND.getMsg()));
+            when(reservationRepository.createSession(any())).thenThrow(
+                    new CustomException(SESSION_CREATE_FAILED,
+                            SESSION_CREATE_FAILED.getMsg()));
 
             //when & then
-            assertThatThrownBy(() -> reservationService.createSessions(List.of()))
+            assertThatThrownBy(() -> reservationService.createSession(Reservation.builder().build()))
                     .isInstanceOf(CustomException.class)
                     .extracting("errorCode")
-                    .isEqualTo(RESERVATION_NOT_FOUND);
+                    .isEqualTo(SESSION_CREATE_FAILED);
         }
     }
-
 }

--- a/src/test/java/spring/fitlinkbe/integration/ReservationIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/ReservationIntegrationTest.java
@@ -99,16 +99,15 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             SessionInfo sessionInfo = sessionInfoRepository.getSessionInfo(1L).orElseThrow();
 
             Reservation reservation = Reservation.builder()
-                    .reservationDate(reqeustDate)
+                    .reservationDates(List.of(reqeustDate))
                     .trainer(trainer)
                     .member(member)
                     .sessionInfo(sessionInfo)
                     .name(member.getName())
                     .dayOfWeek(reqeustDate.getDayOfWeek())
-                    .priority(0)
                     .build();
 
-            reservationRepository.saveReservation(reservation);
+            reservationRepository.reserveSession(reservation);
 
             // when
             ExtractableResponse<Response> result = get(LOCAL_HOST + port + PATH, params, accessToken);
@@ -141,12 +140,12 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             trainerRepository.saveDayOff(dayOff);
 
             Reservation reservation = Reservation.builder()
-                    .reservationDate(dayOffDate.atStartOfDay())
+                    .reservationDates(List.of(dayOffDate.atStartOfDay()))
                     .trainer(trainer)
                     .isDayOff(true)
                     .build();
 
-            reservationRepository.saveReservation(reservation);
+            reservationRepository.reserveSession(reservation);
 
             PersonalDetail personalDetails = personalDetailRepository.getTrainerDetail(1L)
                     .orElseThrow();
@@ -190,16 +189,15 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             LocalDateTime reqeustDate = LocalDateTime.now().plusWeeks(2);
 
             Reservation reservation = Reservation.builder()
-                    .reservationDate(reqeustDate)
+                    .reservationDates(List.of(reqeustDate))
                     .trainer(trainer)
                     .member(member)
                     .sessionInfo(sessionInfo)
                     .name(member.getName())
                     .dayOfWeek(reqeustDate.getDayOfWeek())
-                    .priority(0)
                     .build();
 
-            reservationRepository.saveReservation(reservation);
+            reservationRepository.reserveSession(reservation);
 
             // when
             ExtractableResponse<Response> result = get(LOCAL_HOST + port + PATH, params, accessToken);
@@ -235,16 +233,15 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             LocalDateTime reqeustDate = LocalDateTime.now().plusMonths(1).minusDays(1).minusSeconds(1);
 
             Reservation reservation = Reservation.builder()
-                    .reservationDate(reqeustDate)
+                    .reservationDates(List.of(reqeustDate))
                     .trainer(trainer)
                     .member(member)
                     .sessionInfo(sessionInfo)
                     .name(member.getName())
                     .dayOfWeek(reqeustDate.getDayOfWeek())
-                    .priority(0)
                     .build();
 
-            reservationRepository.saveReservation(reservation);
+            reservationRepository.reserveSession(reservation);
 
             // when
             ExtractableResponse<Response> result = get(LOCAL_HOST + port + PATH, params, accessToken);
@@ -280,16 +277,15 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             LocalDateTime reqeustDate = LocalDateTime.now().plusMonths(1).minusSeconds(1);
 
             Reservation reservation = Reservation.builder()
-                    .reservationDate(reqeustDate)
+                    .reservationDates(List.of(reqeustDate))
                     .trainer(trainer)
                     .member(member)
                     .sessionInfo(sessionInfo)
                     .name(member.getName())
                     .dayOfWeek(reqeustDate.getDayOfWeek())
-                    .priority(0)
                     .build();
 
-            reservationRepository.saveReservation(reservation);
+            reservationRepository.reserveSession(reservation);
 
             // when
             ExtractableResponse<Response> result = get(LOCAL_HOST + port + PATH, params, accessToken);
@@ -328,17 +324,16 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             LocalDateTime reqeustDate = LocalDateTime.now().plusMonths(1).minusSeconds(1);
 
             Reservation reservation = Reservation.builder()
-                    .reservationDate(reqeustDate)
+                    .reservationDates(List.of(reqeustDate))
                     .trainer(trainer)
                     .member(member)
                     .sessionInfo(sessionInfo)
                     .name(member.getName())
                     .dayOfWeek(reqeustDate.getDayOfWeek())
                     .status(RESERVATION_WAITING)
-                    .priority(0)
                     .build();
 
-            Reservation savedReservation = reservationRepository.saveReservation(reservation).orElseThrow();
+            Reservation savedReservation = reservationRepository.reserveSession(reservation).orElseThrow();
 
             // when
             ExtractableResponse<Response> result = get(LOCAL_HOST + port + PATH + "/"
@@ -372,17 +367,16 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             LocalDateTime reqeustDate = LocalDateTime.now().plusMonths(1).minusSeconds(1);
 
             Reservation reservation = Reservation.builder()
-                    .reservationDate(reqeustDate)
+                    .reservationDates(List.of(reqeustDate))
                     .trainer(trainer)
                     .member(member)
                     .sessionInfo(sessionInfo)
                     .name(member.getName())
                     .dayOfWeek(reqeustDate.getDayOfWeek())
                     .status(RESERVATION_WAITING)
-                    .priority(2)
                     .build();
 
-            Reservation savedReservation = reservationRepository.saveReservation(reservation).orElseThrow();
+            Reservation savedReservation = reservationRepository.reserveSession(reservation).orElseThrow();
 
             // when
             ExtractableResponse<Response> result = get(LOCAL_HOST + port + PATH + "/"
@@ -416,23 +410,22 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             LocalDateTime reqeustDate = LocalDateTime.now().plusMonths(1).minusSeconds(1);
 
             Reservation reservation = Reservation.builder()
-                    .reservationDate(reqeustDate)
+                    .reservationDates(List.of(reqeustDate))
                     .trainer(trainer)
                     .member(member)
                     .sessionInfo(sessionInfo)
                     .name(member.getName())
                     .dayOfWeek(reqeustDate.getDayOfWeek())
                     .status(RESERVATION_APPROVED)
-                    .priority(0)
                     .build();
 
-            Reservation savedReservation = reservationRepository.saveReservation(reservation).orElseThrow();
+            Reservation savedReservation = reservationRepository.reserveSession(reservation).orElseThrow();
 
             Session session = Session.builder()
                     .reservationId(savedReservation.getReservationId())
                     .build();
 
-            reservationRepository.saveSession(session);
+            reservationRepository.createSession(session);
 
             // when
             ExtractableResponse<Response> result = get(LOCAL_HOST + port + PATH + "/"
@@ -468,16 +461,15 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             LocalDateTime reservationDate = LocalDateTime.now().plusDays(1);
 
             Reservation reservation = Reservation.builder()
-                    .reservationDate(reservationDate)
+                    .reservationDates(List.of(reservationDate))
                     .trainer(trainer)
                     .member(member)
                     .name(member.getName())
                     .dayOfWeek(reservationDate.getDayOfWeek())
                     .status(RESERVATION_WAITING)
-                    .priority(0)
                     .build();
 
-            reservationRepository.saveReservation(reservation).orElseThrow();
+            reservationRepository.reserveSession(reservation).orElseThrow();
 
             LocalDateTime requestDate = LocalDateTime.now().plusHours(1);
 
@@ -518,23 +510,22 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             LocalDateTime reservationDate = LocalDateTime.now().plusDays(1);
 
             Reservation reservation = Reservation.builder()
-                    .reservationDate(reservationDate)
+                    .reservationDates(List.of(reservationDate))
                     .trainer(trainer)
                     .member(member)
                     .sessionInfo(sessionInfo)
                     .name(member.getName())
                     .dayOfWeek(reservationDate.getDayOfWeek())
                     .status(RESERVATION_WAITING)
-                    .priority(0)
                     .build();
 
-            Reservation savedReservation = reservationRepository.saveReservation(reservation).orElseThrow();
+            Reservation savedReservation = reservationRepository.reserveSession(reservation).orElseThrow();
 
             Session session = Session.builder()
                     .reservationId(savedReservation.getReservationId())
                     .build();
 
-            reservationRepository.saveSession(session);
+            reservationRepository.createSession(session);
 
             LocalDateTime requestDate = LocalDateTime.now().plusHours(1);
 
@@ -608,15 +599,11 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
             LocalDateTime requestDate = LocalDateTime.now().plusHours(1);
 
-            ReservationRequestDto.ReserveSessions request = ReservationRequestDto.ReserveSessions
-                    .builder()
-                    .reserveSessions(List.of(ReservationRequestDto.ReserveSessions.ReserveSession.builder()
-                            .trainerId(1L)
-                            .memberId(1L)
-                            .date(requestDate)
-                            .priority(0)
-                            .name("홍길동")
-                            .build()))
+            ReservationRequestDto.ReserveSession request = ReservationRequestDto.ReserveSession.builder()
+                    .trainerId(1L)
+                    .memberId(1L)
+                    .dates(List.of(requestDate))
+                    .name("홍길동")
                     .build();
 
             // when
@@ -628,16 +615,20 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             assertSoftly(softly -> {
                 // 예약이 잘 됐는지 확인
                 softly.assertThat(result.statusCode()).isEqualTo(200);
-                List<ReservationResponseDto.GetList> content = result.body().jsonPath()
-                        .getList("data", ReservationResponseDto.GetList.class);
-                softly.assertThat(content.size()).isEqualTo(1);
-                softly.assertThat(content.get(0).status()).isEqualTo(RESERVATION_APPROVED);
+
+                ReservationResponseDto.Success content = result.body().jsonPath()
+                        .getObject("data", ReservationResponseDto.Success.class);
+
+                softly.assertThat(content.reservationId()).isEqualTo(1L);
+                softly.assertThat(content.status()).isEqualTo(RESERVATION_APPROVED);
+
                 // 세션이 잘 생성됐는지 확인
-                Session session = reservationRepository.getSession(content.get(0).reservationId()).orElseThrow();
+                Session session = reservationRepository.getSession(content.reservationId()).orElseThrow();
                 softly.assertThat(session).isNotNull();
                 softly.assertThat(session.getStatus()).isEqualTo(Session.Status.SESSION_WAITING);
+
                 // 알람이 잘 생성됐는지 확인
-                Notification notification = notificationRepository.getNotification(content.get(0).reservationId(),
+                Notification notification = notificationRepository.getNotification(content.reservationId(),
                         Notification.ReferenceType.RESERVATION);
                 softly.assertThat(notification).isNotNull();
                 softly.assertThat(notification.getNotificationType()).isEqualTo(RESERVATION_APPROVE);
@@ -656,15 +647,11 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
             LocalDateTime requestDate = LocalDateTime.now().plusHours(1);
 
-            ReservationRequestDto.ReserveSessions request = ReservationRequestDto.ReserveSessions
-                    .builder()
-                    .reserveSessions(List.of(ReservationRequestDto.ReserveSessions.ReserveSession.builder()
-                            .trainerId(1L)
-                            .memberId(1L)
-                            .date(requestDate)
-                            .priority(0)
-                            .name("홍길동")
-                            .build()))
+            ReservationRequestDto.ReserveSession request = ReservationRequestDto.ReserveSession.builder()
+                    .trainerId(1L)
+                    .memberId(1L)
+                    .dates(List.of(requestDate))
+                    .name("홍길동")
                     .build();
 
             // when
@@ -676,12 +663,14 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             assertSoftly(softly -> {
                 //예약이 잘됐는지 확인
                 softly.assertThat(result.statusCode()).isEqualTo(200);
-                List<ReservationResponseDto.GetList> content = result.body().jsonPath()
-                        .getList("data", ReservationResponseDto.GetList.class);
-                softly.assertThat(content.size()).isEqualTo(1);
-                softly.assertThat(content.get(0).status()).isEqualTo(RESERVATION_WAITING);
+                ReservationResponseDto.Success content = result.body().jsonPath()
+                        .getObject("data", ReservationResponseDto.Success.class);
+
+                softly.assertThat(content.reservationId()).isEqualTo(1L);
+                softly.assertThat(content.status()).isEqualTo(RESERVATION_WAITING);
+
                 // 알람이 잘 생성됐는지 확인
-                Notification notification = notificationRepository.getNotification(content.get(0).reservationId(),
+                Notification notification = notificationRepository.getNotification(content.reservationId(),
                         Notification.ReferenceType.RESERVATION);
                 softly.assertThat(notification).isNotNull();
                 softly.assertThat(notification.getNotificationType()).isEqualTo(RESERVATION_REQUESTED);
@@ -698,25 +687,14 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             String accessToken = tokenProvider.createAccessToken(PersonalDetail.Status.NORMAL,
                     personalDetails.getPersonalDetailId());
 
-            LocalDateTime requestDate1 = LocalDateTime.now().plusHours(1);
-            LocalDateTime requestDate2 = LocalDateTime.now().plusHours(3);
+            LocalDateTime requestDate1 = LocalDateTime.now().plusHours(3);
+            LocalDateTime requestDate2 = LocalDateTime.now().plusHours(1);
 
-            ReservationRequestDto.ReserveSessions request = ReservationRequestDto.ReserveSessions
-                    .builder()
-                    .reserveSessions(List.of(ReservationRequestDto.ReserveSessions.ReserveSession.builder()
-                                    .trainerId(1L)
-                                    .memberId(1L)
-                                    .date(requestDate1)
-                                    .priority(1)
-                                    .name("홍길동")
-                                    .build(),
-                            ReservationRequestDto.ReserveSessions.ReserveSession.builder()
-                                    .trainerId(1L)
-                                    .memberId(1L)
-                                    .date(requestDate2)
-                                    .priority(2)
-                                    .name("홍길동")
-                                    .build()))
+            ReservationRequestDto.ReserveSession request = ReservationRequestDto.ReserveSession.builder()
+                    .trainerId(1L)
+                    .memberId(1L)
+                    .dates(List.of(requestDate1, requestDate2))
+                    .name("홍길동")
                     .build();
 
             // when
@@ -728,13 +706,15 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             assertSoftly(softly -> {
                 //예약이 잘 됐는지 확인
                 softly.assertThat(result.statusCode()).isEqualTo(200);
-                List<ReservationResponseDto.GetList> content = result.body().jsonPath()
-                        .getList("data", ReservationResponseDto.GetList.class);
-                softly.assertThat(content.size()).isEqualTo(2);
-                softly.assertThat(content.get(0).status()).isEqualTo(RESERVATION_WAITING);
-                softly.assertThat(content.get(1).status()).isEqualTo(RESERVATION_WAITING);
+
+                ReservationResponseDto.Success content = result.body().jsonPath()
+                        .getObject("data", ReservationResponseDto.Success.class);
+
+                softly.assertThat(content.reservationId()).isEqualTo(1L);
+                softly.assertThat(content.status()).isEqualTo(RESERVATION_WAITING);
+
                 // 알람이 잘 생성됐는지 확인
-                Notification notification = notificationRepository.getNotification(content.get(0).reservationId(),
+                Notification notification = notificationRepository.getNotification(content.reservationId(),
                         Notification.ReferenceType.RESERVATION);
                 softly.assertThat(notification).isNotNull();
                 softly.assertThat(notification.getNotificationType()).isEqualTo(RESERVATION_REQUESTED);
@@ -753,14 +733,10 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
             LocalDateTime requestDate = LocalDateTime.now().plusHours(1);
 
-            ReservationRequestDto.ReserveSessions request = ReservationRequestDto.ReserveSessions
-                    .builder()
-                    .reserveSessions(List.of(ReservationRequestDto.ReserveSessions.ReserveSession.builder()
-                            .memberId(1L)
-                            .date(requestDate)
-                            .priority(0)
-                            .name("홍길동")
-                            .build()))
+            ReservationRequestDto.ReserveSession request = ReservationRequestDto.ReserveSession.builder()
+                    .memberId(1L)
+                    .dates(List.of(requestDate))
+                    .name("홍길동")
                     .build();
 
             // when
@@ -790,14 +766,10 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
             LocalDateTime requestDate = LocalDateTime.now().plusHours(1);
 
-            ReservationRequestDto.ReserveSessions request = ReservationRequestDto.ReserveSessions
-                    .builder()
-                    .reserveSessions(List.of(ReservationRequestDto.ReserveSessions.ReserveSession.builder()
-                            .trainerId(1L)
-                            .date(requestDate)
-                            .priority(0)
-                            .name("홍길동")
-                            .build()))
+            ReservationRequestDto.ReserveSession request = ReservationRequestDto.ReserveSession.builder()
+                    .trainerId(1L)
+                    .dates(List.of(requestDate))
+                    .name("홍길동")
                     .build();
 
             // when
@@ -816,7 +788,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
         }
 
         @Test
-        @DisplayName("직접 예약 실패 - date 부재")
+        @DisplayName("직접 예약 실패 - dates 부재")
         void reserveSessionNoDate() {
             // given
             PersonalDetail personalDetails = personalDetailRepository.getTrainerDetail(1L)
@@ -825,14 +797,10 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             String accessToken = tokenProvider.createAccessToken(PersonalDetail.Status.NORMAL,
                     personalDetails.getPersonalDetailId());
 
-            ReservationRequestDto.ReserveSessions request = ReservationRequestDto.ReserveSessions
-                    .builder()
-                    .reserveSessions(List.of(ReservationRequestDto.ReserveSessions.ReserveSession.builder()
-                            .trainerId(1L)
-                            .memberId(1L)
-                            .priority(0)
-                            .name("홍길동")
-                            .build()))
+            ReservationRequestDto.ReserveSession request = ReservationRequestDto.ReserveSession.builder()
+                    .trainerId(1L)
+                    .memberId(1L)
+                    .name("홍길동")
                     .build();
 
             // when
@@ -844,7 +812,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             assertSoftly(softly -> {
                 softly.assertThat(result.statusCode()).isEqualTo(200);
                 softly.assertThat(result.body().jsonPath().getObject("success", Boolean.class)).isFalse();
-                softly.assertThat(result.body().jsonPath().getObject("msg", String.class)).isEqualTo("현재 날짜보다 이전 날짜는 설정이 불가능 합니다.");
+                softly.assertThat(result.body().jsonPath().getObject("msg", String.class)).isEqualTo("예약 요청 날짜는 비어있을 수 없습니다.");
                 softly.assertThat(result.body().jsonPath().getObject("data", ReservationResponseDto.GetList.class))
                         .isNull();
             });
@@ -862,14 +830,10 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
             LocalDateTime requestDate = LocalDateTime.now().plusHours(1);
 
-            ReservationRequestDto.ReserveSessions request = ReservationRequestDto.ReserveSessions
-                    .builder()
-                    .reserveSessions(List.of(ReservationRequestDto.ReserveSessions.ReserveSession.builder()
-                            .trainerId(1L)
-                            .memberId(1L)
-                            .date(requestDate)
-                            .priority(0)
-                            .build()))
+            ReservationRequestDto.ReserveSession request = ReservationRequestDto.ReserveSession.builder()
+                    .trainerId(1L)
+                    .memberId(1L)
+                    .dates(List.of(requestDate))
                     .build();
 
             // when
@@ -886,6 +850,5 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                         .isNull();
             });
         }
-
     }
 }

--- a/src/test/java/spring/fitlinkbe/integration/ReservationIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/ReservationIntegrationTest.java
@@ -558,7 +558,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
         }
 
         @Test
-        @DisplayName("트레이너 예약 상세 대기 목록 조회 실패 - 예약 대기 상태가 아님")
+        @DisplayName("트레이너 예약 상세 대기 목록 조회 실패 - 예약 대기자 없음")
         void getReservationWithTrainerNoWaitingStatus() {
             // given
             PersonalDetail personalDetails = personalDetailRepository.getTrainerDetail(1L)
@@ -587,32 +587,16 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
             reservationRepository.reserveSession(reservation1).orElseThrow();
 
-            Member member2 = testDataHandler.createMember();
-            SessionInfo sessionInfo2 = testDataHandler.createSessionInfo(member2, trainer);
-
-            Reservation reservation2 = Reservation.builder()
-                    .reservationDates(List.of(reserveDate))
-                    .trainer(trainer)
-                    .member(member2)
-                    .sessionInfo(sessionInfo2)
-                    .name(member2.getName())
-                    .dayOfWeek(reserveDate.getDayOfWeek())
-                    .status(RESERVATION_WAITING)
-                    .build();
-
-            reservationRepository.reserveSession(reservation2).orElseThrow();
-
             // when
             ExtractableResponse<Response> result = get(LOCAL_HOST + port + PATH + "/waiting-members/"
                     + reserveDate, accessToken);
-
 
             // then
             assertSoftly(softly -> {
                 softly.assertThat(result.statusCode()).isEqualTo(200);
                 softly.assertThat(result.body().jsonPath().getObject("success", Boolean.class)).isFalse();
                 softly.assertThat(result.body().jsonPath().getObject("msg", String.class))
-                        .contains("예약 상태가 대기 상태가 아닙니다.");
+                        .contains("이 날짜에 예약 대기자가 없습니다.");
                 softly.assertThat(result.body().jsonPath().getObject("data", ReservationResponseDto.GetWaitingMember.class))
                         .isNull();
             });

--- a/src/test/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationControllerTest.java
+++ b/src/test/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationControllerTest.java
@@ -29,7 +29,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -75,8 +74,7 @@ class ReservationControllerTest {
                     .member(Member.builder().memberId(1L).build())
                     .trainer(Trainer.builder().trainerId(1L).build())
                     .sessionInfo(SessionInfo.builder().SessionInfoId(1L).build())
-                    .reservationDate(LocalDateTime.now())
-                    .priority(1)
+                    .reservationDates(List.of(LocalDateTime.now()))
                     .dayOfWeek(LocalDateTime.now().getDayOfWeek())
                     .name("홍길동")
                     .build();
@@ -120,8 +118,7 @@ class ReservationControllerTest {
                     .reservationId(1L)
                     .member(Member.builder().memberId(1L).build())
                     .sessionInfo(SessionInfo.builder().SessionInfoId(1L).build())
-                    .reservationDate(LocalDateTime.now())
-                    .priority(1)
+                    .reservationDates(List.of(LocalDateTime.now()))
                     .dayOfWeek(LocalDateTime.now().getDayOfWeek())
                     .name("홍길동")
                     .build();
@@ -199,8 +196,7 @@ class ReservationControllerTest {
                     .reservationId(1L)
                     .member(Member.builder().memberId(1L).build())
                     .sessionInfo(SessionInfo.builder().SessionInfoId(1L).build())
-                    .reservationDate(LocalDateTime.now())
-                    .priority(1)
+                    .reservationDates(List.of(LocalDateTime.now()))
                     .dayOfWeek(LocalDateTime.now().getDayOfWeek())
                     .name("홍길동")
                     .build();
@@ -240,8 +236,7 @@ class ReservationControllerTest {
                     .reservationId(1L)
                     .member(Member.builder().memberId(1L).build())
                     .sessionInfo(SessionInfo.builder().SessionInfoId(1L).build())
-                    .reservationDate(LocalDateTime.now())
-                    .priority(1)
+                    .reservationDates(List.of(LocalDateTime.now()))
                     .dayOfWeek(LocalDateTime.now().getDayOfWeek())
                     .name("홍길동")
                     .build();
@@ -284,8 +279,7 @@ class ReservationControllerTest {
                     .reservationId(1L)
                     .member(Member.builder().memberId(1L).build())
                     .sessionInfo(SessionInfo.builder().SessionInfoId(1L).build())
-                    .reservationDate(LocalDateTime.now())
-                    .priority(1)
+                    .reservationDates(List.of(LocalDateTime.now()))
                     .dayOfWeek(LocalDateTime.now().getDayOfWeek())
                     .name("홍길동")
                     .build();
@@ -329,8 +323,7 @@ class ReservationControllerTest {
                     .member(Member.builder().memberId(1L).build())
                     .trainer(Trainer.builder().trainerId(1L).build())
                     .sessionInfo(SessionInfo.builder().SessionInfoId(1L).build())
-                    .reservationDate(LocalDateTime.now())
-                    .priority(1)
+                    .reservationDates(List.of(LocalDateTime.now()))
                     .dayOfWeek(LocalDateTime.now().getDayOfWeek())
                     .name("홍길동")
                     .build();
@@ -536,15 +529,11 @@ class ReservationControllerTest {
         @DisplayName("트레이너가 세션 예약 성공")
         void reserveSessionWithTrainer() throws Exception {
             //given
-            ReservationRequestDto.ReserveSessions
-                    request = ReservationRequestDto.ReserveSessions.builder()
-                    .reserveSessions(List.of((ReservationRequestDto.ReserveSessions.ReserveSession.builder()
-                            .trainerId(1L)
-                            .memberId(1L)
-                            .name("멤버1")
-                            .date(LocalDateTime.now().plusSeconds(2))
-                            .priority(0)
-                            .build())))
+            ReservationRequestDto.ReserveSession request = ReservationRequestDto.ReserveSession.builder()
+                    .trainerId(1L)
+                    .memberId(1L)
+                    .name("멤버1")
+                    .dates(List.of(LocalDateTime.now().plusSeconds(2)))
                     .build();
 
             Reservation reservation = Reservation.builder().reservationId(1L).build();
@@ -560,9 +549,8 @@ class ReservationControllerTest {
 
             String accessToken = getAccessToken(personalDetail);
 
-            when(reservationFacade.reserveSession(anyList(), any(SecurityUser.class))).thenReturn(ReservationResult.Reservations.from(List.of(reservation)));
-//            when(reservationFacade.reserveSession(anyList(),
-//                    any(SecurityUser.class))).thenReturn(List.of(reservation));
+            when(reservationFacade.reserveSession(any(ReservationCriteria.ReserveSession.class),
+                    any(SecurityUser.class))).thenReturn(reservation);
 
             //when & then
             mockMvc.perform(post("/v1/reservations")
@@ -576,23 +564,19 @@ class ReservationControllerTest {
                     .andExpect(jsonPath("$.status").value(200))
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.msg").value("OK"))
-                    .andExpect(jsonPath("$.data").isArray())
-                    .andExpect(jsonPath("$.data").isNotEmpty());
+                    .andExpect(jsonPath("$.data").isNotEmpty())
+                    .andExpect(jsonPath("$.data.reservationId").value(1L));
         }
 
         @Test
         @DisplayName("멤버가 세션 예약 성공")
         void reserveSessionWithMember() throws Exception {
             //given
-            ReservationRequestDto.ReserveSessions
-                    request = ReservationRequestDto.ReserveSessions.builder()
-                    .reserveSessions(List.of((ReservationRequestDto.ReserveSessions.ReserveSession.builder()
-                            .trainerId(1L)
-                            .memberId(1L)
-                            .name("멤버1")
-                            .date(LocalDateTime.now().plusSeconds(2))
-                            .priority(0)
-                            .build())))
+            ReservationRequestDto.ReserveSession request = ReservationRequestDto.ReserveSession.builder()
+                    .trainerId(1L)
+                    .memberId(1L)
+                    .name("멤버1")
+                    .dates(List.of(LocalDateTime.now().plusSeconds(2)))
                     .build();
 
             Reservation reservation = Reservation.builder().reservationId(1L).build();
@@ -608,9 +592,8 @@ class ReservationControllerTest {
 
             String accessToken = getAccessToken(personalDetail);
 
-            when(reservationFacade.reserveSession(anyList(), any(SecurityUser.class))).thenReturn(ReservationResult.Reservations.from(List.of(reservation)));
-//            when(reservationFacade.reserveSession(anyList(),
-//                    any(SecurityUser.class))).thenReturn(List.of(reservation));
+            when(reservationFacade.reserveSession(any(ReservationCriteria.ReserveSession.class)
+                    , any(SecurityUser.class))).thenReturn(reservation);
 
             //when & then
             mockMvc.perform(post("/v1/reservations")
@@ -624,24 +607,19 @@ class ReservationControllerTest {
                     .andExpect(jsonPath("$.status").value(200))
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.msg").value("OK"))
-                    .andExpect(jsonPath("$.data").isArray())
-                    .andExpect(jsonPath("$.data").isNotEmpty());
+                    .andExpect(jsonPath("$.data.reservationId").value(1L));
         }
 
         @Test
         @DisplayName("세션 예약 실패 - memberId 누락")
         void reserveSessionWithNoMemberId() throws Exception {
             //given
-            ReservationRequestDto.ReserveSessions
-                    request = ReservationRequestDto.ReserveSessions.builder()
-                    .reserveSessions(List.of((ReservationRequestDto.ReserveSessions.ReserveSession.builder()
-                            .trainerId(1L)
-                            .name("멤버1")
-                            .date(LocalDateTime.now().plusSeconds(2))
-                            .priority(0)
-                            .build())))
-                    .build();
 
+            ReservationRequestDto.ReserveSession request = ReservationRequestDto.ReserveSession.builder()
+                    .trainerId(1L)
+                    .name("멤버1")
+                    .dates(List.of(LocalDateTime.now().plusSeconds(2)))
+                    .build();
 
             Reservation reservation = Reservation.builder().reservationId(1L).build();
 
@@ -657,9 +635,8 @@ class ReservationControllerTest {
             String accessToken = getAccessToken(personalDetail);
 
             //when
-            when(reservationFacade.reserveSession(anyList(), any(SecurityUser.class))).thenReturn(ReservationResult.Reservations.from(List.of(reservation)));
-//            when(reservationFacade.reserveSession(anyList(),
-//                    any(SecurityUser.class))).thenReturn(List.of(reservation));
+            when(reservationFacade.reserveSession(any(ReservationCriteria.ReserveSession.class),
+                    any(SecurityUser.class))).thenReturn(reservation);
 
             //then
             mockMvc.perform(post("/v1/reservations")
@@ -680,14 +657,11 @@ class ReservationControllerTest {
         @DisplayName("세션 예약 실패 - date 정보 누락")
         void reserveSessionWithNoDate() throws Exception {
             //given
-            ReservationRequestDto.ReserveSessions
-                    request = ReservationRequestDto.ReserveSessions.builder()
-                    .reserveSessions(List.of((ReservationRequestDto.ReserveSessions.ReserveSession.builder()
-                            .trainerId(1L)
-                            .memberId(1L)
-                            .name("멤버1")
-                            .priority(0)
-                            .build())))
+
+            ReservationRequestDto.ReserveSession request = ReservationRequestDto.ReserveSession.builder()
+                    .trainerId(1L)
+                    .memberId(1L)
+                    .name("멤버1")
                     .build();
 
             Reservation reservation = Reservation.builder().reservationId(1L).build();
@@ -704,9 +678,8 @@ class ReservationControllerTest {
             String accessToken = getAccessToken(personalDetail);
 
             //when
-            when(reservationFacade.reserveSession(anyList(), any(SecurityUser.class))).thenReturn(ReservationResult.Reservations.from(List.of(reservation)));
-//            when(reservationFacade.reserveSession(anyList(),
-//                    any(SecurityUser.class))).thenReturn(List.of(reservation));
+            when(reservationFacade.reserveSession(any(ReservationCriteria.ReserveSession.class),
+                    any(SecurityUser.class))).thenReturn(reservation);
 
             //then
             mockMvc.perform(post("/v1/reservations")
@@ -719,7 +692,7 @@ class ReservationControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.status").value(400))
                     .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.msg").value("현재 날짜보다 이전 날짜는 설정이 불가능 합니다."))
+                    .andExpect(jsonPath("$.msg").value("예약 요청 날짜는 비어있을 수 없습니다."))
                     .andExpect(jsonPath("$.data").doesNotExist());
         }
 
@@ -727,15 +700,12 @@ class ReservationControllerTest {
         @DisplayName("세션 예약 실패 - name 정보 누락")
         void reserveSessionWithNoName() throws Exception {
             //given
-            ReservationRequestDto.ReserveSessions
-                    request = ReservationRequestDto.ReserveSessions.builder()
-                    .reserveSessions(List.of((ReservationRequestDto.ReserveSessions.ReserveSession.builder()
-                            .trainerId(1L)
-                            .memberId(1L)
-                            .date(LocalDateTime.now().plusSeconds(2))
-                            .priority(0)
-                            .build())))
+            ReservationRequestDto.ReserveSession request = ReservationRequestDto.ReserveSession.builder()
+                    .trainerId(1L)
+                    .memberId(1L)
+                    .dates(List.of(LocalDateTime.now().plusSeconds(2)))
                     .build();
+
 
             Reservation reservation = Reservation.builder().reservationId(1L).build();
 
@@ -751,9 +721,8 @@ class ReservationControllerTest {
             String accessToken = getAccessToken(personalDetail);
 
             //when
-            when(reservationFacade.reserveSession(anyList(), any(SecurityUser.class))).thenReturn(ReservationResult.Reservations.from(List.of(reservation)));
-//            when(reservationFacade.reserveSession(anyList(),
-//                    any(SecurityUser.class))).thenReturn(List.of(reservation));
+            when(reservationFacade.reserveSession(any(ReservationCriteria.ReserveSession.class),
+                    any(SecurityUser.class))).thenReturn(reservation);
 
             //then
             mockMvc.perform(post("/v1/reservations")

--- a/src/test/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationControllerTest.java
+++ b/src/test/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationControllerTest.java
@@ -419,7 +419,8 @@ class ReservationControllerTest {
                             .personalDetail(PersonalDetail.builder().personalDetailId(2L).build())
                             .build();
 
-            when(reservationFacade.getWaitingMembers(any(LocalDateTime.class))).thenReturn(List.of(result));
+            when(reservationFacade.getWaitingMembers(any(LocalDateTime.class), any(SecurityUser.class)))
+                    .thenReturn(List.of(result));
 
             //when & then
             mockMvc.perform(get("/v1/reservations/waiting-members/%s".formatted(requestDate))
@@ -455,7 +456,8 @@ class ReservationControllerTest {
                             .personalDetail(PersonalDetail.builder().personalDetailId(2L).build())
                             .build();
 
-            when(reservationFacade.getWaitingMembers(any(LocalDateTime.class))).thenReturn(List.of(result));
+            when(reservationFacade.getWaitingMembers(any(LocalDateTime.class), any(SecurityUser.class)))
+                    .thenReturn(List.of(result));
 
             //when & then
             mockMvc.perform(get("/v1/reservations/waiting-members/%s".formatted(""))


### PR DESCRIPTION
### 구현 기능

- `GET` "/v1/reservations/waiting-members/{reservationDate}" 예약 상세 대기 조회

### 세부 사항

- 예약 상세 대기 조회 API 개발 완료
- 테스트 코드 추가
- Reservation에서 priority 제거로 리팩토링 진행
- ddl문 수정

### DB 변동사항

- Reservation 에서 priority 제거
    - 대신 reservationsDate를 배열로 받아 그대로 json형태로 저장하여 순서대로 우선순위 저장
- Reservation 에서 reservationDate → reservationDates로 변경하면서 타입도 JSON 변경