### PR TITLE
[Fliz-139] BE 예약 취소 API

### DIFF
--- a/src/main/java/spring/fitlinkbe/application/reservation/criteria/ReservationCriteria.java
+++ b/src/main/java/spring/fitlinkbe/application/reservation/criteria/ReservationCriteria.java
@@ -68,4 +68,14 @@ public class ReservationCriteria {
                     .toList();
         }
     }
+
+    @Builder(toBuilder = true)
+    public record CancelReservation(Long reservationId, String cancelReason) {
+        public ReservationCommand.CancelReservation toCommand() {
+            return ReservationCommand.CancelReservation.builder()
+                    .reservationId(reservationId)
+                    .cancelReason(cancelReason)
+                    .build();
+        }
+    }
 }

--- a/src/main/java/spring/fitlinkbe/domain/common/ConnectingInfoRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/ConnectingInfoRepository.java
@@ -19,6 +19,7 @@ public interface ConnectingInfoRepository {
 
     /**
      * 해당 트레이너와 회원의 연결 정보를 가져온다.
+     *
      * @param trainerId
      * @param memberId
      * @return

--- a/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     RESERVATION_IS_FAILED("예약에 실패하였습니다.", 400),
     RESERVATION_NOT_ALLOWED("예약을 할 수 있는 상태가 아닙니다.", 400),
     SET_DISABLE_DATE_FAILED("예약 불가 설정에 실패하였습니다.", 400),
+    RESERVATION_CANCEL_FAILED("예약 취소에 실패하였습니다.", 400),
     RESERVATION_IS_ALREADY_CANCEL("이미 예약이 취소되었습니다.", 400),
     RESERVATION_IS_NOT_WAITING_STATUS("예약 상태가 대기 상태가 아닙니다.", 400),
     RESERVATION_WAITING_MEMBERS_EMPTY("이 날짜에 예약 대기자가 없습니다.", 400),

--- a/src/main/java/spring/fitlinkbe/domain/common/model/SessionInfo.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/model/SessionInfo.java
@@ -51,4 +51,8 @@ public class SessionInfo {
     public Long getMemberId() {
         return member.getMemberId();
     }
+
+    public void restoreSession() {
+        remainingCount++;
+    }
 }

--- a/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
+++ b/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
@@ -164,4 +164,13 @@ public class MemberService {
     public List<SessionInfo> findAllSessionInfo(List<Long> memberIds, Long trainerId) {
         return sessionInfoRepository.findAllSessionInfo(memberIds, trainerId);
     }
+
+    /**
+     * 세션 복구
+     */
+    public void restoreSession(Long trainerId, Long memberId) {
+        SessionInfo getSessionInfo = this.getSessionInfo(trainerId, memberId);
+        getSessionInfo.restoreSession();
+        this.saveSessionInfo(getSessionInfo);
+    }
 }

--- a/src/main/java/spring/fitlinkbe/domain/notification/Notification.java
+++ b/src/main/java/spring/fitlinkbe/domain/notification/Notification.java
@@ -75,6 +75,26 @@ public class Notification {
                 .build();
     }
 
+    public static Notification cancelRequestReservationNotification(Long reservationId, String name,
+                                                                    PersonalDetail memberDetail, Reason reason) {
+        String content = "회원 %s 님의 %s를 요청하였습니다.".formatted(
+                name,
+                reason.name);
+
+        return Notification.builder()
+                .refId(reservationId)
+                .refType(ReferenceType.RESERVATION)
+                .notificationType(NotificationType.RESERVATION_CANCEL)
+                .personalDetail(memberDetail)
+                .name(NotificationType.RESERVATION_CANCEL.getName())
+                .content(content)
+                .isSent(true)
+                .isProcessed(false)
+                .sendDate(LocalDateTime.now())
+                .build();
+
+    }
+
     public static Notification approveReservationNotification(Long reservationId, PersonalDetail memberDetail) {
 
         String content = " %s 님의 예약이 승인되었습니다.".formatted(memberDetail.getName());
@@ -149,7 +169,9 @@ public class Notification {
     @RequiredArgsConstructor
     public enum Reason {
         DAY_OFF("연차"),
-        RESERVATION_REFUSE("예약 거절");
+        RESERVATION_REFUSE("예약 거절"),
+        RESERVATION_CANCEL("예약 취소"),
+        RESERVATION_CANCEL_REQUEST("예약 취소 요청");
         private final String name;
     }
 }

--- a/src/main/java/spring/fitlinkbe/domain/notification/NotificationService.java
+++ b/src/main/java/spring/fitlinkbe/domain/notification/NotificationService.java
@@ -29,6 +29,11 @@ public class NotificationService {
         notificationRepository.save(notification);
     }
 
+    public void sendCancelRequestReservationNotification(Long reservationId, String name, PersonalDetail memberDetail, Reason reason) {
+        Notification notification = cancelRequestReservationNotification(reservationId, name, memberDetail, reason);
+        notificationRepository.save(notification);
+    }
+
     public void sendApproveReservationNotification(Long reservationId, PersonalDetail memberDetail) {
         Notification notification = approveReservationNotification(reservationId, memberDetail);
         notificationRepository.save(notification);

--- a/src/main/java/spring/fitlinkbe/domain/reservation/Reservation.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/Reservation.java
@@ -66,6 +66,7 @@ public class Reservation {
         RESERVATION_WAITING("예약 대기"), // 예약 대기
         RESERVATION_APPROVED("예약 확정"), // 예약 확정
         RESERVATION_CANCELLED("예약 취소"), // 예약 취소
+        RESERVATION_CANCEL_REQUEST("예약 취소 요청"), // 예약 취소
         RESERVATION_REFUSED("예약 거절"),  // 예약 거부
         RESERVATION_CHANGE_REQUEST("예약 변경 요청"), //예약 변경 요청
         RESERVATION_COMPLETED("예약 종료"); // 세션까지 완전 완료 되었을 때
@@ -134,7 +135,23 @@ public class Reservation {
             throw new CustomException(RESERVATION_CANCEL_NOT_ALLOWED);
         }
         cancelReason = message;
-        status = RESERVATION_CANCELLED;
+        this.status = RESERVATION_CANCELLED;
+    }
+
+    public void cancelRequest(String message) {
+        // 당일 예약 취소는 불가능 함
+        if (LocalDateTime.now().isAfter(reservationDates.get(0).minusDays(1).truncatedTo(ChronoUnit.DAYS).plusHours(23))) {
+            throw new CustomException(RESERVATION_CANCEL_NOT_ALLOWED, "당일 예약 취소 요청은 불가합니다.");
+        }
+        if (status == DISABLED_TIME_RESERVATION || status == RESERVATION_REFUSED) {
+            throw new CustomException(RESERVATION_CANCEL_NOT_ALLOWED);
+        }
+        if (status == RESERVATION_CANCELLED) {
+            throw new CustomException(RESERVATION_IS_ALREADY_CANCEL);
+        }
+        cancelReason = message;
+        this.status = RESERVATION_CANCEL_REQUEST;
+
     }
 
     public boolean isReservationNotAllowed() {

--- a/src/main/java/spring/fitlinkbe/domain/reservation/ReservationRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/ReservationRepository.java
@@ -17,15 +17,15 @@ public interface ReservationRepository {
 
     List<Reservation> saveReservations(List<Reservation> canceledReservations);
 
+    List<Session> saveSessions(List<Session> sessions);
+
     Optional<Reservation> getReservation(Long reservationId);
 
-    Optional<Reservation> reserveSession(Reservation reservations);
+    Optional<Reservation> saveReservation(Reservation reservation);
 
     Optional<Session> getSession(Long reservationId);
 
-    Optional<Session> createSession(Session session);
-
-    List<Session> saveSessions(List<Session> sessions);
+    Optional<Session> saveSession(Session session);
 
 
 }

--- a/src/main/java/spring/fitlinkbe/domain/reservation/command/ReservationCommand.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/command/ReservationCommand.java
@@ -45,4 +45,9 @@ public class ReservationCommand {
                     .build();
         }
     }
+
+    @Builder(toBuilder = true)
+    public record CancelReservation(Long reservationId, String cancelReason) {
+
+    }
 }

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationJpaRepository.java
@@ -18,17 +18,17 @@ public interface ReservationJpaRepository extends JpaRepository<ReservationEntit
             "LEFT JOIN FETCH r.member " +
             "LEFT JOIN FETCH r.trainer " +
             "LEFT JOIN FETCH r.sessionInfo " +
-            "WHERE r.member.memberId = :userId " +
+            "WHERE r.member.memberId = :memberId " +
             "AND r.createdAt > CURRENT_TIMESTAMP")
