### PR TITLE
[FLIZ-113] 내 PT내역 조회 api 작업

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.1'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'com.ewerk.gradle.plugins.querydsl' version '1.0.10'
 }
 
 group = 'spring'
@@ -38,6 +39,12 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    /* queryDSL */
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -55,3 +62,30 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+// QueryDSL 추가 시작
+def querydslDir = "build/generated/querydsl"
+
+querydsl {
+    library = "com.querydsl:querydsl-apt"
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+sourceSets {
+    main {
+        java {
+            srcDirs = ['src/main/java', querydslDir]
+        }
+    }
+}
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
+}
+configurations {
+    querydsl.extendsFrom compileClasspath
+}
+
+clean {
+    delete file(querydslDir)
+}
+// QueryDSL 추가 끝

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.1'
     id 'io.spring.dependency-management' version '1.1.7'
-    id 'com.ewerk.gradle.plugins.querydsl' version '1.0.10'
 }
 
 group = 'spring'
@@ -62,30 +61,3 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
-
-// QueryDSL 추가 시작
-def querydslDir = "build/generated/querydsl"
-
-querydsl {
-    library = "com.querydsl:querydsl-apt"
-    jpa = true
-    querydslSourcesDir = querydslDir
-}
-sourceSets {
-    main {
-        java {
-            srcDirs = ['src/main/java', querydslDir]
-        }
-    }
-}
-compileQuerydsl {
-    options.annotationProcessorPath = configurations.querydsl
-}
-configurations {
-    querydsl.extendsFrom compileClasspath
-}
-
-clean {
-    delete file(querydslDir)
-}
-// QueryDSL 추가 끝

--- a/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
@@ -18,6 +18,7 @@ import spring.fitlinkbe.domain.member.Member;
 import spring.fitlinkbe.domain.member.MemberService;
 import spring.fitlinkbe.domain.member.WorkoutSchedule;
 import spring.fitlinkbe.domain.notification.NotificationService;
+import spring.fitlinkbe.domain.reservation.ReservationService;
 import spring.fitlinkbe.domain.reservation.Session;
 import spring.fitlinkbe.domain.trainer.Trainer;
 import spring.fitlinkbe.domain.trainer.TrainerService;
