### PR TITLE
[FLIZ-119] PT 희망 시간 내 정보 조회 API 응답으로 변경 작업

### DIFF
--- a/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
@@ -71,7 +71,9 @@ public class MemberFacade {
         Member me = memberService.getMember(memberId);
         Trainer trainer = connectingInfo.map(ConnectingInfo::getTrainer).orElse(null);
 
-        return MemberInfoResult.Response.of(me, trainer, sessionInfo.orElse(null));
+        List<WorkoutSchedule> workoutSchedules = memberService.getWorkoutSchedules(memberId);
+
+        return MemberInfoResult.Response.of(me, trainer, sessionInfo.orElse(null), workoutSchedules);
     }
 
     @Transactional
@@ -91,13 +93,6 @@ public class MemberFacade {
     public MemberInfoResult.DetailResponse getMyDetail(Long memberId) {
         Member me = memberService.getMember(memberId);
         return MemberInfoResult.DetailResponse.from(me);
-    }
-
-    public List<WorkoutScheduleResult.Response> getWorkoutSchedule(Long memberId) {
-        List<WorkoutSchedule> workoutSchedules = memberService.getWorkoutSchedules(memberId);
-
-        return workoutSchedules.stream().map(WorkoutScheduleResult.Response::from)
-                .sorted(Comparator.comparing(WorkoutScheduleResult.Response::dayOfWeek)).toList();
     }
 
     public List<WorkoutScheduleResult.Response> updateWorkoutSchedule(

--- a/src/main/java/spring/fitlinkbe/application/member/criteria/MemberInfoResult.java
+++ b/src/main/java/spring/fitlinkbe/application/member/criteria/MemberInfoResult.java
@@ -3,9 +3,11 @@ package spring.fitlinkbe.application.member.criteria;
 import lombok.Builder;
 import spring.fitlinkbe.domain.common.model.SessionInfo;
 import spring.fitlinkbe.domain.member.Member;
+import spring.fitlinkbe.domain.member.WorkoutSchedule;
 import spring.fitlinkbe.domain.trainer.Trainer;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public class MemberInfoResult {
 
@@ -16,9 +18,10 @@ public class MemberInfoResult {
             Long trainerId,
             String trainerName,
             String profilePictureUrl,
-            SessionInfoResponse sessionInfo
+            SessionInfoResponse sessionInfo,
+            List<WorkoutScheduleResult.Response> workoutSchedules
     ) {
-        public static Response of(Member me, Trainer trainer, SessionInfo sessionInfo) {
+        public static Response of(Member me, Trainer trainer, SessionInfo sessionInfo, List<WorkoutSchedule> workoutSchedules) {
             return Response.builder()
                     .memberId(me.getMemberId())
                     .name(me.getName())
@@ -26,6 +29,7 @@ public class MemberInfoResult {
                     .trainerName(trainer != null ? trainer.getName() : null)
                     .profilePictureUrl(me.getProfilePictureUrl())
                     .sessionInfo(sessionInfo != null ? SessionInfoResponse.from(sessionInfo) : null)
+                    .workoutSchedules(workoutSchedules.stream().map(WorkoutScheduleResult.Response::from).toList())
                     .build();
         }
     }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/MemberController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/MemberController.java
@@ -106,15 +106,6 @@ public class MemberController {
                 .count() == workoutSchedule.size();
     }
 
-    @GetMapping("/me/workout-schedule")
-    public ApiResultResponse<List<WorkoutScheduleDto.Response>> getWorkoutSchedule(@Login SecurityUser user) {
-        List<WorkoutScheduleResult.Response> result = memberFacade.getWorkoutSchedule(user.getMemberId());
-
-        return ApiResultResponse.ok(result.stream()
-                .map(WorkoutScheduleDto.Response::from)
-                .toList());
-    }
-
     @GetMapping("/me/sessions")
     public ApiResultResponse<CustomPageResponse<MemberSessionDto.SessionResponse>> getSessions(
             @Login SecurityUser user,

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/MemberController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/MemberController.java
@@ -74,7 +74,7 @@ public class MemberController {
         return ApiResultResponse.ok(MemberInfoDto.DetailResponse.from(result));
     }
 
-    @PutMapping("/workout-schedule")
+    @PutMapping("/me/workout-schedule")
     public ApiResultResponse<Object> updateWorkoutSchedule(
             @Login SecurityUser user,
             @RequestBody @Valid List<WorkoutScheduleDto.Request> requestBody
@@ -106,7 +106,7 @@ public class MemberController {
                 .count() == workoutSchedule.size();
     }
 
-    @GetMapping("/workout-schedule")
+    @GetMapping("/me/workout-schedule")
     public ApiResultResponse<List<WorkoutScheduleDto.Response>> getWorkoutSchedule(@Login SecurityUser user) {
         List<WorkoutScheduleResult.Response> result = memberFacade.getWorkoutSchedule(user.getMemberId());
 

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/MemberInfoDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/MemberInfoDto.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import spring.fitlinkbe.application.member.criteria.MemberInfoResult;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public class MemberInfoDto {
 
@@ -16,7 +17,8 @@ public class MemberInfoDto {
             Long trainerId,
             String trainerName,
             String profilePictureUrl,
-            SessionInfoResponse sessionInfo
+            SessionInfoResponse sessionInfo,
+            List<WorkoutScheduleDto.Response> workoutSchedules
     ) {
         public static Response from(MemberInfoResult.Response result) {
             return Response.builder()
@@ -26,6 +28,7 @@ public class MemberInfoDto {
                     .trainerName(result.trainerName())
                     .profilePictureUrl(result.profilePictureUrl())
                     .sessionInfo(result.sessionInfo() != null ? SessionInfoResponse.from(result.sessionInfo()) : null)
+                    .workoutSchedules(result.workoutSchedules().stream().map(WorkoutScheduleDto.Response::from).toList())
                     .build();
         }
     }

--- a/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
@@ -470,7 +470,7 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
     @Nested
     @DisplayName("회원 PT 희망 시간 수정 API 테스트")
     public class MemberPtTimeUpdateTest {
-        private static final String MEMBER_PT_TIME_UPDATE_API = "/v1/members/workout-schedule";
+        private static final String MEMBER_PT_TIME_UPDATE_API = "/v1/members/me/workout-schedule";
 
         @Test
         @DisplayName("회원 PT 희망 시간 수정 성공 - PT 희망 시간이 없을 때")

--- a/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
@@ -253,12 +253,13 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
         @DisplayName("멤버 내 정보 조회 성공")
         public void memberInfoSuccess() throws Exception {
             // given
-            // NORMAL 상태의 멤버, 트레이너, 세션 정보가 있을 때
+            // NORMAL 상태의 멤버, 트레이너, 세션 정보, PT 희망 시간 정보가 있을 때
             Member member = testDataHandler.createMember();
             Trainer trainer = testDataHandler.createTrainer("AB1423");
             SessionInfo sessionInfo = testDataHandler.createSessionInfo(member, trainer);
             String token = testDataHandler.createTokenFromMember(member);
             testDataHandler.connectMemberAndTrainer(member, trainer);
+            List<WorkoutSchedule> workoutSchedules = testDataHandler.createWorkoutSchedules(member);
 
             // when
             // 멤버가 자신의 정보를 조회한다면
@@ -283,6 +284,17 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
                 softly.assertThat(data.sessionInfo().sessionInfoId()).isEqualTo(sessionInfo.getSessionInfoId());
                 softly.assertThat(data.sessionInfo().remainingCount()).isEqualTo(sessionInfo.getRemainingCount());
                 softly.assertThat(data.sessionInfo().totalCount()).isEqualTo(sessionInfo.getTotalCount());
+
+                softly.assertThat(data.workoutSchedules().size()).isEqualTo(workoutSchedules.size());
+                for (WorkoutScheduleDto.Response responseDto : data.workoutSchedules()) {
+                    WorkoutSchedule workoutSchedule = workoutSchedules.stream().filter(ws -> ws.getWorkoutScheduleId()
+                            .equals(responseDto.workoutScheduleId())).findFirst().orElseThrow();
+
+                    softly.assertThat(responseDto.workoutScheduleId()).isEqualTo(workoutSchedule.getWorkoutScheduleId());
+                    softly.assertThat(responseDto.dayOfWeek()).isEqualTo(workoutSchedule.getDayOfWeek());
+                    softly.assertThat(responseDto.preferenceTimes())
+                            .containsExactlyInAnyOrderElementsOf(workoutSchedule.getPreferenceTimes());
+                }
             });
         }
     }
@@ -393,76 +405,6 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
                 softly.assertThat(data.name()).isEqualTo(member.getName());
                 softly.assertThat(data.birthDate()).isEqualTo(member.getBirthDate());
                 softly.assertThat(data.phoneNumber()).isEqualTo(member.getPhoneNumber());
-            });
-        }
-    }
-
-    @Nested
-    @DisplayName("회원 PT 희망 시간 조회 API 테스트")
-    public class MemberPtTimeTest {
-        private static final String MEMBER_PT_TIME_API = "/v1/members/workout-schedule";
-
-        @Test
-        @DisplayName("회원 PT 희망 시간 조회 성공")
-        public void memberPtTimeSuccess() throws Exception {
-            // given
-            // 회원, 희망 시간 정보가 있을 때
-            Member member = testDataHandler.createMember();
-            String token = testDataHandler.createTokenFromMember(member);
-            List<WorkoutSchedule> workoutSchedules = testDataHandler.createWorkoutSchedules(member);
-
-            // when
-            // 회원이 PT 희망 시간을 조회한다면
-            ExtractableResponse<Response> result = get(MEMBER_PT_TIME_API, token);
-
-            // then
-            // PT 희망 시간을 응답한다
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result.statusCode()).isEqualTo(200);
-                ApiResultResponse<List<WorkoutScheduleDto.Response>> response = readValue(result.body().jsonPath().prettify(), new TypeReference<>() {
-                });
-
-                List<WorkoutScheduleDto.Response> data = response.data();
-                softly.assertThat(response).isNotNull();
-                softly.assertThat(response.success()).isTrue();
-                softly.assertThat(response.status()).isEqualTo(200);
-
-                softly.assertThat(data.size()).isEqualTo(workoutSchedules.size());
-                for (WorkoutScheduleDto.Response responseDto : data) {
-                    WorkoutSchedule workoutSchedule = workoutSchedules.stream().filter(ws -> ws.getWorkoutScheduleId()
-                            .equals(responseDto.workoutScheduleId())).findFirst().orElseThrow();
-
-                    softly.assertThat(responseDto.workoutScheduleId()).isEqualTo(workoutSchedule.getWorkoutScheduleId());
-                    softly.assertThat(responseDto.dayOfWeek()).isEqualTo(workoutSchedule.getDayOfWeek());
-                    softly.assertThat(responseDto.preferenceTimes())
-                            .containsExactlyInAnyOrderElementsOf(workoutSchedule.getPreferenceTimes());
-                }
-            });
-        }
-
-        @Test
-        @DisplayName("회원 PT 희망 시간 조회 성공 - PT 희망 시간이 없을 때")
-        public void memberPtTimeSuccessByEmpty() throws Exception {
-            // given
-            // 회원이 있고, PT 희망 시간이 없을 때
-            Member member = testDataHandler.createMember();
-            String token = testDataHandler.createTokenFromMember(member);
-
-            // when
-            // 회원이 PT 희망 시간을 조회한다면
-            ExtractableResponse<Response> result = get(MEMBER_PT_TIME_API, token);
-
-            // then
-            // PT 희망 시간이 없다는 응답을 받는다
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result.statusCode()).isEqualTo(200);
-                ApiResultResponse<List<WorkoutScheduleDto.Response>> response = readValue(result.body().jsonPath().prettify(), new TypeReference<>() {
-                });
-
-                softly.assertThat(response).isNotNull();
-                softly.assertThat(response.success()).isTrue();
-                softly.assertThat(response.status()).isEqualTo(200);
-                softly.assertThat(response.data()).isEmpty();
             });
         }
     }


### PR DESCRIPTION
### 작업 내용
- 내 정보 조회 api 응답에서 PT 희망시간 정보 주도록 수정했습니다
- 기존에 PT 희망 시간 조회 api 삭제했습니다
- PT 희망 시간 수정 api url 에 me 추가했습니다
  - 서버 리소스를 정확하게 url이 명시하도록 하는게 좋을 것 같아서 수정했습니다.
  - 다른 내 정보 관련 api에는 me가 들어가 있는데 이것만 빠져있어서 수정했습니다
 