-    List<ReservationEntity> findByMember_MemberId(Long userId);
+    List<ReservationEntity> findByMember_MemberId(Long memberId);
 
     @Query("SELECT r FROM ReservationEntity r " +
             "LEFT JOIN FETCH r.member " +
             "LEFT JOIN FETCH r.trainer " +
             "LEFT JOIN FETCH r.sessionInfo " +
-            "WHERE r.trainer.trainerId = :userId " +
+            "WHERE r.trainer.trainerId = :trainerId " +
             "AND r.createdAt > CURRENT_TIMESTAMP")
-    List<ReservationEntity> findByTrainer_TrainerId(Long userId);
+    List<ReservationEntity> findByTrainer_TrainerId(Long trainerId);
 
     @Query("SELECT r FROM ReservationEntity r " +
             "LEFT JOIN FETCH r.member " +

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationRepositoryImpl.java
@@ -87,7 +87,7 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     }
 
     @Override
-    public Optional<Reservation> reserveSession(Reservation reservation) {
+    public Optional<Reservation> saveReservation(Reservation reservation) {
         ReservationEntity reservationEntity = reservationJpaRepository.save(ReservationEntity.from(reservation, em));
 
         return Optional.of(reservationEntity.toDomain());
@@ -103,7 +103,7 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     }
 
     @Override
-    public Optional<Session> createSession(Session session) {
+    public Optional<Session> saveSession(Session session) {
         SessionEntity savedEntity = sessionJpaRepository.save(SessionEntity.from(session, em));
 
         return Optional.of(savedEntity.toDomain());

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/common/exception/ApiControllerAdvice.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/common/exception/ApiControllerAdvice.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import spring.fitlinkbe.domain.common.exception.CustomException;
 import spring.fitlinkbe.interfaces.controller.common.dto.ApiResultResponse;
@@ -68,6 +69,13 @@ public class ApiControllerAdvice {
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ApiResultResponse<Object> handlerMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
         log.error("MethodArgumentTypeMismatchException is occurred! {}", e.getMessage());
+        return ApiResultResponse.of(HttpStatus.BAD_REQUEST, false, e.getMessage(), null);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @ExceptionHandler(HandlerMethodValidationException.class)
+    public ApiResultResponse<Object> handlerMethodValidationException(HandlerMethodValidationException e) {
+        log.error("HandlerMethodValidationException is occurred! {}", e.getMessage());
         return ApiResultResponse.of(HttpStatus.BAD_REQUEST, false, e.getMessage(), null);
     }
 

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/MemberInfoDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/member/dto/MemberInfoDto.java
@@ -19,7 +19,7 @@ public class MemberInfoDto {
             String phoneNumber,
             String profilePictureUrl,
             SessionInfoResponse sessionInfo
-    ){
+    ) {
         public static SimpleResponse from(MemberInfoResult.SimpleResponse result) {
             return SimpleResponse.builder()
                     .memberId(result.memberId())

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
@@ -141,4 +141,25 @@ public class ReservationController {
                 .toList());
 
     }
+
+    /**
+     * 예약 취소
+     *
+     * @param request cancelReason 정보
+     * @return ApiResultResponse 취소된 reservationId 정보를 반환한다.
+     */
+    @PostMapping("/{reservationId}/cancel")
+    public ApiResultResponse<ReservationResponseDto.Success> cancelReservation(@PathVariable("reservationId")
+                                                                               @NotNull(message = "예약 ID는 필수값입니다.")
+                                                                               Long reservationId,
+                                                                               @Valid @RequestBody ReservationRequestDto.CancelReservation
+                                                                                       request,
+                                                                               @Login SecurityUser user
+    ) {
+
+        Reservation result = reservationFacade.cancelReservation(request.toCriteria(reservationId), user);
+
+        return ApiResultResponse.ok(ReservationResponseDto.Success.of(result));
+
+    }
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationRequestDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationRequestDto.java
@@ -62,4 +62,16 @@ public class ReservationRequestDto {
                     .build();
         }
     }
+
+    @Builder(toBuilder = true)
+    public record CancelReservation(@NotEmpty(message = "취소 사유는 필수값 입니다.") String cancelReason) {
+
+        public ReservationCriteria.CancelReservation toCriteria(Long reservationId) {
+
+            return ReservationCriteria.CancelReservation.builder()
+                    .reservationId(reservationId)
+                    .cancelReason(cancelReason)
+                    .build();
+        }
+    }
 }

--- a/src/test/java/spring/fitlinkbe/domain/reservation/ReservationServiceTest.java
+++ b/src/test/java/spring/fitlinkbe/domain/reservation/ReservationServiceTest.java
@@ -269,7 +269,7 @@ class ReservationServiceTest {
                     .status(DISABLED_TIME_RESERVATION)
                     .build();
 
-            when(reservationRepository.reserveSession(any(Reservation.class)))
+            when(reservationRepository.saveReservation(any(Reservation.class)))
                     .thenReturn(Optional.ofNullable(savedReservation));
 
             //when
@@ -283,11 +283,11 @@ class ReservationServiceTest {
 
     @Nested
     @DisplayName("세션 예약 Service TEST")
-    class ReserveSessionServiceTest {
+    class saveReservationServiceTest {
 
         @Test
         @DisplayName("세션 예약 성공")
-        void reserveSession() {
+        void saveReservation() {
             //given
             Reservation reservation = Reservation.builder()
                     .status(RESERVATION_WAITING)
@@ -298,7 +298,7 @@ class ReservationServiceTest {
                     .status(RESERVATION_WAITING)
                     .build();
 
-            when(reservationRepository.reserveSession(reservation))
+            when(reservationRepository.saveReservation(reservation))
                     .thenReturn(Optional.ofNullable(savedReservation));
 
             //when
@@ -311,9 +311,9 @@ class ReservationServiceTest {
 
         @Test
         @DisplayName("세션 예약 실패 - 예약 정보가 안넘어 왔을 때")
-        void reserveSessionNoReservationInfo() {
+        void saveReservationNoReservationInfo() {
             //given
-            when(reservationRepository.reserveSession(any(Reservation.class))).thenThrow(
+            when(reservationRepository.saveReservation(any(Reservation.class))).thenThrow(
                     new CustomException(RESERVATION_NOT_FOUND,
                             RESERVATION_NOT_FOUND.getMsg()));
 
@@ -328,11 +328,11 @@ class ReservationServiceTest {
 
     @Nested
     @DisplayName("세션 생성 Service TEST")
-    class CreateSessionServiceTest {
+    class saveSessionServiceTest {
 
         @Test
         @DisplayName("세션 생성 성공")
-        void createSession() {
+        void saveSession() {
             //given
             Reservation reservation = Reservation.builder()
                     .reservationId(1L)
@@ -343,11 +343,11 @@ class ReservationServiceTest {
                     .sessionId(1L)
                     .build();
 
-            when(reservationRepository.createSession(any(Session.class)))
+            when(reservationRepository.saveSession(any(Session.class)))
                     .thenReturn(Optional.ofNullable(session));
 
             //when
-            Session result = reservationService.createSession(reservation);
+            Session result = reservationService.saveSession(reservation);
 
             //then
             assertThat(result).isNotNull();
@@ -356,14 +356,14 @@ class ReservationServiceTest {
 
         @Test
         @DisplayName("세션 생성 실패 - 예약 정보가 안넘어 왔을 때")
-        void createSessionNoReservationInfo() {
+        void saveSessionNoReservationInfo() {
             //given
-            when(reservationRepository.createSession(any())).thenThrow(
+            when(reservationRepository.saveSession(any())).thenThrow(
                     new CustomException(SESSION_CREATE_FAILED,
                             SESSION_CREATE_FAILED.getMsg()));
 
             //when & then
-            assertThatThrownBy(() -> reservationService.createSession(Reservation.builder().build()))
+            assertThatThrownBy(() -> reservationService.saveSession(Reservation.builder().build()))
                     .isInstanceOf(CustomException.class)
                     .extracting("errorCode")
                     .isEqualTo(SESSION_CREATE_FAILED);

--- a/src/test/java/spring/fitlinkbe/integration/ReservationIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/ReservationIntegrationTest.java
@@ -39,7 +39,9 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static spring.fitlinkbe.domain.common.exception.ErrorCode.RESERVATION_NOT_ALLOWED;
 import static spring.fitlinkbe.domain.notification.Notification.NotificationType.*;
+import static spring.fitlinkbe.domain.reservation.Reservation.Status.RESERVATION_CANCEL_REQUEST;
 import static spring.fitlinkbe.domain.reservation.Reservation.Status.*;
+import static spring.fitlinkbe.domain.reservation.Session.Status.SESSION_WAITING;
 
 public class ReservationIntegrationTest extends BaseIntegrationTest {
 
@@ -115,7 +117,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .createdAt(LocalDateTime.now().plusSeconds(2))
                     .build();
 
-            reservationRepository.reserveSession(reservation);
+            reservationRepository.saveReservation(reservation);
 
             // when
             ExtractableResponse<Response> result = get(LOCAL_HOST + port + PATH, params, accessToken);
@@ -155,7 +157,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .createdAt(LocalDateTime.now().plusSeconds(2))
                     .build();
 
-            reservationRepository.reserveSession(reservation);
+            reservationRepository.saveReservation(reservation);
 
             PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(1L)
                     .orElseThrow();
@@ -207,7 +209,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .dayOfWeek(reqeustDate.getDayOfWeek())
                     .build();
 
-            reservationRepository.reserveSession(reservation);
+            reservationRepository.saveReservation(reservation);
 
             // when
             ExtractableResponse<Response> result = get(LOCAL_HOST + port + PATH, params, accessToken);
@@ -253,7 +255,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .createdAt(LocalDateTime.now().plusSeconds(2))
                     .build();
 
-            reservationRepository.reserveSession(reservation);
+            reservationRepository.saveReservation(reservation);
 
             // when
             ExtractableResponse<Response> result = get(LOCAL_HOST + port + PATH, params, accessToken);
@@ -297,7 +299,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .dayOfWeek(reqeustDate.getDayOfWeek())
                     .build();
 
-            reservationRepository.reserveSession(reservation);
+            reservationRepository.saveReservation(reservation);
 
             // when
             ExtractableResponse<Response> result = get(LOCAL_HOST + port + PATH, params, accessToken);
@@ -345,7 +347,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .status(RESERVATION_WAITING)
                     .build();
 
-            Reservation savedReservation = reservationRepository.reserveSession(reservation).orElseThrow();
+            Reservation savedReservation = reservationRepository.saveReservation(reservation).orElseThrow();
 
             // when
             ExtractableResponse<Response> result = get(LOCAL_HOST + port + PATH + "/"
@@ -388,7 +390,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .status(RESERVATION_WAITING)
                     .build();
 
-            Reservation savedReservation = reservationRepository.reserveSession(reservation).orElseThrow();
+            Reservation savedReservation = reservationRepository.saveReservation(reservation).orElseThrow();
 
             // when
             ExtractableResponse<Response> result = get(LOCAL_HOST + port + PATH + "/"
@@ -431,13 +433,13 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .status(RESERVATION_APPROVED)
                     .build();
 
-            Reservation savedReservation = reservationRepository.reserveSession(reservation).orElseThrow();
+            Reservation savedReservation = reservationRepository.saveReservation(reservation).orElseThrow();
 
             Session session = Session.builder()
                     .reservation(savedReservation)
                     .build();
 
-            reservationRepository.createSession(session);
+            reservationRepository.saveSession(session);
 
             // when
             ExtractableResponse<Response> result = get(LOCAL_HOST + port + PATH + "/"
@@ -485,7 +487,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .createdAt(LocalDateTime.now().plusSeconds(2))
                     .build();
 
-            Reservation savedReservation1 = reservationRepository.reserveSession(reservation1).orElseThrow();
+            Reservation savedReservation1 = reservationRepository.saveReservation(reservation1).orElseThrow();
 
             Member member2 = testDataHandler.createMember();
             SessionInfo sessionInfo2 = testDataHandler.createSessionInfo(member2, trainer);
@@ -501,7 +503,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .createdAt(LocalDateTime.now().plusSeconds(2))
                     .build();
 
-            Reservation savedReservation2 = reservationRepository.reserveSession(reservation2).orElseThrow();
+            Reservation savedReservation2 = reservationRepository.saveReservation(reservation2).orElseThrow();
 
             // when
             ExtractableResponse<Response> result = get(LOCAL_HOST + port + PATH + "/waiting-members/"
@@ -547,7 +549,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .status(RESERVATION_WAITING)
                     .build();
 
-            reservationRepository.reserveSession(reservation1).orElseThrow();
+            reservationRepository.saveReservation(reservation1).orElseThrow();
 
             Member member2 = testDataHandler.createMember();
             SessionInfo sessionInfo2 = testDataHandler.createSessionInfo(member2, trainer);
@@ -562,7 +564,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .status(RESERVATION_WAITING)
                     .build();
 
-            reservationRepository.reserveSession(reservation2).orElseThrow();
+            reservationRepository.saveReservation(reservation2).orElseThrow();
 
             // when
             ExtractableResponse<Response> result = get(LOCAL_HOST + port + PATH + "/waiting-members/", accessToken);
@@ -599,7 +601,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .status(RESERVATION_APPROVED)
                     .build();
 
-            reservationRepository.reserveSession(reservation1).orElseThrow();
+            reservationRepository.saveReservation(reservation1).orElseThrow();
 
             // when
             ExtractableResponse<Response> result = get(LOCAL_HOST + port + PATH + "/waiting-members/"
@@ -646,7 +648,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .status(RESERVATION_WAITING)
                     .build();
 
-            reservationRepository.reserveSession(reservation).orElseThrow();
+            reservationRepository.saveReservation(reservation).orElseThrow();
 
             LocalDateTime requestDate = LocalDateTime.now().plusHours(1);
 
@@ -697,13 +699,13 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .createdAt(LocalDateTime.now().plusSeconds(2))
                     .build();
 
-            Reservation savedReservation = reservationRepository.reserveSession(reservation).orElseThrow();
+            Reservation savedReservation = reservationRepository.saveReservation(reservation).orElseThrow();
 
             Session session = Session.builder()
                     .reservation(savedReservation)
                     .build();
 
-            reservationRepository.createSession(session);
+            reservationRepository.saveSession(session);
 
             LocalDateTime requestDate = LocalDateTime.now().plusHours(1);
 
@@ -763,11 +765,11 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
     @Nested
     @DisplayName("직접 예약 Integration TEST")
-    class ReserveSessionIntegrationTest {
+    class saveReservationIntegrationTest {
 
         @Test
         @DisplayName("트레이너가 직접 예약 성공")
-        void reserveSessionWithTrainer() {
+        void saveReservationWithTrainer() {
             // given
             PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(1L)
                     .orElseThrow();
@@ -803,7 +805,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                 // 세션이 잘 생성됐는지 확인
                 Session session = reservationRepository.getSession(content.reservationId()).orElseThrow();
                 softly.assertThat(session).isNotNull();
-                softly.assertThat(session.getStatus()).isEqualTo(Session.Status.SESSION_WAITING);
+                softly.assertThat(session.getStatus()).isEqualTo(SESSION_WAITING);
 
                 // 알람이 잘 생성됐는지 확인
                 Notification notification = notificationRepository.getNotification(content.reservationId(),
@@ -815,7 +817,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
         @Test
         @DisplayName("멤버가 직접 예약 성공")
-        void reserveSessionWithMember() {
+        void saveReservationWithMember() {
             // given
             PersonalDetail personalDetail = personalDetailRepository.getMemberDetail(1L)
                     .orElseThrow();
@@ -857,7 +859,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
         @Test
         @DisplayName("멤버가 직접 예약 성공 - 우선 예약 포함 2개 예약")
-        void reserveSessionWithMemberAndPriority() {
+        void saveReservationWithMemberAndPriority() {
             // given
             PersonalDetail personalDetail = personalDetailRepository.getMemberDetail(1L)
                     .orElseThrow();
@@ -901,7 +903,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
         @Test
         @DisplayName("직접 예약 실패 - trainerID 부재")
-        void reserveSessionNoTrainerId() {
+        void saveReservationNoTrainerId() {
             // given
             PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(1L)
                     .orElseThrow();
@@ -934,7 +936,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
         @Test
         @DisplayName("직접 예약 실패 - memberID 부재")
-        void reserveSessionNoMemberId() {
+        void saveReservationNoMemberId() {
             // given
             PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(1L)
                     .orElseThrow();
@@ -967,7 +969,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
         @Test
         @DisplayName("직접 예약 실패 - dates 부재")
-        void reserveSessionNoDate() {
+        void saveReservationNoDate() {
             // given
             PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(1L)
                     .orElseThrow();
@@ -998,7 +1000,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
         @Test
         @DisplayName("직접 예약 실패 - name 부재")
-        void reserveSessionNoName() {
+        void saveReservationNoName() {
             // given
             PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(1L)
                     .orElseThrow();
@@ -1032,10 +1034,10 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
     @Nested
     @DisplayName("고정 세션 예약 Integration TEST")
-    class FixedReserveSessionIntegrationTest {
+    class FixedSaveReservationIntegrationTest {
         @Test
         @DisplayName("트레이너가 고정 세션 예약 성공 - 예약 1개")
-        void fixedReserveSessionWithTrainer() {
+        void FixedSaveReservationWithTrainer() {
             // given
             PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(1L)
                     .orElseThrow();
@@ -1070,14 +1072,14 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                 // 세션이 잘 생성됐는지 확인
                 Session session = reservationRepository.getSession(content.get(0).reservationId()).orElseThrow();
                 softly.assertThat(session).isNotNull();
-                softly.assertThat(session.getStatus()).isEqualTo(Session.Status.SESSION_WAITING);
+                softly.assertThat(session.getStatus()).isEqualTo(SESSION_WAITING);
 
             });
         }
 
         @Test
         @DisplayName("트레이너가 고정 세션 예약 성공 - 예약 2개")
-        void twoFixedReserveSessionWithTrainer() {
+        void twoFixedSaveReservationWithTrainer() {
             // given
             PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(1L)
                     .orElseThrow();
@@ -1115,18 +1117,18 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                 // 세션이 잘 생성됐는지 확인
                 Session session1 = reservationRepository.getSession(content.get(0).reservationId()).orElseThrow();
                 softly.assertThat(session1).isNotNull();
-                softly.assertThat(session1.getStatus()).isEqualTo(Session.Status.SESSION_WAITING);
+                softly.assertThat(session1.getStatus()).isEqualTo(SESSION_WAITING);
 
                 Session session2 = reservationRepository.getSession(content.get(1).reservationId()).orElseThrow();
                 softly.assertThat(session2).isNotNull();
-                softly.assertThat(session2.getStatus()).isEqualTo(Session.Status.SESSION_WAITING);
+                softly.assertThat(session2.getStatus()).isEqualTo(SESSION_WAITING);
 
             });
         }
 
         @Test
         @DisplayName("트레이너가 고정 세션 예약 성공 - 기존에 존재하던 예약 취소")
-        void fixedReserveSessionWithCancelAlreadyReserveSession() {
+        void FixedSaveReservationWithCancelAlreadySaveReservation() {
             // given
             PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(1L)
                     .orElseThrow();
@@ -1150,7 +1152,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .createdAt(LocalDateTime.now().plusSeconds(2))
                     .build();
 
-            Reservation savedReservation = reservationRepository.reserveSession(reservation)
+            Reservation savedReservation = reservationRepository.saveReservation(reservation)
                     .orElseThrow();
 
             // when
@@ -1172,7 +1174,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                 // 세션이 잘 생성됐는지 확인
                 Session session = reservationRepository.getSession(content.get(0).reservationId()).orElseThrow();
                 softly.assertThat(session).isNotNull();
-                softly.assertThat(session.getStatus()).isEqualTo(Session.Status.SESSION_WAITING);
+                softly.assertThat(session.getStatus()).isEqualTo(SESSION_WAITING);
 
                 // 기존 예약이 잘 취소됐는지 확인
                 Reservation originReservation = reservationRepository
@@ -1193,7 +1195,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
         @Test
         @DisplayName("트레이너가 고정 세션 예약 실패 - 멤버 ID 누락")
-        void fixedReserveSessionWithNoMemberId() {
+        void FixedSaveReservationWithNoMemberId() {
             // given
             PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(1L)
                     .orElseThrow();
@@ -1225,7 +1227,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
         @Test
         @DisplayName("트레이너가 고정 세션 예약 실패 - 이름 누락")
-        void fixedReserveSessionWithNoName() {
+        void FixedSaveReservationWithNoName() {
             // given
             PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(1L)
                     .orElseThrow();
@@ -1257,7 +1259,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
         @Test
         @DisplayName("트레이너가 고정 세션 예약 실패 - date 누락")
-        void fixedReserveSessionWithNoDate() {
+        void FixedSaveReservationWithNoDate() {
             // given
             PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(1L)
                     .orElseThrow();
@@ -1288,7 +1290,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
         @Test
         @DisplayName("트레이너가 고정 세션 예약 실패 - 예약 불가 설정")
-        void fixedReserveSessionWithDisableTime() {
+        void FixedSaveReservationWithDisableTime() {
             // given
             PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(1L)
                     .orElseThrow();
@@ -1312,7 +1314,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .createdAt(LocalDateTime.now().plusSeconds(2))
                     .build();
 
-            reservationRepository.reserveSession(reservation);
+            reservationRepository.saveReservation(reservation);
 
             // when
             ExtractableResponse<Response> result = post(LOCAL_HOST + port + PATH + "/fixed-reservations",
@@ -1331,7 +1333,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
         @Test
         @DisplayName("트레이너가 고정 세션 예약 실패 - 이미 예약 종료")
-        void fixedReserveSessionAlreadyExited() {
+        void FixedSaveReservationAlreadyExited() {
             // given
             PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(1L)
                     .orElseThrow();
@@ -1355,7 +1357,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .createdAt(LocalDateTime.now().plusSeconds(2))
                     .build();
 
-            reservationRepository.reserveSession(reservation);
+            reservationRepository.saveReservation(reservation);
 
             // when
             ExtractableResponse<Response> result = post(LOCAL_HOST + port + PATH + "/fixed-reservations",
@@ -1375,10 +1377,10 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
     @Nested
     @DisplayName("스케줄 고정 세션 예약 Integration TEST")
-    class ScheduledFixedReserveSessionIntegrationTest {
+    class ScheduledFixedSaveReservationIntegrationTest {
         @Test
         @DisplayName("스케줄 고정 세션 예약 성공")
-        void scheduledFixedReserveSession() {
+        void scheduledFixedSaveReservation() {
             // given
             LocalDateTime requestDate = LocalDateTime.now().plusHours(1);
 
@@ -1390,7 +1392,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .createdAt(LocalDateTime.now().plusSeconds(2))
                     .build();
 
-            reservationRepository.reserveSession(reservation);
+            reservationRepository.saveReservation(reservation);
 
             // when
             fixedReservationScheduler.fixedReserveSession();
@@ -1409,7 +1411,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
         @Test
         @DisplayName("스케줄 고정 세션 예약 실패 - 예약 불가 설정")
-        void scheduledFixedReserveSessionSetDisableTime() {
+        void scheduledFixedSaveReservationSetDisableTime() {
             // given
             LocalDateTime requestDate = LocalDateTime.now().plusHours(1);
 
@@ -1421,7 +1423,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .createdAt(LocalDateTime.now().plusSeconds(2))
                     .build();
 
-            reservationRepository.reserveSession(reservation);
+            reservationRepository.saveReservation(reservation);
 
             Reservation reservation2 = Reservation.builder()
                     .reservationDates(List.of(requestDate.plusDays(7)))
@@ -1431,7 +1433,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .createdAt(LocalDateTime.now().plusSeconds(2))
                     .build();
 
-            reservationRepository.reserveSession(reservation2);
+            reservationRepository.saveReservation(reservation2);
 
             //when & then
             assertThatThrownBy(() -> fixedReservationScheduler.fixedReserveSession())
@@ -1439,5 +1441,343 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .extracting("errorCode")
                     .isEqualTo(RESERVATION_NOT_ALLOWED);
         }
+    }
+
+    @Nested
+    @DisplayName("예약 취소 Integration TEST")
+    class CancelReservationIntegrationTest {
+        @Test
+        @DisplayName("트레이너가 예약 취소 성공")
+        void cancelReservationWithTrainer() {
+            // given
+            PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(1L)
+                    .orElseThrow();
+
+            String accessToken = tokenProvider.createAccessToken(PersonalDetail.Status.NORMAL,
+                    personalDetail.getPersonalDetailId(), personalDetail.getUserRole());
+
+            ReservationRequestDto.CancelReservation request = ReservationRequestDto.CancelReservation.builder()
+                    .cancelReason("개인 사정")
+                    .build();
+
+            LocalDateTime requestDate = LocalDateTime.now().plusDays(1);
+
+            // 예약 생성
+            Reservation reservation = Reservation.builder()
+                    .reservationDates(List.of(requestDate))
+                    .trainer(Trainer.builder().trainerId(1L).build())
+                    .member(Member.builder().memberId(1L).build())
+                    .status(RESERVATION_APPROVED)
+                    .createdAt(LocalDateTime.now().plusSeconds(2))
+                    .build();
+
+            Reservation savedReservation = reservationRepository.saveReservation(reservation).orElseThrow();
+
+            // 세션 생성
+            Session session = Session.builder()
+                    .reservation(savedReservation)
+                    .status(SESSION_WAITING)
+                    .build();
+
+            reservationRepository.saveSession(session);
+
+            // when
+            ExtractableResponse<Response> result = post(LOCAL_HOST + port + PATH + "/%s/cancel".formatted(1),
+                    request,
+                    accessToken);
+
+            // then
+            assertSoftly(softly -> {
+                //예약이 잘 취소 됐는지 확인
+                softly.assertThat(result.statusCode()).isEqualTo(200);
+
+                ReservationResponseDto.Success content = result.body().jsonPath()
+                        .getObject("data", ReservationResponseDto.Success.class);
+
+                softly.assertThat(content.reservationId()).isEqualTo(1L);
+                softly.assertThat(content.status()).isEqualTo(RESERVATION_CANCELLED.getName());
+
+                // 알람이 잘 생성됐는지 확인
+                Notification notification = notificationRepository.getNotification(content.reservationId(),
+                        Notification.ReferenceType.RESERVATION);
+                softly.assertThat(notification).isNotNull();
+                softly.assertThat(notification.getNotificationType()).isEqualTo(RESERVATION_CANCEL);
+            });
+
+        }
+
+        @Test
+        @DisplayName("멤버가 예약 취소 요청 성공")
+        void cancelReservationWithMember() {
+            // given
+            PersonalDetail personalDetail = personalDetailRepository.getMemberDetail(1L)
+                    .orElseThrow();
+
+            String accessToken = tokenProvider.createAccessToken(PersonalDetail.Status.NORMAL,
+                    personalDetail.getPersonalDetailId(), personalDetail.getUserRole());
+
+            ReservationRequestDto.CancelReservation request = ReservationRequestDto.CancelReservation.builder()
+                    .cancelReason("개인 사정")
+                    .build();
+
+            LocalDateTime requestDate = LocalDateTime.now().plusDays(1);
+
+            // 예약 생성
+            Reservation reservation = Reservation.builder()
+                    .reservationDates(List.of(requestDate))
+                    .trainer(Trainer.builder().trainerId(1L).build())
+                    .member(Member.builder().memberId(1L).build())
+                    .status(RESERVATION_APPROVED)
+                    .createdAt(LocalDateTime.now().plusSeconds(2))
+                    .build();
+
+            Reservation savedReservation = reservationRepository.saveReservation(reservation).orElseThrow();
+
+            // 세션 생성
+            Session session = Session.builder()
+                    .reservation(savedReservation)
+                    .status(SESSION_WAITING)
+                    .build();
+
+            reservationRepository.saveSession(session);
+
+            // when
+            ExtractableResponse<Response> result = post(LOCAL_HOST + port + PATH + "/%s/cancel".formatted(1),
+                    request,
+                    accessToken);
+
+            // then
+            assertSoftly(softly -> {
+                //예약이 잘 취소 됐는지 확인
+                softly.assertThat(result.statusCode()).isEqualTo(200);
+
+                ReservationResponseDto.Success content = result.body().jsonPath()
+                        .getObject("data", ReservationResponseDto.Success.class);
+
+                softly.assertThat(content.reservationId()).isEqualTo(1L);
+                softly.assertThat(content.status()).isEqualTo(RESERVATION_CANCEL_REQUEST.getName());
+
+                // 알람이 잘 생성됐는지 확인
+                Notification notification = notificationRepository.getNotification(content.reservationId(),
+                        Notification.ReferenceType.RESERVATION);
+                softly.assertThat(notification).isNotNull();
+                softly.assertThat(notification.getNotificationType()).isEqualTo(RESERVATION_CANCEL);
+            });
+
+        }
+
+        @Test
+        @DisplayName("트레이너가 예약 취소 실패 - 예약 사유 부재")
+        void cancelReservationWithNoCancelReason() {
+            // given
+            PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(1L)
+                    .orElseThrow();
+
+            String accessToken = tokenProvider.createAccessToken(PersonalDetail.Status.NORMAL,
+                    personalDetail.getPersonalDetailId(), personalDetail.getUserRole());
+
+            ReservationRequestDto.CancelReservation request = ReservationRequestDto.CancelReservation.builder()
+                    .cancelReason("")
+                    .build();
+
+            LocalDateTime requestDate = LocalDateTime.now().plusDays(1);
+
+            // 예약 생성
+            Reservation reservation = Reservation.builder()
+                    .reservationDates(List.of(requestDate))
+                    .trainer(Trainer.builder().trainerId(1L).build())
+                    .member(Member.builder().memberId(1L).build())
+                    .status(RESERVATION_APPROVED)
+                    .createdAt(LocalDateTime.now().plusSeconds(2))
+                    .build();
+
+            Reservation savedReservation = reservationRepository.saveReservation(reservation).orElseThrow();
+
+            // 세션 생성
+            Session session = Session.builder()
+                    .reservation(savedReservation)
+                    .status(SESSION_WAITING)
+                    .build();
+
+            reservationRepository.saveSession(session);
+
+            // when
+            ExtractableResponse<Response> result = post(LOCAL_HOST + port + PATH + "/%s/cancel".formatted(1),
+                    request,
+                    accessToken);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.statusCode()).isEqualTo(200);
+                softly.assertThat(result.body().jsonPath().getObject("success", Boolean.class)).isFalse();
+                softly.assertThat(result.body().jsonPath().getObject("msg", String.class)).isEqualTo("400 BAD_REQUEST \"Validation failure\"");
+                softly.assertThat(result.body().jsonPath().getObject("data", ReservationResponseDto.Success.class)).isNull();
+            });
+
+        }
+
+        @Test
+        @DisplayName("트레이너가 예약 취소 실패 - 없는 예약 취소 요청")
+        void cancelReservationWithNoExistReservation() {
+            // given
+            PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(1L)
+                    .orElseThrow();
+
+            String accessToken = tokenProvider.createAccessToken(PersonalDetail.Status.NORMAL,
+                    personalDetail.getPersonalDetailId(), personalDetail.getUserRole());
+
+            ReservationRequestDto.CancelReservation request = ReservationRequestDto.CancelReservation.builder()
+                    .cancelReason("개인 사유")
+                    .build();
+
+            // when
+            ExtractableResponse<Response> result = post(LOCAL_HOST + port + PATH + "/%s/cancel".formatted(1),
+                    request,
+                    accessToken);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.statusCode()).isEqualTo(200);
+                softly.assertThat(result.body().jsonPath().getObject("success", Boolean.class)).isFalse();
+                softly.assertThat(result.body().jsonPath().getObject("msg", String.class)).isEqualTo("예약 정보를 찾을 수 없습니다. [reservationId: 1]");
+                softly.assertThat(result.body().jsonPath().getObject("data", ReservationResponseDto.Success.class)).isNull();
+            });
+
+        }
+
+        @Test
+        @DisplayName("트레이너가 예약 취소 실패 - 이미 취소된 예약 취소 시도")
+        void cancelReservationWithAlreadyCancelReservation() {
+            // given
+            PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(1L)
+                    .orElseThrow();
+
+            String accessToken = tokenProvider.createAccessToken(PersonalDetail.Status.NORMAL,
+                    personalDetail.getPersonalDetailId(), personalDetail.getUserRole());
+
+            ReservationRequestDto.CancelReservation request = ReservationRequestDto.CancelReservation.builder()
+                    .cancelReason("개인 사유")
+                    .build();
+
+            LocalDateTime requestDate = LocalDateTime.now().plusDays(1);
+
+            // 취소된 예약 생성
+            Reservation reservation = Reservation.builder()
+                    .reservationDates(List.of(requestDate))
+                    .trainer(Trainer.builder().trainerId(1L).build())
+                    .member(Member.builder().memberId(1L).build())
+                    .status(RESERVATION_CANCELLED)
+                    .createdAt(LocalDateTime.now().plusSeconds(2))
+                    .build();
+
+            reservationRepository.saveReservation(reservation).orElseThrow();
+
+            // when
+            ExtractableResponse<Response> result = post(LOCAL_HOST + port + PATH + "/%s/cancel".formatted(1),
+                    request,
+                    accessToken);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.statusCode()).isEqualTo(200);
+                softly.assertThat(result.body().jsonPath().getObject("success", Boolean.class)).isFalse();
+                softly.assertThat(result.body().jsonPath().getObject("msg", String.class)).isEqualTo("이미 예약이 취소되었습니다.");
+                softly.assertThat(result.body().jsonPath().getObject("data", ReservationResponseDto.Success.class)).isNull();
+            });
+
+        }
+
+        @Test
+        @DisplayName("트레이너가 예약 취소 실패 - 예약 취소 불가 상태 예약 취소 시도")
+        void cancelReservationWithCancelNotAllowed() {
+            // given
+            PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(1L)
+                    .orElseThrow();
+
+            String accessToken = tokenProvider.createAccessToken(PersonalDetail.Status.NORMAL,
+                    personalDetail.getPersonalDetailId(), personalDetail.getUserRole());
+
+            ReservationRequestDto.CancelReservation request = ReservationRequestDto.CancelReservation.builder()
+                    .cancelReason("개인 사유")
+                    .build();
+
+            LocalDateTime requestDate = LocalDateTime.now().plusDays(1);
+
+            // 예약 승인이 거절된 예약 생성
+            Reservation reservation = Reservation.builder()
+                    .reservationDates(List.of(requestDate))
+                    .trainer(Trainer.builder().trainerId(1L).build())
+                    .member(Member.builder().memberId(1L).build())
+                    .status(RESERVATION_REFUSED)
+                    .createdAt(LocalDateTime.now().plusSeconds(2))
+                    .build();
+
+            reservationRepository.saveReservation(reservation).orElseThrow();
+
+            // when
+            ExtractableResponse<Response> result = post(LOCAL_HOST + port + PATH + "/%s/cancel".formatted(1),
+                    request,
+                    accessToken);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.statusCode()).isEqualTo(200);
+                softly.assertThat(result.body().jsonPath().getObject("success", Boolean.class)).isFalse();
+                softly.assertThat(result.body().jsonPath().getObject("msg", String.class)).isEqualTo("예약 취소를 할 수 없는 상태입니다.");
+                softly.assertThat(result.body().jsonPath().getObject("data", ReservationResponseDto.Success.class)).isNull();
+            });
+
+        }
+
+        @Test
+        @DisplayName("멤버가 예약 취소 요청 실패 - 당일 예약 취소 요청")
+        void cancelReservationWithRequestToday() {
+            // given
+            PersonalDetail personalDetail = personalDetailRepository.getMemberDetail(1L)
+                    .orElseThrow();
+
+            String accessToken = tokenProvider.createAccessToken(PersonalDetail.Status.NORMAL,
+                    personalDetail.getPersonalDetailId(), personalDetail.getUserRole());
+
+            ReservationRequestDto.CancelReservation request = ReservationRequestDto.CancelReservation.builder()
+                    .cancelReason("개인 사유")
+                    .build();
+
+            LocalDateTime requestDate = LocalDateTime.now().plusHours(1);
+
+            // 예약 생성
+            Reservation reservation = Reservation.builder()
+                    .reservationDates(List.of(requestDate))
+                    .trainer(Trainer.builder().trainerId(1L).build())
+                    .member(Member.builder().memberId(1L).build())
+                    .status(RESERVATION_APPROVED)
+                    .createdAt(LocalDateTime.now().plusSeconds(2))
+                    .build();
+
+            Reservation savedReservation = reservationRepository.saveReservation(reservation).orElseThrow();
+
+            // 세션 생성
+            Session session = Session.builder()
+                    .reservation(savedReservation)
+                    .status(SESSION_WAITING)
+                    .build();
+
+            reservationRepository.saveSession(session);
+
+            // when
+            ExtractableResponse<Response> result = post(LOCAL_HOST + port + PATH + "/%s/cancel".formatted(1),
+                    request,
+                    accessToken);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.statusCode()).isEqualTo(200);
+                softly.assertThat(result.body().jsonPath().getObject("success", Boolean.class)).isFalse();
+                softly.assertThat(result.body().jsonPath().getObject("msg", String.class)).isEqualTo("당일 예약 취소 요청은 불가합니다.");
+                softly.assertThat(result.body().jsonPath().getObject("data", ReservationResponseDto.Success.class)).isNull();
+            });
+
+        }
+
     }
 }

--- a/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
+++ b/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
@@ -279,13 +279,13 @@ public class TestDataHandler {
                 .status(Reservation.Status.RESERVATION_APPROVED)
                 .reservationDates(List.of(LocalDateTime.now()))
                 .build();
-        Reservation saved = reservationRepository.reserveSession(reservation).orElseThrow();
+        Reservation saved = reservationRepository.saveReservation(reservation).orElseThrow();
 
         Session session = Session.builder()
                 .reservation(saved)
                 .status(status)
                 .isCompleted(true)
                 .build();
-        return reservationRepository.createSession(session).orElseThrow();
+        return reservationRepository.saveSession(session).orElseThrow();
     }
 }


### PR DESCRIPTION
### 구현 기능

- `POST` "/v1/reservations/{reservationId}/cancel" 예약 취소

### 세부 사항

- 예약 취소 API 개발 완료
- 테스트 코드 추가
- 관련 알람 추가