### PR TITLE
[FLIZ-143] 내 회원 상세 조회 api 작업

### DIFF
--- a/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
@@ -87,11 +87,13 @@ public class MemberFacade {
         return MemberInfoResult.MemberUpdateResponse.from(me);
     }
 
+    @Transactional(readOnly = true)
     public MemberInfoResult.DetailResponse getMyDetail(Long memberId) {
         Member me = memberService.getMember(memberId);
         return MemberInfoResult.DetailResponse.from(me);
     }
 
+    @Transactional
     public List<WorkoutScheduleResult.Response> updateWorkoutSchedule(
             Long memberId,
             List<WorkoutScheduleCriteria.Request> request
@@ -177,6 +179,7 @@ public class MemberFacade {
         return SessionInfoCriteria.Response.from(sessionInfo);
     }
 
+    @Transactional(readOnly = true)
     public Page<MemberInfoResult.SimpleResponse> getMembers(Long trainerId, Pageable pageRequest, String keyword) {
         Page<Member> memberPage = memberService.getMembers(trainerId, pageRequest, keyword);
 
@@ -186,5 +189,18 @@ public class MemberFacade {
                 .collect(Collectors.toMap(SessionInfo::getMemberId, Function.identity()));
 
         return memberPage.map(member -> MemberInfoResult.SimpleResponse.of(member, grouped.get(member.getMemberId())));
+    }
+
+    @Transactional(readOnly = true)
+    public MemberInfoResult.Response getMemberInfo(Long trainerId, Long memberId) {
+        memberService.checkConnected(trainerId, memberId);
+
+        ConnectingInfo connectingInfo = memberService.findConnectedInfo(memberId);
+        SessionInfo sessionInfo = memberService.findSessionInfo(trainerId, memberId);
+        Member me = memberService.getMember(memberId);
+
+        List<WorkoutSchedule> workoutSchedules = memberService.getWorkoutSchedules(memberId);
+
+        return MemberInfoResult.Response.of(me, connectingInfo, sessionInfo, workoutSchedules);
     }
 }

--- a/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
@@ -87,7 +87,6 @@ public class MemberFacade {
         return MemberInfoResult.MemberUpdateResponse.from(me);
     }
 
-    @Transactional(readOnly = true)
     public MemberInfoResult.DetailResponse getMyDetail(Long memberId) {
         Member me = memberService.getMember(memberId);
         return MemberInfoResult.DetailResponse.from(me);

--- a/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
+++ b/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
@@ -150,6 +150,14 @@ public class MemberService {
         }
     }
 
+    /**
+     * 연결된 정보 조회
+     * @return 해당 회원과 연동 완료된 (Connected) 상태의 연결 정보
+     */
+    public ConnectingInfo findConnectedInfo(Long memberId) {
+        return connectingInfoRepository.getConnectedInfo(memberId).orElse(null);
+    }
+
     public void saveSessionInfo(SessionInfo sessionInfo) {
         sessionInfoRepository.saveSessionInfo(sessionInfo);
     }
@@ -173,4 +181,5 @@ public class MemberService {
         getSessionInfo.restoreSession();
         this.saveSessionInfo(getSessionInfo);
     }
+
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/MemberController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/MemberController.java
@@ -156,6 +156,18 @@ public class MemberController {
         return ApiResultResponse.ok(CustomPageResponse.of(result, MemberInfoDto.SimpleResponse::from));
     }
 
+    @GetMapping("/{memberId}")
+    @RoleCheck(allowedRoles = {UserRole.TRAINER})
+    public ApiResultResponse<MemberInfoDto.Response> getMemberInfo(
+            @Login SecurityUser user,
+            @PathVariable Long memberId
+    ) {
+        MemberInfoResult.Response result = memberFacade.getMemberInfo(user.getTrainerId(), memberId);
+
+        return ApiResultResponse.ok(MemberInfoDto.Response.from(result));
+
+    }
+
     @InitBinder
     public void initBinder(WebDataBinder dataBinder) {
         Object target = dataBinder.getTarget();

--- a/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
@@ -1272,6 +1272,7 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
                 });
 
                 softly.assertThat(response).isNotNull();
+                softly.assertThat(response.msg()).isEqualTo("트레이너가 멤버와 연결되어 있지 않습니다.");
                 softly.assertThat(response.success()).isFalse();
                 softly.assertThat(response.status()).isEqualTo(400);
                 softly.assertThat(response.data()).isNull();

--- a/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
@@ -1195,6 +1195,90 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
         }
     }
 