@@ -33,6 +34,7 @@ public class MemberFacade {
     private final MemberService memberService;
     private final TrainerService trainerService;
     private final NotificationService notificationService;
+    private final ReservationService reservationService;
 
     @Transactional
     public void connectTrainer(Long memberId, String trainerCode) {
@@ -146,8 +148,9 @@ public class MemberFacade {
         workoutSchedules.removeAll(deletedWorkoutSchedules);
     }
 
+    @Transactional(readOnly = true)
     public Page<MemberSessionResult.SessionResponse> getSessions(Long memberId, Session.Status status, Pageable pageRequest) {
-        Page<Session> sessions = memberService.getSessions(memberId, status, pageRequest);
+        Page<Session> sessions = reservationService.getSessions(memberId, status, pageRequest);
 
         return sessions.map(MemberSessionResult.SessionResponse::from);
     }

--- a/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
@@ -1,9 +1,12 @@
 package spring.fitlinkbe.application.member;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import spring.fitlinkbe.application.member.criteria.MemberInfoResult;
+import spring.fitlinkbe.application.member.criteria.MemberSessionResult;
 import spring.fitlinkbe.application.member.criteria.WorkoutScheduleCriteria;
 import spring.fitlinkbe.application.member.criteria.WorkoutScheduleResult;
 import spring.fitlinkbe.domain.common.exception.CustomException;
@@ -15,6 +18,7 @@ import spring.fitlinkbe.domain.member.Member;
 import spring.fitlinkbe.domain.member.MemberService;
 import spring.fitlinkbe.domain.member.WorkoutSchedule;
 import spring.fitlinkbe.domain.notification.NotificationService;
+import spring.fitlinkbe.domain.reservation.Session;
 import spring.fitlinkbe.domain.trainer.Trainer;
 import spring.fitlinkbe.domain.trainer.TrainerService;
 
@@ -140,5 +144,12 @@ public class MemberFacade {
                 .toList();
         memberService.deleteAllWorkoutSchedules(deletedWorkoutSchedules);
         workoutSchedules.removeAll(deletedWorkoutSchedules);
+    }
+
+    public Page<MemberSessionResult.SessionResponse> getSessions(Long memberId, Session.Status status, Pageable pageRequest) {
+        memberService.checkMemberExists(memberId);
+        Page<Session> sessions = memberService.getSessions(memberId, status, pageRequest);
+
+        return sessions.map(MemberSessionResult.SessionResponse::from);
     }
 }

--- a/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
@@ -147,7 +147,6 @@ public class MemberFacade {
     }
 
     public Page<MemberSessionResult.SessionResponse> getSessions(Long memberId, Session.Status status, Pageable pageRequest) {
-        memberService.checkMemberExists(memberId);
         Page<Session> sessions = memberService.getSessions(memberId, status, pageRequest);
 
         return sessions.map(MemberSessionResult.SessionResponse::from);

--- a/src/main/java/spring/fitlinkbe/application/member/criteria/MemberSessionResult.java
+++ b/src/main/java/spring/fitlinkbe/application/member/criteria/MemberSessionResult.java
@@ -1,0 +1,21 @@
+package spring.fitlinkbe.application.member.criteria;
+
+import spring.fitlinkbe.domain.reservation.Session;
+
+import java.time.LocalDateTime;
+
+public class MemberSessionResult {
+    public record SessionResponse(
+            Long sessionId,
+            Session.Status status,
+            LocalDateTime date
+    ) {
+        public static SessionResponse from(Session session) {
+            return new SessionResponse(
+                    session.getSessionId(),
+                    session.getStatus(),
+                    session.getReservation().getReservationDate()
+            );
+        }
+    }
+}

--- a/src/main/java/spring/fitlinkbe/domain/common/exception/CustomException.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/exception/CustomException.java
@@ -19,7 +19,7 @@ public class CustomException extends RuntimeException {
 
     @Override
     public String getMessage() {
-        return "[%s] %s".formatted(errorCode, errorCode.getMsg());
+        return "[%s] %s".formatted(errorCode, msg);
     }
 
     public int getStatus() {

--- a/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
 
     WORKOUT_SCHEDULE_NOT_FOUND("운동 희망일이 존재하지 않습니다", 404),
     DUPLICATED_WORKOUT_SCHEDULE("운동 희망일이 겹칩니다", 400),
+    MEMBER_PERMISSION_DENIED("회원은 권한이 없습니다.", 403),
 
     // Reservation 관련 ErrorCode
 
@@ -54,7 +55,8 @@ public enum ErrorCode {
     // Common ErrorCode
     INVALID_PHONE_NUMBER_FORMAT("유효하지 않은 전화번호 형식입니다.", 400),
     PERSONAL_DETAIL_NOT_FOUND("Personal Detail 정보가 존재하지 않습니다.", 404),
-    CONNECTING_INFO_NOT_FOUND("Connecting Info 정보가 존재하지 않습니다.", 404);
+    CONNECTING_INFO_NOT_FOUND("Connecting Info 정보가 존재하지 않습니다.", 404),
+    ;
 
     private final String msg;
     private final int status;

--- a/src/main/java/spring/fitlinkbe/domain/member/MemberRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/member/MemberRepository.java
@@ -10,4 +10,6 @@ public interface MemberRepository {
     Optional<Member> getMember(Long memberId);
 
     List<Member> getMembers();
+
+    boolean exists(Long memberId);
 }

--- a/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
+++ b/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
@@ -1,6 +1,8 @@
 package spring.fitlinkbe.domain.member;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import spring.fitlinkbe.domain.auth.command.AuthCommand;
@@ -12,6 +14,8 @@ import spring.fitlinkbe.domain.common.exception.ErrorCode;
 import spring.fitlinkbe.domain.common.model.ConnectingInfo;
 import spring.fitlinkbe.domain.common.model.PersonalDetail;
 import spring.fitlinkbe.domain.common.model.SessionInfo;
+import spring.fitlinkbe.domain.reservation.Session;
+import spring.fitlinkbe.domain.reservation.SessionRepository;
 import spring.fitlinkbe.domain.trainer.Trainer;
 
 import java.util.List;
@@ -29,6 +33,7 @@ public class MemberService {
     private final PersonalDetailRepository personalDetailRepository;
     private final ConnectingInfoRepository connectingInfoRepository;
     private final SessionInfoRepository sessionInfoRepository;
+    private final SessionRepository sessionRepository;
 
     public PersonalDetail registerMember(Long personalDetailId, AuthCommand.MemberRegisterRequest command, Member savedMember) {
         PersonalDetail personalDetail = personalDetailRepository.getById(personalDetailId);
@@ -123,5 +128,15 @@ public class MemberService {
     public void deleteAllWorkoutSchedules(List<WorkoutSchedule> deletedWorkoutSchedules) {
         workoutScheduleRepository.deleteAllByIds(deletedWorkoutSchedules.stream()
                 .map(WorkoutSchedule::getWorkoutScheduleId).toList());
+    }
+
+    public Page<Session> getSessions(Long memberId, Session.Status status, Pageable pageRequest) {
+        return sessionRepository.getSessions(memberId, status, pageRequest);
+    }
+
+    public void checkMemberExists(Long memberId) {
+        if (!memberRepository.exists(memberId)) {
+            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
+++ b/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
@@ -1,8 +1,6 @@
 package spring.fitlinkbe.domain.member;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import spring.fitlinkbe.domain.auth.command.AuthCommand;
@@ -14,8 +12,6 @@ import spring.fitlinkbe.domain.common.exception.ErrorCode;
 import spring.fitlinkbe.domain.common.model.ConnectingInfo;
 import spring.fitlinkbe.domain.common.model.PersonalDetail;
 import spring.fitlinkbe.domain.common.model.SessionInfo;
-import spring.fitlinkbe.domain.reservation.Session;
-import spring.fitlinkbe.domain.reservation.SessionRepository;
 import spring.fitlinkbe.domain.trainer.Trainer;
 
 import java.util.List;
@@ -33,7 +29,6 @@ public class MemberService {
     private final PersonalDetailRepository personalDetailRepository;
     private final ConnectingInfoRepository connectingInfoRepository;
     private final SessionInfoRepository sessionInfoRepository;
-    private final SessionRepository sessionRepository;
 
     public PersonalDetail registerMember(Long personalDetailId, AuthCommand.MemberRegisterRequest command, Member savedMember) {
         PersonalDetail personalDetail = personalDetailRepository.getById(personalDetailId);
@@ -128,10 +123,6 @@ public class MemberService {
     public void deleteAllWorkoutSchedules(List<WorkoutSchedule> deletedWorkoutSchedules) {
         workoutScheduleRepository.deleteAllByIds(deletedWorkoutSchedules.stream()
                 .map(WorkoutSchedule::getWorkoutScheduleId).toList());
-    }
-
-    public Page<Session> getSessions(Long memberId, Session.Status status, Pageable pageRequest) {
-        return sessionRepository.getSessions(memberId, status, pageRequest);
     }
 
     public void checkMemberExists(Long memberId) {

--- a/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
@@ -123,7 +123,7 @@ public class ReservationService {
     public Session createSession(Reservation savedReservation) {
 
         Session session = Session.builder()
-                .reservationId(savedReservation.getReservationId())
+                .reservation(savedReservation)
                 .status(Session.Status.SESSION_WAITING)
                 .build();
 

--- a/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
@@ -3,6 +3,8 @@ package spring.fitlinkbe.domain.reservation;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import spring.fitlinkbe.domain.common.enums.UserRole;
@@ -29,6 +31,7 @@ import static spring.fitlinkbe.domain.reservation.Reservation.getEndDate;
 public class ReservationService {
 
     private final ReservationRepository reservationRepository;
+    private final SessionRepository sessionRepository;
 
     @Transactional(readOnly = true)
     public List<Reservation> getReservations() {
@@ -78,6 +81,10 @@ public class ReservationService {
 
         return getSession.orElseThrow(() -> new CustomException(ErrorCode.SESSION_NOT_FOUND,
                 "세션 정보를 찾을 수 없습니다. [reservationId: %d]".formatted(reservationId)));
+    }
+
+    public Page<Session> getSessions(Long memberId, Session.Status status, Pageable pageRequest) {
+        return sessionRepository.getSessions(memberId, status, pageRequest);
     }
 
     @Transactional

--- a/src/main/java/spring/fitlinkbe/domain/reservation/Session.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/Session.java
@@ -16,7 +16,7 @@ import static spring.fitlinkbe.domain.common.exception.ErrorCode.SESSION_IS_ALRE
 @AllArgsConstructor
 public class Session {
     private Long sessionId;
-    private Long reservationId;
+    private Reservation reservation;
     private Status status;
     private String cancelReason;
     private boolean isCompleted;

--- a/src/main/java/spring/fitlinkbe/domain/reservation/Session.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/Session.java
@@ -27,8 +27,6 @@ public class Session {
         SESSION_WAITING, // 세션 대기
         SESSION_NOT_ATTEND, // 세션 불참석
         SESSION_COMPLETED, // 세션 완료
-
-        NO_SHOW // 노쇼
     }
 
     public void cancel(String message) {

--- a/src/main/java/spring/fitlinkbe/domain/reservation/Session.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/Session.java
@@ -27,6 +27,8 @@ public class Session {
         SESSION_WAITING, // 세션 대기
         SESSION_NOT_ATTEND, // 세션 불참석
         SESSION_COMPLETED, // 세션 완료
+
+        NO_SHOW // 노쇼
     }
 
     public void cancel(String message) {

--- a/src/main/java/spring/fitlinkbe/domain/reservation/SessionRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/SessionRepository.java
@@ -1,0 +1,8 @@
+package spring.fitlinkbe.domain.reservation;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface SessionRepository {
+    Page<Session> getSessions(Long memberId, Session.Status status, Pageable pageRequest);
+}

--- a/src/main/java/spring/fitlinkbe/infra/member/MemberRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/member/MemberRepositoryImpl.java
@@ -36,4 +36,9 @@ public class MemberRepositoryImpl implements MemberRepository {
     public List<Member> getMembers() {
         return memberJpaRepository.findAll().stream().map(MemberEntity::toDomain).toList();
     }
+
+    @Override
+    public boolean exists(Long memberId) {
+        return memberJpaRepository.existsById(memberId);
+    }
 }

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationEntity.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationEntity.java
@@ -2,6 +2,7 @@ package spring.fitlinkbe.infra.reservation;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.Hibernate;
 import spring.fitlinkbe.domain.reservation.Reservation;
 import spring.fitlinkbe.infra.common.model.BaseTimeEntity;
 import spring.fitlinkbe.infra.common.sessioninfo.SessionInfoEntity;
@@ -77,9 +78,10 @@ public class ReservationEntity extends BaseTimeEntity {
     public Reservation toDomain() {
         return Reservation.builder()
                 .reservationId(reservationId)
-                .member(isReservationNotAllowed() ? null : member.toDomain())
-                .trainer(trainer.toDomain())
-                .sessionInfo((sessionInfo == null || isReservationNotAllowed()) ? null : sessionInfo.toDomain())
+                .member(isReservationNotAllowed() ? null : Hibernate.isInitialized(member) ? member.toDomain() : null)
+                .trainer(Hibernate.isInitialized(trainer) ? trainer.toDomain() : null)
+                .sessionInfo((sessionInfo == null || isReservationNotAllowed()) ? null :
+                        Hibernate.isInitialized(sessionInfo) ? sessionInfo.toDomain() : null)
                 .name(name)
                 .reservationDates(reservationDates)
                 .changeDate(changeDate)

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationJpaRepository.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ReservationJpaRepository extends JpaRepository<ReservationEntity, Long> {
-
     @Query("SELECT r FROM ReservationEntity r " +
             "LEFT JOIN FETCH r.member " +
             "LEFT JOIN FETCH r.trainer " +

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationJpaRepository.java
@@ -1,5 +1,7 @@
 package spring.fitlinkbe.infra.reservation;
 
+import jakarta.annotation.Nonnull;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import spring.fitlinkbe.domain.reservation.Reservation;
@@ -37,4 +39,10 @@ public interface ReservationJpaRepository extends JpaRepository<ReservationEntit
             "r.status = :status")
     List<ReservationEntity> findWaitingStatus(Reservation.Status status,
                                               Long trainerId);
+
+    @Override
+    @Nonnull
+    @EntityGraph(attributePaths = {"member", "trainer", "sessionInfo"})
+    List<ReservationEntity> findAll();
+
 }

--- a/src/main/java/spring/fitlinkbe/infra/reservation/SessionEntity.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/SessionEntity.java
@@ -2,6 +2,7 @@ package spring.fitlinkbe.infra.reservation;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.Hibernate;
 import spring.fitlinkbe.domain.reservation.Session;
 import spring.fitlinkbe.infra.common.model.BaseTimeEntity;
 
@@ -45,7 +46,7 @@ public class SessionEntity extends BaseTimeEntity {
     public Session toDomain() {
         return Session.builder()
                 .sessionId(sessionId)
-                .reservation(reservation.toDomain())
+                .reservation(Hibernate.isInitialized(reservation) ? reservation.toDomain() : null)
                 .status(status)
                 .cancelReason(cancelReason)
                 .isCompleted(isCompleted)

--- a/src/main/java/spring/fitlinkbe/infra/reservation/SessionEntity.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/SessionEntity.java
@@ -23,6 +23,7 @@ public class SessionEntity extends BaseTimeEntity {
     @JoinColumn(name = "reservation_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private ReservationEntity reservation;
 
+    @Enumerated(EnumType.STRING)
     private Status status;
 
     private String cancelReason;
@@ -34,9 +35,7 @@ public class SessionEntity extends BaseTimeEntity {
         return SessionEntity.builder()
                 .sessionId(session.getSessionId() != null
                         ? session.getSessionId() : null)
-
-                .reservation(session.getReservationId() != null ?
-                        em.getReference(ReservationEntity.class, session.getReservationId()) : null)
+                .reservation(em.getReference(ReservationEntity.class, session.getReservation().getReservationId()))
                 .status(session.getStatus())
                 .cancelReason(session.getCancelReason())
                 .isCompleted(session.isCompleted())
@@ -46,7 +45,7 @@ public class SessionEntity extends BaseTimeEntity {
     public Session toDomain() {
         return Session.builder()
                 .sessionId(sessionId)
-                .reservationId(reservation.getReservationId())
+                .reservation(reservation.toDomain())
                 .status(status)
                 .cancelReason(cancelReason)
                 .isCompleted(isCompleted)

--- a/src/main/java/spring/fitlinkbe/infra/reservation/SessionJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/SessionJpaRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface SessionJpaRepository extends JpaRepository<SessionEntity, Long> {
+public interface SessionJpaRepository extends JpaRepository<SessionEntity, Long>, SessionRepositoryCustom {
 
     @EntityGraph(attributePaths = {"reservation"})
     Optional<SessionEntity> findByReservation_ReservationId(Long reservationId);

--- a/src/main/java/spring/fitlinkbe/infra/reservation/SessionRepositoryCustom.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/SessionRepositoryCustom.java
@@ -1,0 +1,9 @@
+package spring.fitlinkbe.infra.reservation;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import spring.fitlinkbe.domain.reservation.Session;
+
+public interface SessionRepositoryCustom {
+    Page<SessionEntity> findSessions(Long memberId, Session.Status status, Pageable pageRequest);
+}

--- a/src/main/java/spring/fitlinkbe/infra/reservation/SessionRepositoryCustomImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/SessionRepositoryCustomImpl.java
@@ -1,0 +1,48 @@
+package spring.fitlinkbe.infra.reservation;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import spring.fitlinkbe.domain.reservation.Session;
+
+import java.util.List;
+
+import static spring.fitlinkbe.infra.reservation.QSessionEntity.sessionEntity;
+
+@RequiredArgsConstructor
+public class SessionRepositoryCustomImpl implements SessionRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<SessionEntity> findSessions(Long memberId, Session.Status status, Pageable pageRequest) {
+        List<SessionEntity> entityList = queryFactory.selectFrom(sessionEntity)
+                .join(sessionEntity.reservation).fetchJoin()
+                .where(eqMemberId(memberId).and(eqStatus(status)))
+                .orderBy(sessionEntity.createdAt.desc())
+                .offset(pageRequest.getOffset())
+                .limit(pageRequest.getPageSize())
+                .fetch();
+
+        Long totalCount = queryFactory.select(sessionEntity.count())
+                .from(sessionEntity)
+                .where(eqMemberId(memberId).and(eqStatus(status)))
+                .fetchOne();
+        if (totalCount == null) {
+            totalCount = 0L;
+        }
+
+        return new PageImpl<>(entityList, pageRequest, totalCount);
+    }
+
+    private BooleanExpression eqMemberId(Long memberId) {
+        return memberId != null ? sessionEntity.reservation.member.memberId.eq(memberId) : null;
+    }
+
+    private BooleanExpression eqStatus(Session.Status status) {
+        return status != null ? sessionEntity.status.eq(status) : null;
+    }
+}

--- a/src/main/java/spring/fitlinkbe/infra/reservation/SessionRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/SessionRepositoryImpl.java
@@ -1,0 +1,23 @@
+package spring.fitlinkbe.infra.reservation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import spring.fitlinkbe.domain.reservation.Session;
+import spring.fitlinkbe.domain.reservation.SessionRepository;
+
+
+@Repository
+@RequiredArgsConstructor
+public class SessionRepositoryImpl implements SessionRepository {
+
+    private final SessionJpaRepository sessionJpaRepository;
+
+    @Override
+    public Page<Session> getSessions(Long memberId, Session.Status status, Pageable pageRequest) {
+        Page<SessionEntity> result = sessionJpaRepository.findSessions(memberId, status, pageRequest);
+
+        return result.map(SessionEntity::toDomain);
+    }
+}

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/common/dto/CustomPageResponse.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/common/dto/CustomPageResponse.java
@@ -1,0 +1,14 @@
+package spring.fitlinkbe.interfaces.controller.common.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Getter
+public class CustomPageResponse<T> {
+    private final List<T> content;
+    private final int totalPages;
+    private final int totalElements;
+}

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/common/dto/CustomPageResponse.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/common/dto/CustomPageResponse.java
@@ -1,14 +1,44 @@
 package spring.fitlinkbe.interfaces.controller.common.dto;
 
+import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
-@RequiredArgsConstructor
 @Getter
 public class CustomPageResponse<T> {
-    private final List<T> content;
-    private final int totalPages;
-    private final int totalElements;
+    private List<T> content;
+    private int totalPages;
+    private long totalElements;
+
+    @Builder
+    public CustomPageResponse(List<T> content, int totalPages, long totalElements) {
+        this.content = content;
+        this.totalPages = totalPages;
+        this.totalElements = totalElements;
+    }
+
+    public CustomPageResponse() {
+    }
+
+    public static <E, R> CustomPageResponse<R> of(Page<E> page, Function<E, R> mapper) {
+        return CustomPageResponse.<R>builder()
+                .content(page.getContent().stream()
+                        .map(mapper)
+                        .collect(Collectors.toList()))
+                .totalPages(page.getTotalPages())
+                .totalElements(page.getTotalElements())
+                .build();
+    }
+
+    public static <E> CustomPageResponse<E> from(Page<E> page) {
+        return CustomPageResponse.<E>builder()
+                .content(page.getContent())
+                .totalPages(page.getTotalPages())
+                .totalElements(page.getTotalElements())
+                .build();
+    }
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/MemberController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/MemberController.java
@@ -11,7 +11,6 @@ import spring.fitlinkbe.application.member.MemberFacade;
 import spring.fitlinkbe.application.member.criteria.MemberInfoResult;
 import spring.fitlinkbe.application.member.criteria.MemberSessionResult;
 import spring.fitlinkbe.application.member.criteria.WorkoutScheduleResult;
-import spring.fitlinkbe.domain.common.enums.UserRole;
 import spring.fitlinkbe.domain.common.exception.CustomException;
 import spring.fitlinkbe.domain.common.exception.ErrorCode;
 import spring.fitlinkbe.domain.reservation.Session;
@@ -116,32 +115,15 @@ public class MemberController {
                 .toList());
     }
 
-    @GetMapping("/{memberId}/sessions")
+    @GetMapping("/me/sessions")
     public ApiResultResponse<CustomPageResponse<MemberSessionDto.SessionResponse>> getSessions(
-            @PathVariable Long memberId,
             @Login SecurityUser user,
             @PageableDefault(size = 5) Pageable pageRequest,
             @RequestParam(required = false) Session.Status status
     ) {
-        checkMemberPermission(memberId, user);
-        Page<MemberSessionResult.SessionResponse> result = memberFacade.getSessions(memberId, status, pageRequest);
+        Page<MemberSessionResult.SessionResponse> result = memberFacade.getSessions(user.getMemberId(), status, pageRequest);
 
         return ApiResultResponse.ok(CustomPageResponse.of(result, MemberSessionDto.SessionResponse::from));
-    }
-
-    /**
-     * @param memberId
-     * @param user
-     * @throws CustomException
-     */
-    private void checkMemberPermission(Long memberId, SecurityUser user) {
-        if (user.getUserRole() == UserRole.TRAINER) {
-            return;
-        }
-
-        if (!memberId.equals(user.getMemberId())) {
-            throw new CustomException(ErrorCode.MEMBER_PERMISSION_DENIED, "회원은 자기 자신의 정보만 조회 가능합니다.");
-        }
     }
 
     @InitBinder

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/MemberSessionDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/MemberSessionDto.java
@@ -1,0 +1,14 @@
+package spring.fitlinkbe.interfaces.controller.member.dto;
+
+import spring.fitlinkbe.domain.reservation.Session;
+
+import java.time.LocalDateTime;
+
+public class MemberSessionDto {
+    public record SessionResponse(
+            Long sessionId,
+            Session.Status status,
+            LocalDateTime date
+    ) {
+    }
+}

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/MemberSessionDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/MemberSessionDto.java
@@ -1,14 +1,25 @@
 package spring.fitlinkbe.interfaces.controller.member.dto;
 
+import lombok.Builder;
+import spring.fitlinkbe.application.member.criteria.MemberSessionResult;
 import spring.fitlinkbe.domain.reservation.Session;
 
 import java.time.LocalDateTime;
 
 public class MemberSessionDto {
+
+    @Builder
     public record SessionResponse(
             Long sessionId,
             Session.Status status,
             LocalDateTime date
     ) {
+        public static SessionResponse from(MemberSessionResult.SessionResponse result) {
+            return SessionResponse.builder()
+                    .sessionId(result.sessionId())
+                    .status(result.status())
+                    .date(result.date())
+                    .build();
+        }
     }
 }

--- a/src/main/java/spring/fitlinkbe/support/config/QueryDslConfig.java
+++ b/src/main/java/spring/fitlinkbe/support/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package spring.fitlinkbe.support.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+    private final EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/test/java/spring/fitlinkbe/domain/reservation/ReservationServiceTest.java
+++ b/src/test/java/spring/fitlinkbe/domain/reservation/ReservationServiceTest.java
@@ -148,16 +148,16 @@ class ReservationServiceTest {
         void getSession() {
             //given
             Session session = Session.builder()
-                    .reservationId(1L)
+                    .reservation(Reservation.builder().reservationId(1L).build())
                     .sessionId(1L)
                     .build();
 
-            when(reservationRepository.getSession(session.getReservationId()))
+            when(reservationRepository.getSession(session.getReservation().getReservationId()))
                     .thenReturn(Optional.of(session));
 
             //when
             Session result = reservationService.getSession(
-                    RESERVATION_APPROVED, session.getReservationId());
+                    RESERVATION_APPROVED, session.getReservation().getReservationId());
 
             //then
             assertThat(result.getSessionId()).isEqualTo(1L);

--- a/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
@@ -906,8 +906,8 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
             testDataHandler.createSession(member, trainer, Session.Status.SESSION_WAITING);
             testDataHandler.createSession(member, trainer, Session.Status.SESSION_WAITING);
             testDataHandler.createSession(member, trainer, Session.Status.SESSION_WAITING);
-            testDataHandler.createSession(member, trainer, Session.Status.NO_SHOW);
-            testDataHandler.createSession(member, trainer, Session.Status.NO_SHOW);
+            testDataHandler.createSession(member, trainer, Session.Status.SESSION_NOT_ATTEND);
+            testDataHandler.createSession(member, trainer, Session.Status.SESSION_NOT_ATTEND);
         }
 
     }

--- a/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
@@ -714,9 +714,9 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
     }
 
     @Nested
-    @DisplayName("회원 PT 내역 조회 API 테스트")
+    @DisplayName("특정 회원 PT 내역 조회 API 테스트")
     public class MemberSessionTest {
-        private static final String MEMBER_SESSION_API = "/v1/members/sessions";
+        private static final String MEMBER_SESSION_API = "/v1/members/{memberId}/sessions";
 
         @Test
         @DisplayName("회원 PT 내역 조회 성공 - 전체 조회")
@@ -735,7 +735,7 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
             // 회원이 PT 내역을 조회할 때
             int page = 0;
             int size = 10;
-            String url = MEMBER_SESSION_API + "?page=" + page + "&size=" + size;
+            String url = MEMBER_SESSION_API.replace("{memberId}", member.getMemberId().toString()) + "?page=" + page + "&size=" + size;
             ExtractableResponse<Response> result = get(url, token);
 
             // then
@@ -773,7 +773,7 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
             // 회원이 PT 내역을 조회할 때 상태별로 조회할 때
             int page = 0;
             int size = 10;
-            String url = MEMBER_SESSION_API + "?page=" + page + "&size=" + size + "&status=SESSION_WAITING";
+            String url = MEMBER_SESSION_API.replace("{memberId}", member.getMemberId().toString()) + "?page=" + page + "&size=" + size + "&status=SESSION_WAITING";
             ExtractableResponse<Response> result = get(url, token);
 
             // then
@@ -811,7 +811,7 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
             // 회원이 PT 내역을 조회할 때 페이징 조회할 때
             int page = 0;
             int size = 3;
-            String url = MEMBER_SESSION_API + "?page=" + page + "&size=" + size;
+            String url = MEMBER_SESSION_API.replace("{memberId}", member.getMemberId().toString()) + "?page=" + page + "&size=" + size;
             ExtractableResponse<Response> result = get(url, token);
 
             // then
@@ -847,7 +847,7 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
 
             // when
             // 회원이 PT 내역을 조회할 때 페이징 기본값으로 조회할 때
-            ExtractableResponse<Response> result = get(MEMBER_SESSION_API, token);
+            ExtractableResponse<Response> result = get(MEMBER_SESSION_API.replace("{memberId}", member.getMemberId().toString()), token);
 
             // then
             // PT 내역을 받는다
@@ -879,7 +879,7 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
             // 회원이 PT 내역을 조회할 때 세션 정보가 없을 때
             int page = 0;
             int size = 10;
-            String url = MEMBER_SESSION_API + "?page=" + page + "&size=" + size;
+            String url = MEMBER_SESSION_API.replace("{memberId}", member.getMemberId().toString()) + "?page=" + page + "&size=" + size;
             ExtractableResponse<Response> result = get(url, token);
 
             // then

--- a/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
@@ -3,8 +3,6 @@ package spring.fitlinkbe.integration;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Transient;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -716,9 +714,9 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
     }
 
     @Nested
-    @DisplayName("특정 회원 PT 내역 조회 API 테스트")
+    @DisplayName("나의 PT 내역 조회 API 테스트")
     public class MemberSessionTest {
-        private static final String MEMBER_SESSION_API = "/v1/members/{memberId}/sessions";
+        private static final String MEMBER_SESSION_API = "/v1/members/me/sessions";
 
         @Test
         @DisplayName("회원 PT 내역 조회 성공 - 전체 조회")
@@ -737,7 +735,7 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
             // 회원이 PT 내역을 조회할 때
             int page = 0;
             int size = 10;
-            String url = MEMBER_SESSION_API.replace("{memberId}", member.getMemberId().toString()) + "?page=" + page + "&size=" + size;
+            String url = MEMBER_SESSION_API + "?page=" + page + "&size=" + size;
             ExtractableResponse<Response> result = get(url, token);
 
             // then
@@ -775,7 +773,7 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
             // 회원이 PT 내역을 조회할 때 상태별로 조회할 때
             int page = 0;
             int size = 10;
-            String url = MEMBER_SESSION_API.replace("{memberId}", member.getMemberId().toString()) + "?page=" + page + "&size=" + size + "&status=SESSION_WAITING";
+            String url = MEMBER_SESSION_API + "?page=" + page + "&size=" + size + "&status=SESSION_WAITING";
             ExtractableResponse<Response> result = get(url, token);
 
             // then
@@ -813,7 +811,7 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
             // 회원이 PT 내역을 조회할 때 페이징 조회할 때
             int page = 0;
             int size = 3;
-            String url = MEMBER_SESSION_API.replace("{memberId}", member.getMemberId().toString()) + "?page=" + page + "&size=" + size;
+            String url = MEMBER_SESSION_API + "?page=" + page + "&size=" + size;
             ExtractableResponse<Response> result = get(url, token);
 
             // then
@@ -849,7 +847,7 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
 
             // when
             // 회원이 PT 내역을 조회할 때 페이징 기본값으로 조회할 때
-            ExtractableResponse<Response> result = get(MEMBER_SESSION_API.replace("{memberId}", member.getMemberId().toString()), token);
+            ExtractableResponse<Response> result = get(MEMBER_SESSION_API, token);
 
             // then
             // PT 내역을 받는다
@@ -881,7 +879,7 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
             // 회원이 PT 내역을 조회할 때 세션 정보가 없을 때
             int page = 0;
             int size = 10;
-            String url = MEMBER_SESSION_API.replace("{memberId}", member.getMemberId().toString()) + "?page=" + page + "&size=" + size;
+            String url = MEMBER_SESSION_API + "?page=" + page + "&size=" + size;
             ExtractableResponse<Response> result = get(url, token);
 
             // then

--- a/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
@@ -3,6 +3,8 @@ package spring.fitlinkbe.integration;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Transient;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/spring/fitlinkbe/integration/ReservationIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/ReservationIntegrationTest.java
@@ -422,7 +422,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             Reservation savedReservation = reservationRepository.reserveSession(reservation).orElseThrow();
 
             Session session = Session.builder()
-                    .reservationId(savedReservation.getReservationId())
+                    .reservation(savedReservation)
                     .build();
 
             reservationRepository.createSession(session);
@@ -685,7 +685,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             Reservation savedReservation = reservationRepository.reserveSession(reservation).orElseThrow();
 
             Session session = Session.builder()
-                    .reservationId(savedReservation.getReservationId())
+                    .reservation(savedReservation)
                     .build();
 
             reservationRepository.createSession(session);

--- a/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
+++ b/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
@@ -13,12 +13,16 @@ import spring.fitlinkbe.domain.member.Member;
 import spring.fitlinkbe.domain.member.MemberRepository;
 import spring.fitlinkbe.domain.member.WorkoutSchedule;
 import spring.fitlinkbe.domain.member.WorkoutScheduleRepository;
+import spring.fitlinkbe.domain.reservation.Reservation;
+import spring.fitlinkbe.domain.reservation.ReservationRepository;
+import spring.fitlinkbe.domain.reservation.Session;
 import spring.fitlinkbe.domain.trainer.Trainer;
 import spring.fitlinkbe.domain.trainer.TrainerRepository;
 import spring.fitlinkbe.support.security.AuthTokenProvider;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
@@ -42,10 +46,12 @@ public class TestDataHandler {
 
     private final WorkoutScheduleRepository workoutScheduleRepository;
 
+    private final ReservationRepository reservationRepository;
+
     public TestDataHandler(
             PersonalDetailRepository personalDetailRepository,
             MemberRepository memberRepository, TrainerRepository trainerRepository,
-            SessionInfoRepository sessionInfoRepository, AuthTokenProvider authTokenProvider, ConnectingInfoRepository connectingInfoRepository, WorkoutScheduleRepository workoutScheduleRepository) {
+            SessionInfoRepository sessionInfoRepository, AuthTokenProvider authTokenProvider, ConnectingInfoRepository connectingInfoRepository, WorkoutScheduleRepository workoutScheduleRepository, ReservationRepository reservationRepository) {
         this.personalDetailRepository = personalDetailRepository;
         this.memberRepository = memberRepository;
         this.trainerRepository = trainerRepository;
@@ -53,6 +59,7 @@ public class TestDataHandler {
         this.authTokenProvider = authTokenProvider;
         this.connectingInfoRepository = connectingInfoRepository;
         this.workoutScheduleRepository = workoutScheduleRepository;
+        this.reservationRepository = reservationRepository;
     }
 
     public Member createMember() {
@@ -236,5 +243,21 @@ public class TestDataHandler {
         return workoutScheduleRepository.saveAll(
                 List.of(workoutSchedule1, workoutSchedule2, workoutSchedule3, workoutSchedule4, workoutSchedule5)
         );
+    }
+
+    public Session createSession(Member member, Trainer trainer, Session.Status status) {
+        Reservation reservation = Reservation.builder()
+                .member(member)
+                .trainer(trainer)
+                .status(Reservation.Status.RESERVATION_APPROVED)
+                .reservationDate(LocalDateTime.now())
+                .build();
+
+        Session session = Session.builder()
+                .reservationId(reservation.getReservationId())
+                .status(status)
+                .isCompleted(true)
+                .build();
+        return reservationRepository.saveSession(session).orElseThrow();
     }
 }

--- a/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
+++ b/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
@@ -252,15 +252,15 @@ public class TestDataHandler {
                 .member(member)
                 .trainer(trainer)
                 .status(Reservation.Status.RESERVATION_APPROVED)
-                .reservationDate(LocalDateTime.now())
+                .reservationDates(List.of(LocalDateTime.now()))
                 .build();
-        Reservation saved = reservationRepository.saveReservation(reservation).orElseThrow();
+        Reservation saved = reservationRepository.reserveSession(reservation).orElseThrow();
 
         Session session = Session.builder()
                 .reservation(saved)
                 .status(status)
                 .isCompleted(true)
                 .build();
-        return reservationRepository.saveSession(session).orElseThrow();
+        return reservationRepository.createSession(session).orElseThrow();
     }
 }

--- a/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
+++ b/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
@@ -51,7 +51,9 @@ public class TestDataHandler {
     public TestDataHandler(
             PersonalDetailRepository personalDetailRepository,
             MemberRepository memberRepository, TrainerRepository trainerRepository,
-            SessionInfoRepository sessionInfoRepository, AuthTokenProvider authTokenProvider, ConnectingInfoRepository connectingInfoRepository, WorkoutScheduleRepository workoutScheduleRepository, ReservationRepository reservationRepository) {
+            SessionInfoRepository sessionInfoRepository, AuthTokenProvider authTokenProvider,
+            ConnectingInfoRepository connectingInfoRepository, WorkoutScheduleRepository workoutScheduleRepository,
+            ReservationRepository reservationRepository) {
         this.personalDetailRepository = personalDetailRepository;
         this.memberRepository = memberRepository;
         this.trainerRepository = trainerRepository;
@@ -252,9 +254,10 @@ public class TestDataHandler {
                 .status(Reservation.Status.RESERVATION_APPROVED)
                 .reservationDate(LocalDateTime.now())
                 .build();
+        Reservation saved = reservationRepository.saveReservation(reservation).orElseThrow();
 
         Session session = Session.builder()
-                .reservationId(reservation.getReservationId())
+                .reservation(saved)
                 .status(status)
                 .isCompleted(true)
                 .build();


### PR DESCRIPTION
### 작업 내용
- GET `/v1/members/me/sessions` API 작업했습니다.

### DB 수정사항
- session 테이블 status enum이 기존에 @Enumerated 어노테이션이 빠져있어서 추가했습니다 (DDL에 이미 enum 으로 되어있으면 상관 x)
### 추가 사항
- Session Domain에서 reservationId를 Reservation 객체로 바꿨습니다.
- toDomain에서 초기화 되어있는 객체만 toDomain 호출되도록 수정했습니다. (밑에서 이야기하는 문제 막을 더 좋은 방식 있으면 이야기 해주시면 좋을 것 같아요)
  - 기존 방식에서는객체들을 타고 들어가며 모두 toDomain() 호출하면 lazy loading되면서 쿼리가 너무 많이 나갈 것 같습니다.
  - 예약 조회시에도 fetch join이 안걸려있어서 다 lazyloading 처리되는 부분들 fetch join 걸어놨는데 이부분 문제 없을지 확인해주시면 좋을 것 같습니다.