### PR TITLE
[FLIZ-149] 특정 회원 pt 내역 조회 수정 작업

### DIFF
--- a/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
@@ -159,6 +159,7 @@ public class MemberFacade {
 
         ReservationCommand.GetSessions command = ReservationCommand.GetSessions.builder()
                 .memberId(memberId)
+                .trainerId(trainerId)
                 .status(status)
                 .pageRequest(pageRequest)
                 .build();

--- a/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
@@ -99,7 +99,8 @@ public class ReservationService {
 
     @Transactional(readOnly = true)
     public Page<Session> getSessions(ReservationCommand.GetSessions command) {
-        return sessionRepository.getSessions(command.memberId(), command.status(), command.pageRequest());
+        return sessionRepository.getSessions(command.memberId(), command.trainerId(),
+                command.status(), command.pageRequest());
     }
 
     @Transactional

--- a/src/main/java/spring/fitlinkbe/domain/reservation/SessionRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/SessionRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface SessionRepository {
-    Page<Session> getSessions(Long memberId, Session.Status status, Pageable pageRequest);
+    Page<Session> getSessions(Long memberId, Long trainerId, Session.Status status, Pageable pageRequest);
 }

--- a/src/main/java/spring/fitlinkbe/domain/reservation/command/ReservationCommand.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/command/ReservationCommand.java
@@ -35,7 +35,7 @@ public class ReservationCommand {
     }
 
     @Builder(toBuilder = true)
-    public record GetSessions(Long memberId, Session.Status status, Pageable pageRequest) {
+    public record GetSessions(Long memberId, Long trainerId, Session.Status status, Pageable pageRequest) {
         public static GetSessions of(Long memberId, Session.Status status, Pageable pageRequest) {
 
             return GetSessions.builder()

--- a/src/main/java/spring/fitlinkbe/infra/reservation/SessionRepositoryCustom.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/SessionRepositoryCustom.java
@@ -5,5 +5,5 @@ import org.springframework.data.domain.Pageable;
 import spring.fitlinkbe.domain.reservation.Session;
 
 public interface SessionRepositoryCustom {
-    Page<SessionEntity> findSessions(Long memberId, Session.Status status, Pageable pageRequest);
+    Page<SessionEntity> findSessions(Long memberId, Long trainerId, Session.Status status, Pageable pageRequest);
 }

--- a/src/main/java/spring/fitlinkbe/infra/reservation/SessionRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/SessionRepositoryImpl.java
@@ -15,8 +15,8 @@ public class SessionRepositoryImpl implements SessionRepository {
     private final SessionJpaRepository sessionJpaRepository;
 
     @Override
-    public Page<Session> getSessions(Long memberId, Session.Status status, Pageable pageRequest) {
-        Page<SessionEntity> result = sessionJpaRepository.findSessions(memberId, status, pageRequest);
+    public Page<Session> getSessions(Long memberId, Long trainerId, Session.Status status, Pageable pageRequest) {
+        Page<SessionEntity> result = sessionJpaRepository.findSessions(memberId, trainerId, status, pageRequest);
 
         return result.map(SessionEntity::toDomain);
     }

--- a/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
@@ -981,11 +981,10 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
             Trainer trainer = testDataHandler.createTrainer("AB1423");
             Trainer anotherTrainer = testDataHandler.createTrainer("CD1423");
             testDataHandler.connectMemberAndTrainer(member, trainer);
-            testDataHandler.connectMemberAndTrainer(member, anotherTrainer);
             String token = testDataHandler.createTokenFromTrainer(trainer);
 
-            createSessions(member, trainer);
             createSessions(member, anotherTrainer);
+            createSessions(member, trainer);
 
             // when
             // 트레이너가 회원 PT 내역을 조회할 때 다른 트레이너와 진행한 PT 세션은 제외한다


### PR DESCRIPTION
### 작업 내용
- 특정 회원 PT내역 조회시 요청을 보낸 트레이너와 진행한 PT 내역만 조회되도록 수정
- 기존 로직에서는 연결이 끊어진 이전 트레이너와 진행한 PT 내역도 모두 조회되어 혼동이 올 수 있다고 생각했습니다.