+    @Nested
+    @DisplayName("내 특정 회원 조회 테스트")
+    public class MyMemberInfoTest {
+        private static final String MEMBER_INFO_API = "/v1/members/{memberId}";
+
+        @Test
+        @DisplayName("회원 정보 조회 성공")
+        public void memberInfoSuccess() throws Exception {
+            // given
+            // 회원, 트레이너, 세션 정보, PT 희망 시간 정보가 있을 때
+            Member member = testDataHandler.createMember();
+            Trainer trainer = testDataHandler.createTrainer("AB1423");
+            SessionInfo sessionInfo = testDataHandler.createSessionInfo(member, trainer);
+            String token = testDataHandler.createTokenFromTrainer(trainer);
+            testDataHandler.connectMemberAndTrainer(member, trainer);
+            List<WorkoutSchedule> workoutSchedules = testDataHandler.createWorkoutSchedules(member);
+
+            // when
+            // 트레이너가 자기 회원의 정보를 조회한다면
+            String url = MEMBER_INFO_API.replace("{memberId}", member.getMemberId().toString());
+            ExtractableResponse<Response> result = get(url, token);
+
+            // then
+            // 회원의 정보를 받는다
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.statusCode()).isEqualTo(200);
+                ApiResultResponse<MemberInfoDto.Response> response = readValue(result.body().jsonPath().prettify(), new TypeReference<>() {
+                });
+
+                MemberInfoDto.Response data = response.data();
+                softly.assertThat(response).isNotNull();
+                softly.assertThat(response.success()).isTrue();
+                softly.assertThat(response.status()).isEqualTo(200);
+                softly.assertThat(data.memberId()).isEqualTo(member.getMemberId());
+                softly.assertThat(data.name()).isEqualTo(member.getName());
+                softly.assertThat(data.profilePictureUrl()).isEqualTo(member.getProfilePictureUrl());
+                softly.assertThat(data.trainerName()).isEqualTo(trainer.getName());
+                softly.assertThat(data.trainerId()).isEqualTo(trainer.getTrainerId());
+                softly.assertThat(data.sessionInfo().sessionInfoId()).isEqualTo(sessionInfo.getSessionInfoId());
+                softly.assertThat(data.sessionInfo().remainingCount()).isEqualTo(sessionInfo.getRemainingCount());
+                softly.assertThat(data.sessionInfo().totalCount()).isEqualTo(sessionInfo.getTotalCount());
+
+                softly.assertThat(data.workoutSchedules().size()).isEqualTo(workoutSchedules.size());
+                for (WorkoutScheduleDto.Response responseDto : data.workoutSchedules()) {
+                    WorkoutSchedule workoutSchedule = workoutSchedules.stream().filter(ws -> ws.getWorkoutScheduleId()
+                            .equals(responseDto.workoutScheduleId())).findFirst().orElseThrow();
+
+                    softly.assertThat(responseDto.workoutScheduleId()).isEqualTo(workoutSchedule.getWorkoutScheduleId());
+                    softly.assertThat(responseDto.dayOfWeek()).isEqualTo(workoutSchedule.getDayOfWeek());
+                    softly.assertThat(responseDto.preferenceTimes())
+                            .containsExactlyInAnyOrderElementsOf(workoutSchedule.getPreferenceTimes());
+                }
+            });
+        }
+
+        @Test
+        @DisplayName("회원 정보 조회 실패 - 트레이너와 연결이 안되어있는 멤버일 때")
+        public void memberInfoFailByNotConnected() throws Exception {
+            // given
+            // 회원, 트레이너 정보가 있을 때
+            Member member = testDataHandler.createMember();
+            Trainer trainer = testDataHandler.createTrainer("AB1423");
+            String token = testDataHandler.createTokenFromTrainer(trainer);
+
+            // when
+            // 트레이너가 연결되어 있지 않은 회원 정보를 조회할 때
+            String url = MEMBER_INFO_API.replace("{memberId}", member.getMemberId().toString());
+            ExtractableResponse<Response> result = get(url, token);
+
+            // then
+            // 연결 정보가 없다는 응답을 받는다
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.statusCode()).isEqualTo(200);
+                ApiResultResponse<Object> response = readValue(result.body().jsonPath().prettify(), new TypeReference<>() {
+                });
+
+                softly.assertThat(response).isNotNull();
+                softly.assertThat(response.success()).isFalse();
+                softly.assertThat(response.status()).isEqualTo(400);
+                softly.assertThat(response.data()).isNull();
+            });
+        }
+    }
+
     private void createMembers(Trainer trainer) {
         Member member1 = testDataHandler.createMember("member1");
         Member member2 = testDataHandler.createMember("member2");


### PR DESCRIPTION
### 작업 내용
- GET `/v1/members/:memberId` api 작업했습니다.
- 조회하는 대상이 트레이너와 연결된 대상이 아니라면 조회가 불가능하도록 구현했습니다