### PR TITLE
[FLIZ-130] 특정 멤버 PT 내역 조회, 세션 수 수정 API

### DIFF
--- a/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
@@ -24,7 +24,6 @@ import spring.fitlinkbe.domain.trainer.TrainerService;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -60,15 +59,15 @@ public class MemberFacade {
 
     @Transactional(readOnly = true)
     public MemberInfoResult.Response getMyInfo(Long memberId) {
-        ConnectingInfo connectingInfo = memberService.findConnectingInfo(memberId).orElse(null);
-        Optional<SessionInfo> sessionInfo = connectingInfo != null ? memberService
-                .findSessionInfo(connectingInfo.getTrainerId(), memberId) : Optional.empty();
+        ConnectingInfo connectingInfo = memberService.findConnectingInfo(memberId);
+        SessionInfo sessionInfo = connectingInfo != null ? memberService
+                .findSessionInfo(connectingInfo.getTrainerId(), memberId) : null;
 
         Member me = memberService.getMember(memberId);
 
         List<WorkoutSchedule> workoutSchedules = memberService.getWorkoutSchedules(memberId);
 
-        return MemberInfoResult.Response.of(me, connectingInfo, sessionInfo.orElse(null), workoutSchedules);
+        return MemberInfoResult.Response.of(me, connectingInfo, sessionInfo, workoutSchedules);
     }
 
     @Transactional
@@ -169,7 +168,7 @@ public class MemberFacade {
         memberService.checkConnected(trainerId, memberId);
         SessionInfo sessionInfo = memberService.getSessionInfo(sessionInfoId);
 
-        sessionInfo.update(request.totalCount(), request.remainingCount());
+        request.patch(sessionInfo);
         memberService.saveSessionInfo(sessionInfo);
 
         return SessionInfoCriteria.Response.from(sessionInfo);

--- a/src/main/java/spring/fitlinkbe/application/member/criteria/MemberInfoResult.java
+++ b/src/main/java/spring/fitlinkbe/application/member/criteria/MemberInfoResult.java
@@ -1,6 +1,7 @@
 package spring.fitlinkbe.application.member.criteria;
 
 import lombok.Builder;
+import spring.fitlinkbe.domain.common.model.ConnectingInfo;
 import spring.fitlinkbe.domain.common.model.SessionInfo;
 import spring.fitlinkbe.domain.member.Member;
 import spring.fitlinkbe.domain.member.WorkoutSchedule;
@@ -17,16 +18,20 @@ public class MemberInfoResult {
             String name,
             Long trainerId,
             String trainerName,
+            ConnectingInfo.ConnectingStatus connectingStatus,
             String profilePictureUrl,
             SessionInfoResponse sessionInfo,
             List<WorkoutScheduleResult.Response> workoutSchedules
     ) {
-        public static Response of(Member me, Trainer trainer, SessionInfo sessionInfo, List<WorkoutSchedule> workoutSchedules) {
+        public static Response of(Member me, ConnectingInfo connectingInfo, SessionInfo sessionInfo, List<WorkoutSchedule> workoutSchedules) {
+            Trainer trainer = connectingInfo != null ? connectingInfo.getTrainer() : null;
+
             return Response.builder()
                     .memberId(me.getMemberId())
                     .name(me.getName())
                     .trainerId(trainer != null ? trainer.getTrainerId() : null)
                     .trainerName(trainer != null ? trainer.getName() : null)
+                    .connectingStatus(connectingInfo != null ? connectingInfo.getStatus() : null)
                     .profilePictureUrl(me.getProfilePictureUrl())
                     .sessionInfo(sessionInfo != null ? SessionInfoResponse.from(sessionInfo) : null)
                     .workoutSchedules(workoutSchedules.stream().map(WorkoutScheduleResult.Response::from).toList())

--- a/src/main/java/spring/fitlinkbe/application/member/criteria/SessionInfoCriteria.java
+++ b/src/main/java/spring/fitlinkbe/application/member/criteria/SessionInfoCriteria.java
@@ -11,6 +11,14 @@ public class SessionInfoCriteria {
 
             Integer totalCount
     ) {
+        public void patch(SessionInfo sessionInfo) {
+            if (remainingCount != null) {
+                sessionInfo.updateRemainingCount(remainingCount);
+            }
+            if (totalCount != null) {
+                sessionInfo.updateTotalCount(totalCount);
+            }
+        }
     }
 
     public record Response(

--- a/src/main/java/spring/fitlinkbe/application/member/criteria/SessionInfoCriteria.java
+++ b/src/main/java/spring/fitlinkbe/application/member/criteria/SessionInfoCriteria.java
@@ -1,0 +1,29 @@
+package spring.fitlinkbe.application.member.criteria;
+
+import lombok.Builder;
+import spring.fitlinkbe.domain.common.model.SessionInfo;
+
+public class SessionInfoCriteria {
+
+    @Builder
+    public record UpdateRequest(
+            Integer remainingCount,
+
+            Integer totalCount
+    ) {
+    }
+
+    public record Response(
+            Long sessionInfoId,
+            Integer remainingCount,
+            Integer totalCount
+    ) {
+        public static Response from(SessionInfo sessionInfo) {
+            return new Response(
+                    sessionInfo.getSessionInfoId(),
+                    sessionInfo.getRemainingCount(),
+                    sessionInfo.getTotalCount()
+            );
+        }
+    }
+}

--- a/src/main/java/spring/fitlinkbe/domain/common/ConnectingInfoRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/ConnectingInfoRepository.java
@@ -17,4 +17,11 @@ public interface ConnectingInfoRepository {
      */
     Optional<ConnectingInfo> getConnectedInfo(Long memberId);
 
+    /**
+     * 해당 트레이너와 회원의 연결 정보를 가져온다.
+     * @param trainerId
+     * @param memberId
+     * @return
+     */
+    Optional<ConnectingInfo> findConnectingInfo(Long trainerId, Long memberId);
 }

--- a/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
@@ -57,6 +57,8 @@ public enum ErrorCode {
     INVALID_PHONE_NUMBER_FORMAT("유효하지 않은 전화번호 형식입니다.", 400),
     PERSONAL_DETAIL_NOT_FOUND("Personal Detail 정보가 존재하지 않습니다.", 404),
     CONNECTING_INFO_NOT_FOUND("Connecting Info 정보가 존재하지 않습니다.", 404),
+
+    INVALID_PARAMETER("유효하지 않은 파라미터입니다.", 400),
     ;
 
     private final String msg;

--- a/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
@@ -14,7 +14,7 @@ public enum ErrorCode {
     MEMBER_DETAIL_NOT_FOUND("멤버 상세 정보를 찾지 못하였습니다", 404),
     MEMBER_NOT_FOUND("멤버 정보를 찾지 못하였습니다.", 404),
     MEMBER_NOT_CONNECTED_TRAINER("연결된 트레이너가 존재하지 않습니다.", 400),
-    DISCONNECT_AVAILABLE_AFTER_ACCEPTED("트래이너 연동 수락 이후에만 연결을 해제할 수 있습니다.", 409),
+    DISCONNECT_AVAILABLE_AFTER_ACCEPTED("트래이너 연동 요청 이후에만 연결을 해제할 수 있습니다.", 409),
 
     CONNECT_AVAILABLE_AFTER_DISCONNECTED("이미 연결 요청중 또는 연결된 트레이너가 존재합니다.", 409),
 

--- a/src/main/java/spring/fitlinkbe/domain/common/model/ConnectingInfo.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/model/ConnectingInfo.java
@@ -36,6 +36,10 @@ public class ConnectingInfo {
         this.status = ConnectingStatus.DISCONNECTED;
     }
 
+    public Boolean isConnected() {
+        return this.status == ConnectingStatus.CONNECTED;
+    }
+
     public enum ConnectingStatus {
         REQUESTED, CONNECTED, REJECTED, DISCONNECTED
     }

--- a/src/main/java/spring/fitlinkbe/domain/common/model/ConnectingInfo.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/model/ConnectingInfo.java
@@ -40,6 +40,10 @@ public class ConnectingInfo {
         return this.status == ConnectingStatus.CONNECTED;
     }
 
+    public Long getTrainerId() {
+        return this.trainer.getTrainerId();
+    }
+
     public enum ConnectingStatus {
         REQUESTED, CONNECTED, REJECTED, DISCONNECTED
     }

--- a/src/main/java/spring/fitlinkbe/domain/common/model/SessionInfo.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/model/SessionInfo.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import spring.fitlinkbe.domain.common.exception.CustomException;
+import spring.fitlinkbe.domain.common.exception.ErrorCode;
 import spring.fitlinkbe.domain.member.Member;
 import spring.fitlinkbe.domain.trainer.Trainer;
 
@@ -21,14 +23,28 @@ public class SessionInfo {
     private int remainingCount;
 
     /**
-     * 세션 정보 업데이트, totalCount 와 remainingCount 가 0 이상이면서 null 이 아닌 경우에만 업데이트
+     * 남은 PT 횟수 업데이트
+     *
+     * @param count 업데이트 할 횟수
+     * @throws spring.fitlinkbe.domain.common.exception.CustomException count 가 0보다 작을 경우
      */
-    public void update(Integer totalCount, Integer remainingCount) {
-        if (totalCount != null && totalCount >= 0) {
-            this.totalCount = totalCount;
+    public void updateRemainingCount(int count) {
+        if (count < 0) {
+            throw new CustomException(ErrorCode.INVALID_PARAMETER, "남은 횟수는 0보다 작을 수 없습니다. [count: %d]".formatted(count));
         }
-        if (remainingCount != null && remainingCount >= 0) {
-            this.remainingCount = remainingCount;
+        remainingCount = count;
+    }
+
+    /**
+     * 총 PT 횟수 업데이트 </br>
+     *
+     * @param count 업데이트 할 횟수
+     * @throws spring.fitlinkbe.domain.common.exception.CustomException count 가 0보다 작을 경우
+     */
+    public void updateTotalCount(int count) {
+        if (count < 0) {
+            throw new CustomException(ErrorCode.INVALID_PARAMETER, "총 횟수는 0보다 작을 수 없습니다. [count: %d]".formatted(count));
         }
+        totalCount = count;
     }
 }

--- a/src/main/java/spring/fitlinkbe/domain/common/model/SessionInfo.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/model/SessionInfo.java
@@ -19,4 +19,16 @@ public class SessionInfo {
     private Trainer trainer;
     private int totalCount;
     private int remainingCount;
+
+    /**
+     * 세션 정보 업데이트, totalCount 와 remainingCount 가 0 이상이면서 null 이 아닌 경우에만 업데이트
+     */
+    public void update(Integer totalCount, Integer remainingCount) {
+        if (totalCount != null && totalCount >= 0) {
+            this.totalCount = totalCount;
+        }
+        if (remainingCount != null && remainingCount >= 0) {
+            this.remainingCount = remainingCount;
+        }
+    }
 }

--- a/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
+++ b/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
@@ -116,6 +116,11 @@ public class MemberService {
                 .orElseThrow(() -> new CustomException(ErrorCode.SESSION_NOT_FOUND));
     }
 
+    public SessionInfo getSessionInfo(Long sessionInfoId) {
+        return sessionInfoRepository.getSessionInfo(sessionInfoId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SESSION_NOT_FOUND));
+    }
+
     public void savePersonalDetail(PersonalDetail personalDetail) {
         personalDetailRepository.savePersonalDetail(personalDetail);
     }
@@ -132,13 +137,18 @@ public class MemberService {
     }
 
     /**
-     * 해당 트레이너와 회원의 연결 정보 조회
+     * 멤버와 트레이너가 연결되어 있는지 확인
      *
-     * @param trainerId
-     * @param memberId
-     * @return
+     * @throws CustomException 연결되어 있지 않을 경우
      */
-    public Optional<ConnectingInfo> findConnectingInfo(Long trainerId, Long memberId) {
-        return connectingInfoRepository.findConnectingInfo(trainerId, memberId);
+    public void checkConnected(Long trainerId, Long memberId) {
+        Optional<ConnectingInfo> connectingInfo = connectingInfoRepository.findConnectingInfo(trainerId, memberId);
+        if (connectingInfo.isEmpty() || !connectingInfo.get().isConnected()) {
+            throw new CustomException(ErrorCode.MEMBER_NOT_CONNECTED_TRAINER, "트레이너가 멤버와 연결되어 있지 않습니다.");
+        }
+    }
+
+    public void saveSessionInfo(SessionInfo sessionInfo) {
+        sessionInfoRepository.saveSessionInfo(sessionInfo);
     }
 }

--- a/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
+++ b/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
@@ -99,17 +99,22 @@ public class MemberService {
     /**
      * 해당 회원의 트레이너 연결 정보 조회 </br>
      * 요청 상태거나 연결된 상태만 조회
+     *
+     * @return 연결된 트레이너가 없을 경우 null 반환
      */
-    public Optional<ConnectingInfo> findConnectingInfo(Long memberId) {
-        return connectingInfoRepository.getConnectedInfo(memberId);
+    public ConnectingInfo findConnectingInfo(Long memberId) {
+        return connectingInfoRepository.getConnectedInfo(memberId).orElse(null);
     }
 
     public void saveConnectingInfo(ConnectingInfo connectingInfo) {
         connectingInfoRepository.save(connectingInfo);
     }
 
-    public Optional<SessionInfo> findSessionInfo(Long trainerId, Long memberId) {
-        return sessionInfoRepository.getSessionInfo(trainerId, memberId);
+    /**
+     * @return 연결된 트레이너가 없을 경우 null 반환
+     */
+    public SessionInfo findSessionInfo(Long trainerId, Long memberId) {
+        return sessionInfoRepository.getSessionInfo(trainerId, memberId).orElse(null);
     }
 
     public SessionInfo getSessionInfo(Long trainerId, Long memberId) {

--- a/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
+++ b/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
@@ -130,4 +130,15 @@ public class MemberService {
             throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
         }
     }
+
+    /**
+     * 해당 트레이너와 회원의 연결 정보 조회
+     *
+     * @param trainerId
+     * @param memberId
+     * @return
+     */
+    public Optional<ConnectingInfo> findConnectingInfo(Long trainerId, Long memberId) {
+        return connectingInfoRepository.findConnectingInfo(trainerId, memberId);
+    }
 }

--- a/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
+++ b/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
@@ -90,16 +90,17 @@ public class MemberService {
     /**
      * 해당 회원의 트레이너 연결 정보 조회 </br>
      * 요청 상태거나 연결된 상태만 조회
-     *
-     * @param memberId
-     * @return
      */
-    public ConnectingInfo getConnectedInfo(Long memberId) {
+    public ConnectingInfo getConnectingInfo(Long memberId) {
         return connectingInfoRepository.getConnectedInfo(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_CONNECTED_TRAINER));
     }
 
-    public Optional<ConnectingInfo> findConnectedInfo(Long memberId) {
+    /**
+     * 해당 회원의 트레이너 연결 정보 조회 </br>
+     * 요청 상태거나 연결된 상태만 조회
+     */
+    public Optional<ConnectingInfo> findConnectingInfo(Long memberId) {
         return connectingInfoRepository.getConnectedInfo(memberId);
     }
 
@@ -107,8 +108,8 @@ public class MemberService {
         connectingInfoRepository.save(connectingInfo);
     }
 
-    public Optional<SessionInfo> findSessionInfo(Long memberId) {
-        return sessionInfoRepository.getSessionInfo(memberId);
+    public Optional<SessionInfo> findSessionInfo(Long trainerId, Long memberId) {
+        return sessionInfoRepository.getSessionInfo(trainerId, memberId);
     }
 
     public SessionInfo getSessionInfo(Long trainerId, Long memberId) {
@@ -128,12 +129,6 @@ public class MemberService {
     public void deleteAllWorkoutSchedules(List<WorkoutSchedule> deletedWorkoutSchedules) {
         workoutScheduleRepository.deleteAllByIds(deletedWorkoutSchedules.stream()
                 .map(WorkoutSchedule::getWorkoutScheduleId).toList());
-    }
-
-    public void checkMemberExists(Long memberId) {
-        if (!memberRepository.exists(memberId)) {
-            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
-        }
     }
 
     /**

--- a/src/main/java/spring/fitlinkbe/domain/notification/Notification.java
+++ b/src/main/java/spring/fitlinkbe/domain/notification/Notification.java
@@ -40,7 +40,7 @@ public class Notification {
     }
 
     public static Notification disconnectNotification(String memberName, PersonalDetail trainerDetail) {
-        String content = memberName + " 님과의 연동이 해제되었습니다.";
+        String content = memberName + " 님과의 연동 (또는 연동 요청) 이 취소되었습니다.";
 
         return Notification.builder()
                 .refId(null)

--- a/src/main/java/spring/fitlinkbe/infra/common/connectingInfo/ConnectingInfoJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/common/connectingInfo/ConnectingInfoJpaRepository.java
@@ -21,4 +21,7 @@ public interface ConnectingInfoJpaRepository extends JpaRepository<ConnectingInf
     @Query("select c from ConnectingInfoEntity c join fetch c.member m " +
             "where m.memberId = :memberId and (c.status = 'CONNECTED' or c.status = 'REQUESTED')")
     Optional<ConnectingInfoEntity> findExistMemberConnectingInfo(Long memberId);
+
+    @EntityGraph(attributePaths = {"member", "trainer"})
+    Optional<ConnectingInfoEntity> findByTrainer_TrainerIdAndMember_MemberId(Long trainerId, Long memberId);
 }

--- a/src/main/java/spring/fitlinkbe/infra/common/connectingInfo/ConnectingInfoRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/common/connectingInfo/ConnectingInfoRepositoryImpl.java
@@ -33,4 +33,10 @@ public class ConnectingInfoRepositoryImpl implements ConnectingInfoRepository {
         return connectingInfoJpaRepository.findExistMemberConnectingInfo(memberId)
                 .map(ConnectingInfoEntity::toDomain);
     }
+
+    @Override
+    public Optional<ConnectingInfo> findConnectingInfo(Long trainerId, Long memberId) {
+        return connectingInfoJpaRepository.findByTrainer_TrainerIdAndMember_MemberId(trainerId, memberId)
+                .map(ConnectingInfoEntity::toDomain);
+    }
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/common/exception/ApiControllerAdvice.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/common/exception/ApiControllerAdvice.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import spring.fitlinkbe.domain.common.exception.CustomException;
 import spring.fitlinkbe.interfaces.controller.common.dto.ApiResultResponse;
 
@@ -61,6 +62,13 @@ public class ApiControllerAdvice {
     public ApiResultResponse<Object> handlerAccessDeniedException(AccessDeniedException e) {
         log.error("AccessDeniedException is occurred! {}", e.getMessage());
         return ApiResultResponse.of(HttpStatus.FORBIDDEN, false, e.getMessage(), null);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ApiResultResponse<Object> handlerMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        log.error("MethodArgumentTypeMismatchException is occurred! {}", e.getMessage());
+        return ApiResultResponse.of(HttpStatus.BAD_REQUEST, false, e.getMessage(), null);
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/MemberController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/MemberController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import spring.fitlinkbe.application.member.MemberFacade;
 import spring.fitlinkbe.application.member.criteria.MemberInfoResult;
 import spring.fitlinkbe.application.member.criteria.MemberSessionResult;
+import spring.fitlinkbe.application.member.criteria.SessionInfoCriteria;
 import spring.fitlinkbe.application.member.criteria.WorkoutScheduleResult;
 import spring.fitlinkbe.domain.common.enums.UserRole;
 import spring.fitlinkbe.domain.common.exception.CustomException;
@@ -17,10 +18,7 @@ import spring.fitlinkbe.domain.common.exception.ErrorCode;
 import spring.fitlinkbe.domain.reservation.Session;
 import spring.fitlinkbe.interfaces.controller.common.dto.ApiResultResponse;
 import spring.fitlinkbe.interfaces.controller.common.dto.CustomPageResponse;
-import spring.fitlinkbe.interfaces.controller.member.dto.MemberDto;
-import spring.fitlinkbe.interfaces.controller.member.dto.MemberInfoDto;
-import spring.fitlinkbe.interfaces.controller.member.dto.MemberSessionDto;
-import spring.fitlinkbe.interfaces.controller.member.dto.WorkoutScheduleDto;
+import spring.fitlinkbe.interfaces.controller.member.dto.*;
 import spring.fitlinkbe.support.aop.RoleCheck;
 import spring.fitlinkbe.support.argumentresolver.Login;
 import spring.fitlinkbe.support.security.SecurityUser;
@@ -130,6 +128,18 @@ public class MemberController {
         Page<MemberSessionResult.SessionResponse> result = memberFacade.getSessions(user.getTrainerId(), memberId, status, pageRequest);
 
         return ApiResultResponse.ok(CustomPageResponse.of(result, MemberSessionDto.SessionResponse::from));
+    }
+
+    @PatchMapping("{memberId}/session-info/{sessionInfoId}")
+    public ApiResultResponse<SessionInfoDto.Response> updateSessionInfo(
+            @Login SecurityUser user,
+            @PathVariable Long memberId,
+            @PathVariable Long sessionInfoId,
+            @RequestBody @Valid SessionInfoDto.UpdateRequest requestBody
+    ) {
+        SessionInfoCriteria.Response result = memberFacade.updateSessionInfo(user.getTrainerId(), memberId, sessionInfoId, requestBody.toCriteria());
+
+        return ApiResultResponse.ok(SessionInfoDto.Response.from(result));
     }
 
     @InitBinder

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/MemberController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/MemberController.java
@@ -115,7 +115,19 @@ public class MemberController {
             @PageableDefault(size = 5) Pageable pageRequest,
             @RequestParam(required = false) Session.Status status
     ) {
-        Page<MemberSessionResult.SessionResponse> result = memberFacade.getSessions(user.getMemberId(), status, pageRequest);
+        Page<MemberSessionResult.SessionResponse> result = memberFacade.getMySessions(user.getMemberId(), status, pageRequest);
+
+        return ApiResultResponse.ok(CustomPageResponse.of(result, MemberSessionDto.SessionResponse::from));
+    }
+
+    @GetMapping("{memberId}/sessions")
+    public ApiResultResponse<CustomPageResponse<MemberSessionDto.SessionResponse>> getSessions(
+            @Login SecurityUser user,
+            @PathVariable Long memberId,
+            @PageableDefault(size = 5) Pageable pageRequest,
+            @RequestParam(required = false) Session.Status status
+    ) {
+        Page<MemberSessionResult.SessionResponse> result = memberFacade.getSessions(user.getTrainerId(), memberId, status, pageRequest);
 
         return ApiResultResponse.ok(CustomPageResponse.of(result, MemberSessionDto.SessionResponse::from));
     }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/MemberController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/MemberController.java
@@ -29,13 +29,13 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/members")
+@RoleCheck(allowedRoles = {UserRole.MEMBER})
 public class MemberController {
 
     private final MemberFacade memberFacade;
     private final CollectionValidator validator;
 
     @PostMapping("/connect")
-    @RoleCheck(allowedRoles = {UserRole.MEMBER})
     public ApiResultResponse<Object> connectTrainer(
             @Login SecurityUser user,
             @RequestBody @Valid MemberDto.MemberConnectRequest requestBody) {
@@ -45,7 +45,6 @@ public class MemberController {
     }
 
     @PostMapping("/disconnect")
-    @RoleCheck(allowedRoles = {UserRole.MEMBER})
     public ApiResultResponse<Object> disconnectTrainer(@Login SecurityUser user) {
         memberFacade.disconnectTrainer(user.getMemberId());
 
@@ -53,7 +52,6 @@ public class MemberController {
     }
 
     @GetMapping("/me")
-    @RoleCheck(allowedRoles = {UserRole.MEMBER})
     public ApiResultResponse<MemberInfoDto.Response> getMyInfo(@Login SecurityUser user) {
         MemberInfoResult.Response result = memberFacade.getMyInfo(user.getMemberId());
 
@@ -61,7 +59,6 @@ public class MemberController {
     }
 
     @PatchMapping("/me")
-    @RoleCheck(allowedRoles = {UserRole.MEMBER})
     public ApiResultResponse<MemberInfoDto.MemberUpdateResponse> updateMyInfo(
             @Login SecurityUser user,
             @RequestBody @Valid MemberInfoDto.MemberUpdateRequest requestBody) {
@@ -72,7 +69,6 @@ public class MemberController {
     }
 
     @GetMapping("/me/detail")
-    @RoleCheck(allowedRoles = {UserRole.MEMBER})
     public ApiResultResponse<MemberInfoDto.DetailResponse> getMyDetail(@Login SecurityUser user) {
         MemberInfoResult.DetailResponse result = memberFacade.getMyDetail(user.getMemberId());
 
@@ -80,7 +76,6 @@ public class MemberController {
     }
 
     @PutMapping("/me/workout-schedule")
-    @RoleCheck(allowedRoles = {UserRole.MEMBER})
     public ApiResultResponse<Object> updateWorkoutSchedule(
             @Login SecurityUser user,
             @RequestBody @Valid List<WorkoutScheduleDto.Request> requestBody
@@ -113,7 +108,6 @@ public class MemberController {
     }
 
     @GetMapping("/me/sessions")
-    @RoleCheck(allowedRoles = {UserRole.MEMBER})
     public ApiResultResponse<CustomPageResponse<MemberSessionDto.SessionResponse>> getSessions(
             @Login SecurityUser user,
             @PageableDefault(size = 5) Pageable pageRequest,

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/MemberController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/MemberController.java
@@ -28,7 +28,6 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RoleCheck(allowedRoles = {UserRole.MEMBER})
 @RequestMapping("/v1/members")
 public class MemberController {
 
@@ -36,6 +35,7 @@ public class MemberController {
     private final CollectionValidator validator;
 
     @PostMapping("/connect")
+    @RoleCheck(allowedRoles = {UserRole.MEMBER})
     public ApiResultResponse<Object> connectTrainer(
             @Login SecurityUser user,
             @RequestBody @Valid MemberDto.MemberConnectRequest requestBody) {
@@ -45,6 +45,7 @@ public class MemberController {
     }
 
     @PostMapping("/disconnect")
+    @RoleCheck(allowedRoles = {UserRole.MEMBER})
     public ApiResultResponse<Object> disconnectTrainer(@Login SecurityUser user) {
         memberFacade.disconnectTrainer(user.getMemberId());
 
@@ -52,6 +53,7 @@ public class MemberController {
     }
 
     @GetMapping("/me")
+    @RoleCheck(allowedRoles = {UserRole.MEMBER})
     public ApiResultResponse<MemberInfoDto.Response> getMyInfo(@Login SecurityUser user) {
         MemberInfoResult.Response result = memberFacade.getMyInfo(user.getMemberId());
 
@@ -59,6 +61,7 @@ public class MemberController {
     }
 
     @PatchMapping("/me")
+    @RoleCheck(allowedRoles = {UserRole.MEMBER})
     public ApiResultResponse<MemberInfoDto.MemberUpdateResponse> updateMyInfo(
             @Login SecurityUser user,
             @RequestBody @Valid MemberInfoDto.MemberUpdateRequest requestBody) {
@@ -69,6 +72,7 @@ public class MemberController {
     }
 
     @GetMapping("/me/detail")
+    @RoleCheck(allowedRoles = {UserRole.MEMBER})
     public ApiResultResponse<MemberInfoDto.DetailResponse> getMyDetail(@Login SecurityUser user) {
         MemberInfoResult.DetailResponse result = memberFacade.getMyDetail(user.getMemberId());
 
@@ -76,6 +80,7 @@ public class MemberController {
     }
 
     @PutMapping("/me/workout-schedule")
+    @RoleCheck(allowedRoles = {UserRole.MEMBER})
     public ApiResultResponse<Object> updateWorkoutSchedule(
             @Login SecurityUser user,
             @RequestBody @Valid List<WorkoutScheduleDto.Request> requestBody
@@ -108,6 +113,7 @@ public class MemberController {
     }
 
     @GetMapping("/me/sessions")
+    @RoleCheck(allowedRoles = {UserRole.MEMBER})
     public ApiResultResponse<CustomPageResponse<MemberSessionDto.SessionResponse>> getSessions(
             @Login SecurityUser user,
             @PageableDefault(size = 5) Pageable pageRequest,
@@ -119,6 +125,7 @@ public class MemberController {
     }
 
     @GetMapping("{memberId}/sessions")
+    @RoleCheck(allowedRoles = {UserRole.TRAINER})
     public ApiResultResponse<CustomPageResponse<MemberSessionDto.SessionResponse>> getSessions(
             @Login SecurityUser user,
             @PathVariable Long memberId,
@@ -131,6 +138,7 @@ public class MemberController {
     }
 
     @PatchMapping("{memberId}/session-info/{sessionInfoId}")
+    @RoleCheck(allowedRoles = {UserRole.TRAINER})
     public ApiResultResponse<SessionInfoDto.Response> updateSessionInfo(
             @Login SecurityUser user,
             @PathVariable Long memberId,

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/MemberInfoDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/MemberInfoDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.validation.constraints.AssertTrue;
 import lombok.Builder;
 import spring.fitlinkbe.application.member.criteria.MemberInfoResult;
+import spring.fitlinkbe.domain.common.model.ConnectingInfo;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -16,6 +17,7 @@ public class MemberInfoDto {
             String name,
             Long trainerId,
             String trainerName,
+            ConnectingInfo.ConnectingStatus connectingStatus,
             String profilePictureUrl,
             SessionInfoResponse sessionInfo,
             List<WorkoutScheduleDto.Response> workoutSchedules
@@ -26,6 +28,7 @@ public class MemberInfoDto {
                     .name(result.name())
                     .trainerId(result.trainerId())
                     .trainerName(result.trainerName())
+                    .connectingStatus(result.connectingStatus())
                     .profilePictureUrl(result.profilePictureUrl())
                     .sessionInfo(result.sessionInfo() != null ? SessionInfoResponse.from(result.sessionInfo()) : null)
                     .workoutSchedules(result.workoutSchedules().stream().map(WorkoutScheduleDto.Response::from).toList())

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/SessionInfoDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/SessionInfoDto.java
@@ -1,0 +1,23 @@
+package spring.fitlinkbe.interfaces.controller.member.dto;
+
+import jakarta.validation.constraints.PositiveOrZero;
+
+public class SessionInfoDto {
+
+    public record UpdateRequest(
+
+            @PositiveOrZero
+            Integer remainingCount,
+
+            @PositiveOrZero
+            Integer totalCount
+    ) {
+    }
+
+    public record Response(
+            Long sessionInfoId,
+            Integer remainingCount,
+            Integer totalCount
+    ) {
+    }
+}

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/SessionInfoDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/SessionInfoDto.java
@@ -1,6 +1,8 @@
 package spring.fitlinkbe.interfaces.controller.member.dto;
 
 import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Builder;
+import spring.fitlinkbe.application.member.criteria.SessionInfoCriteria;
 
 public class SessionInfoDto {
 
@@ -12,12 +14,26 @@ public class SessionInfoDto {
             @PositiveOrZero
             Integer totalCount
     ) {
+        public SessionInfoCriteria.UpdateRequest toCriteria() {
+            return SessionInfoCriteria.UpdateRequest.builder()
+                    .remainingCount(remainingCount)
+                    .totalCount(totalCount)
+                    .build();
+        }
     }
 
+    @Builder
     public record Response(
             Long sessionInfoId,
             Integer remainingCount,
             Integer totalCount
     ) {
+        public static Response from(SessionInfoCriteria.Response response) {
+            return Response.builder()
+                    .sessionInfoId(response.sessionInfoId())
+                    .remainingCount(response.remainingCount())
+                    .totalCount(response.totalCount())
+                    .build();
+        }
     }
 }

--- a/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import spring.fitlinkbe.domain.common.ConnectingInfoRepository;
+import spring.fitlinkbe.domain.common.SessionInfoRepository;
 import spring.fitlinkbe.domain.common.model.ConnectingInfo;
 import spring.fitlinkbe.domain.common.model.PersonalDetail;
 import spring.fitlinkbe.domain.common.model.SessionInfo;
@@ -24,10 +25,7 @@ import spring.fitlinkbe.integration.common.BaseIntegrationTest;
 import spring.fitlinkbe.integration.common.TestDataHandler;
 import spring.fitlinkbe.interfaces.controller.common.dto.ApiResultResponse;
 import spring.fitlinkbe.interfaces.controller.common.dto.CustomPageResponse;
-import spring.fitlinkbe.interfaces.controller.member.dto.MemberDto;
-import spring.fitlinkbe.interfaces.controller.member.dto.MemberInfoDto;
-import spring.fitlinkbe.interfaces.controller.member.dto.MemberSessionDto;
-import spring.fitlinkbe.interfaces.controller.member.dto.WorkoutScheduleDto;
+import spring.fitlinkbe.interfaces.controller.member.dto.*;
 
 import java.time.DayOfWeek;
 import java.time.LocalTime;
@@ -44,6 +42,9 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
 
     @Autowired
     NotificationRepository notificationRepository;
+
+    @Autowired
+    SessionInfoRepository sessionInfoRepository;
 
     @Nested
     @DisplayName("멤버 트레이너 연결 요청 테스트")
@@ -988,6 +989,90 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
                 softly.assertThat(response.data()).isNull();
             });
         }
+    }
+
+    @Nested
+    @DisplayName("회원 PT 횟수 수정 테스트")
+    public class MemberSessionCountUpdateTest {
+        private static final String MEMBER_SESSION_COUNT_UPDATE_API = "/v1/members/{memberId}/session-info/{sessionInfoId}";
+
+        @Test
+        @DisplayName("회원 PT 횟수 수정 성공")
+        public void memberSessionCountUpdateSuccess() throws Exception {
+            // given
+            // 회원, 트레이너 정보가 있을 때
+            Member member = testDataHandler.createMember();
+            Trainer trainer = testDataHandler.createTrainer("AB1423");
+            testDataHandler.connectMemberAndTrainer(member, trainer);
+            String token = testDataHandler.createTokenFromTrainer(trainer);
+            SessionInfo sessionInfo = testDataHandler.createSessionInfo(member, trainer);
+
+            // when
+            // 트레이너가 회원 PT 횟수 수정 요청을 보낸다면
+            int remainingCount = 5;
+            int totalCount = 5;
+            String url = MEMBER_SESSION_COUNT_UPDATE_API.replace("{memberId}", member.getMemberId().toString())
+                    .replace("{sessionInfoId}", sessionInfo.getSessionInfoId().toString());
+            SessionInfoDto.UpdateRequest request = new SessionInfoDto.UpdateRequest(remainingCount, totalCount);
+            String requestBody = writeValueAsString(request);
+            ExtractableResponse<Response> result = patch(url, requestBody, token);
+
+            // then
+            // PT 횟수가 수정된다
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.statusCode()).isEqualTo(200);
+                ApiResultResponse<SessionInfoDto.Response> response = readValue(result.body().jsonPath().prettify(), new TypeReference<>() {
+                });
+
+                SessionInfoDto.Response data = response.data();
+                softly.assertThat(response).isNotNull();
+                softly.assertThat(response.success()).isTrue();
+                softly.assertThat(response.status()).isEqualTo(200);
+
+                softly.assertThat(data.sessionInfoId()).isEqualTo(sessionInfo.getSessionInfoId());
+                softly.assertThat(data.remainingCount()).isEqualTo(remainingCount);
+                softly.assertThat(data.totalCount()).isEqualTo(totalCount);
+
+                SessionInfo updatedSessionInfo = sessionInfoRepository.getSessionInfo(sessionInfo.getSessionInfoId()).get();
+                softly.assertThat(updatedSessionInfo.getRemainingCount()).isEqualTo(remainingCount);
+                softly.assertThat(updatedSessionInfo.getTotalCount()).isEqualTo(totalCount);
+            });
+        }
+
+        @Test
+        @DisplayName("회원 PT 횟수 수정 실패 - 트레이너가 회원과 연결이 안되어 있을 때")
+        public void memberSessionCountUpdateFailByNotConnected() throws Exception {
+            // given
+            // 회원, 트레이너 정보가 있을 때
+            Member member = testDataHandler.createMember();
+            Trainer trainer = testDataHandler.createTrainer("AB1423");
+            SessionInfo sessionInfo = testDataHandler.createSessionInfo(member, trainer);
+            String token = testDataHandler.createTokenFromTrainer(trainer);
+
+            // when
+            // 트레이너가 회원과 연결이 안되어 있는 회원 PT 횟수 수정 요청을 보낸다면
+            int remainingCount = 5;
+            int totalCount = 5;
+            String url = MEMBER_SESSION_COUNT_UPDATE_API.replace("{memberId}", member.getMemberId().toString())
+                    .replace("{sessionInfoId}", sessionInfo.getSessionInfoId().toString());
+            SessionInfoDto.UpdateRequest request = new SessionInfoDto.UpdateRequest(remainingCount, totalCount);
+            String requestBody = writeValueAsString(request);
+            ExtractableResponse<Response> result = patch(url, requestBody, token);
+
+            // then
+            // 연결 정보가 없다는 응답을 받는다
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.statusCode()).isEqualTo(200);
+                ApiResultResponse<Object> response = readValue(result.body().jsonPath().prettify(), new TypeReference<>() {
+                });
+
+                softly.assertThat(response).isNotNull();
+                softly.assertThat(response.success()).isFalse();
+                softly.assertThat(response.status()).isEqualTo(400);
+                softly.assertThat(response.data()).isNull();
+            });
+        }
+
     }
 
     private void createSessions(Member member, Trainer trainer) {

--- a/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
+++ b/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
@@ -180,6 +180,11 @@ public class TestDataHandler {
                 personalDetail.getUserRole());
     }
 
+    public String createTokenFromTrainer(Trainer trainer) {
+        PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(trainer.getTrainerId()).orElseThrow();
+        return authTokenProvider.createAccessToken(personalDetail.getStatus(), personalDetail.getPersonalDetailId());
+    }
+
     public PersonalDetail getTrainerPersonalDetail(Long trainerId) {
         return personalDetailRepository.getTrainerDetail(trainerId).orElseThrow();
     }

--- a/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
+++ b/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
@@ -182,7 +182,8 @@ public class TestDataHandler {
 
     public String createTokenFromTrainer(Trainer trainer) {
         PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(trainer.getTrainerId()).orElseThrow();
-        return authTokenProvider.createAccessToken(personalDetail.getStatus(), personalDetail.getPersonalDetailId());
+        return authTokenProvider.createAccessToken(personalDetail.getStatus(), personalDetail.getPersonalDetailId(),
+                personalDetail.getUserRole());
     }
 
     public PersonalDetail getTrainerPersonalDetail(Long trainerId) {

--- a/src/test/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationControllerTest.java
+++ b/src/test/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationControllerTest.java
@@ -268,8 +268,8 @@ class ReservationControllerTest {
                             .header("Authorization", "Bearer " + accessToken)
                             .with(oauth2Login().oauth2User(user)))  // OAuth2 인증
                     .andDo(print())
-                    .andExpect(status().is5xxServerError())
-                    .andExpect(jsonPath("$.status").value(500))
+                    .andExpect(status().is2xxSuccessful())
+                    .andExpect(jsonPath("$.status").value(400))
                     .andExpect(jsonPath("$.success").value(false))
                     .andExpect(jsonPath("$.data").isEmpty());
         }


### PR DESCRIPTION
### 작업 사항
- GET `/v1/members/:memberId/sessions` 특정 회원 PT 내역 조회 API 작업
- PATCH `/v1/members/:memberId/session-info/:sessionInfoId` 특정 회원 전체 pt 등록수, 남은 숫자 수정
- 회원 내 정보 조회시 trainer connecting status 정보도 리턴하도록 수정
- 회원 disconnect api 에서 요청 상태일때도 호출이 가능하도록 수정
