### PR TITLE
[FLIZ-153] 트레이너 수업 가능 시간 조회, 등록 API 작업

### DIFF
--- a/src/main/java/spring/fitlinkbe/application/trainer/TrainerFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/trainer/TrainerFacade.java
@@ -3,13 +3,17 @@ package spring.fitlinkbe.application.trainer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import spring.fitlinkbe.application.trainer.criteria.AvailableTimeCriteria;
 import spring.fitlinkbe.application.trainer.criteria.AvailableTimesResult;
 import spring.fitlinkbe.application.trainer.criteria.TrainerInfoResult;
+import spring.fitlinkbe.domain.common.exception.CustomException;
+import spring.fitlinkbe.domain.common.exception.ErrorCode;
 import spring.fitlinkbe.domain.common.model.PersonalDetail;
 import spring.fitlinkbe.domain.trainer.AvailableTime;
 import spring.fitlinkbe.domain.trainer.Trainer;
 import spring.fitlinkbe.domain.trainer.TrainerService;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Component
@@ -57,5 +61,32 @@ public class TrainerFacade {
         List<AvailableTime> scheduledSchedules = trainerService.getScheduledAvailableTimes(trainerId);
 
         return AvailableTimesResult.Response.of(currentSchedules, scheduledSchedules);
+    }
+
+    @Transactional
+    public void saveAvailableTimes(Long trainerId, AvailableTimeCriteria.AddRequest criteria) {
+        Trainer trainer = trainerService.getTrainerInfo(trainerId);
+
+        if (criteria.applyAt().equals(LocalDate.now())) {
+            saveCurrentApplyAvailableTimes(trainer, criteria);
+        } else {
+            saveScheduledAvailableTimes(trainer, criteria);
+        }
+    }
+
+    private void saveCurrentApplyAvailableTimes(Trainer trainer, AvailableTimeCriteria.AddRequest criteria) {
+        if (!trainerService.getCurrentAvailableTimes(trainer.getTrainerId()).isEmpty()) {
+            throw new CustomException(ErrorCode.ALREADY_APPLIED_AVAILABLE_TIMES);
+        }
+        List<AvailableTime> availableTimes = criteria.toAvailableTimes(trainer);
+        trainerService.saveAvailableTimes(availableTimes);
+    }
+
+    private void saveScheduledAvailableTimes(Trainer trainer, AvailableTimeCriteria.AddRequest criteria) {
+        if (!trainerService.getScheduledAvailableTimes(trainer.getTrainerId()).isEmpty()) {
+            throw new CustomException(ErrorCode.ALREADY_SCHEDULED_AVAILABLE_TIMES);
+        }
+        List<AvailableTime> availableTimes = criteria.toAvailableTimes(trainer);
+        trainerService.saveAvailableTimes(availableTimes);
     }
 }

--- a/src/main/java/spring/fitlinkbe/application/trainer/TrainerFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/trainer/TrainerFacade.java
@@ -3,10 +3,14 @@ package spring.fitlinkbe.application.trainer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import spring.fitlinkbe.application.trainer.criteria.AvailableTimesResult;
 import spring.fitlinkbe.application.trainer.criteria.TrainerInfoResult;
 import spring.fitlinkbe.domain.common.model.PersonalDetail;
+import spring.fitlinkbe.domain.trainer.AvailableTime;
 import spring.fitlinkbe.domain.trainer.Trainer;
 import spring.fitlinkbe.domain.trainer.TrainerService;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -46,5 +50,12 @@ public class TrainerFacade {
         Trainer trainer = trainerService.getTrainerInfo(trainerId);
 
         return TrainerInfoResult.TrainerCodeResponse.from(trainer.getTrainerCode());
+    }
+
+    public AvailableTimesResult.Response getAvailableTimes(Long trainerId) {
+        List<AvailableTime> currentSchedules = trainerService.getCurrentAvailableTimes(trainerId);
+        List<AvailableTime> scheduledSchedules = trainerService.getScheduledAvailableTimes(trainerId);
+
+        return AvailableTimesResult.Response.of(currentSchedules, scheduledSchedules);
     }
 }

--- a/src/main/java/spring/fitlinkbe/application/trainer/criteria/AvailableTimeCriteria.java
+++ b/src/main/java/spring/fitlinkbe/application/trainer/criteria/AvailableTimeCriteria.java
@@ -1,0 +1,51 @@
+package spring.fitlinkbe.application.trainer.criteria;
+
+import lombok.Builder;
+import spring.fitlinkbe.domain.trainer.AvailableTime;
+import spring.fitlinkbe.domain.trainer.Trainer;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AvailableTimeCriteria {
+
+
+    @Builder
+    public record AddRequest(
+            LocalDate applyAt,
+            List<AvailableTimeRequest> availableTimes
+    ) {
+
+        public List<AvailableTime> toAvailableTimes(Trainer trainer) {
+            List<AvailableTime> result = new ArrayList<>();
+            for (AvailableTimeRequest availableTime : availableTimes) {
+                result.add(AvailableTime.builder()
+                        .trainer(trainer)
+                        .dayOfWeek(availableTime.dayOfWeek())
+                        .applyAt(applyAt)
+                        .isHoliday(availableTime.isHoliday())
+                        .startTime(availableTime.startTime())
+                        .endTime(availableTime.endTime())
+                        .build());
+            }
+
+            return result;
+        }
+    }
+
+    @Builder
+    public record AvailableTimeRequest(
+
+            DayOfWeek dayOfWeek,
+
+            Boolean isHoliday,
+
+            LocalTime startTime,
+
+            LocalTime endTime
+    ) {
+    }
+}

--- a/src/main/java/spring/fitlinkbe/application/trainer/criteria/AvailableTimesResult.java
+++ b/src/main/java/spring/fitlinkbe/application/trainer/criteria/AvailableTimesResult.java
@@ -1,0 +1,70 @@
+package spring.fitlinkbe.application.trainer.criteria;
+
+import lombok.Builder;
+import spring.fitlinkbe.domain.trainer.AvailableTime;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public class AvailableTimesResult {
+
+    @Builder
+    public record Response(
+            List<AvailableTimeResponse> currentSchedules,
+
+            ScheduledChangeResponse scheduledChanges
+    ) {
+        public static Response of(List<AvailableTime> currentSchedules, List<AvailableTime> scheduledSchedules) {
+            return Response.builder()
+                    .currentSchedules(currentSchedules.stream()
+                            .map(AvailableTimeResponse::from)
+                            .toList())
+                    .scheduledChanges(ScheduledChangeResponse.from(scheduledSchedules))
+                    .build();
+        }
+    }
+
+    @Builder
+    public record AvailableTimeResponse(
+            Long availableTimeId,
+
+            DayOfWeek dayOfWeek,
+
+            Boolean isHoliday,
+
+            LocalTime startTime,
+
+            LocalTime endTime
+    ) {
+        public static AvailableTimeResponse from(AvailableTime availableTime) {
+            return AvailableTimeResponse.builder()
+                    .availableTimeId(availableTime.getAvailableTimeId())
+                    .dayOfWeek(availableTime.getDayOfWeek())
+                    .isHoliday(availableTime.getIsHoliday())
+                    .startTime(availableTime.getStartTime())
+                    .endTime(availableTime.getEndTime())
+                    .build();
+        }
+    }
+
+    @Builder
+    public record ScheduledChangeResponse(
+            LocalDate applyAt,
+
+            List<AvailableTimeResponse> schedules
+    ) {
+        public static ScheduledChangeResponse from(List<AvailableTime> scheduledSchedules) {
+            if (scheduledSchedules.isEmpty()) return null;
+
+            return ScheduledChangeResponse.builder()
+                    .applyAt(scheduledSchedules.stream().findFirst().get().getApplyAt())
+                    .schedules(scheduledSchedules.stream()
+                            .map(AvailableTimeResponse::from)
+                            .toList())
+                    .build();
+        }
+    }
+}
+

--- a/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
@@ -9,6 +9,8 @@ public enum ErrorCode {
 
     // Trainer 관련 ErrorCode
     TRAINER_IS_NOT_FOUND("트레이너 정보가 존재하지 않습니다.", 404),
+    ALREADY_APPLIED_AVAILABLE_TIMES("이미 적용된 수업 시간이 있습니다.", 409),
+    ALREADY_SCHEDULED_AVAILABLE_TIMES("이미 적용 대기중인 스케줄이 있습니다.", 409),
 
     // Member 관련 ErrorCode
     MEMBER_DETAIL_NOT_FOUND("멤버 상세 정보를 찾지 못하였습니다", 404),
@@ -63,6 +65,7 @@ public enum ErrorCode {
     CONNECTING_INFO_NOT_FOUND("Connecting Info 정보가 존재하지 않습니다.", 404),
 
     INVALID_PARAMETER("유효하지 않은 파라미터입니다.", 400),
+
     ;
 
     private final String msg;

--- a/src/main/java/spring/fitlinkbe/domain/trainer/AvailableTime.java
+++ b/src/main/java/spring/fitlinkbe/domain/trainer/AvailableTime.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
@@ -20,6 +21,8 @@ public class AvailableTime {
     private Trainer trainer;
 
     private DayOfWeek dayOfWeek;
+
+    private LocalDate applyAt;
 
     private Boolean isHoliday;
 

--- a/src/main/java/spring/fitlinkbe/domain/trainer/AvailableTimeRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/trainer/AvailableTimeRepository.java
@@ -1,0 +1,12 @@
+package spring.fitlinkbe.domain.trainer;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface AvailableTimeRepository {
+    LocalDate getCurrentAppliedDate(Long trainerId);
+
+    LocalDate getScheduledAppliedDate(Long trainerId);
+
+    List<AvailableTime> getAvailableTimes(Long trainerId, LocalDate appliedDate);
+}

--- a/src/main/java/spring/fitlinkbe/domain/trainer/TrainerRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/trainer/TrainerRepository.java
@@ -19,5 +19,7 @@ public interface TrainerRepository {
 
     void saveAvailableTimes(List<AvailableTime> availableTimes);
 
+    AvailableTime saveAvailableTime(AvailableTime availableTime);
+
     Trainer getTrainerByCode(String trainerCode);
 }

--- a/src/main/java/spring/fitlinkbe/domain/trainer/TrainerService.java
+++ b/src/main/java/spring/fitlinkbe/domain/trainer/TrainerService.java
@@ -8,6 +8,8 @@ import spring.fitlinkbe.domain.common.PersonalDetailRepository;
 import spring.fitlinkbe.domain.common.exception.CustomException;
 import spring.fitlinkbe.domain.common.model.PersonalDetail;
 
+import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 
 import static spring.fitlinkbe.domain.common.exception.ErrorCode.TRAINER_IS_NOT_FOUND;
@@ -19,6 +21,7 @@ public class TrainerService {
 
     private final TrainerRepository trainerRepository;
     private final PersonalDetailRepository personalDetailRepository;
+    private final AvailableTimeRepository availableTimeRepository;
 
     @Transactional(readOnly = true)
     public Trainer getTrainerInfo(Long trainerId) {
@@ -56,5 +59,23 @@ public class TrainerService {
 
     public void savePersonalDetail(PersonalDetail personalDetail) {
         personalDetailRepository.savePersonalDetail(personalDetail);
+    }
+
+    public List<AvailableTime> getCurrentAvailableTimes(Long trainerId) {
+        LocalDate currentAppliedDate = availableTimeRepository.getCurrentAppliedDate(trainerId);
+        if (currentAppliedDate == null) {
+            return Collections.emptyList();
+        }
+
+        return availableTimeRepository.getAvailableTimes(trainerId, currentAppliedDate);
+    }
+
+    public List<AvailableTime> getScheduledAvailableTimes(Long trainerId) {
+        LocalDate scheduledAppliedDate = availableTimeRepository.getScheduledAppliedDate(trainerId);
+        if (scheduledAppliedDate == null) {
+            return Collections.emptyList();
+        }
+
+        return availableTimeRepository.getAvailableTimes(trainerId, scheduledAppliedDate);
     }
 }

--- a/src/main/java/spring/fitlinkbe/infra/trainer/AvailableTimeEntity.java
+++ b/src/main/java/spring/fitlinkbe/infra/trainer/AvailableTimeEntity.java
@@ -6,6 +6,7 @@ import spring.fitlinkbe.domain.trainer.AvailableTime;
 import spring.fitlinkbe.infra.common.model.BaseTimeEntity;
 
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalTime;
 
 @Entity
@@ -26,6 +27,8 @@ public class AvailableTimeEntity extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private DayOfWeek dayOfWeek;
 
+    private LocalDate applyAt;
+
     private Boolean isHoliday;
 
     private Boolean unavailable;
@@ -40,6 +43,7 @@ public class AvailableTimeEntity extends BaseTimeEntity {
                 .trainer(TrainerEntity.from(availableTime.getTrainer()))
                 .dayOfWeek(availableTime.getDayOfWeek())
                 .isHoliday(availableTime.getIsHoliday())
+                .applyAt(availableTime.getApplyAt())
                 .unavailable(availableTime.getUnavailable())
                 .startTime(availableTime.getStartTime())
                 .endTime(availableTime.getEndTime())
@@ -55,6 +59,7 @@ public class AvailableTimeEntity extends BaseTimeEntity {
                 .unavailable(unavailable)
                 .startTime(startTime)
                 .endTime(endTime)
+                .applyAt(applyAt)
                 .createdAt(getCreatedAt())
                 .updatedAt(getUpdatedAt())
                 .build();

--- a/src/main/java/spring/fitlinkbe/infra/trainer/AvailableTimeJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/trainer/AvailableTimeJpaRepository.java
@@ -3,7 +3,6 @@ package spring.fitlinkbe.infra.trainer;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import spring.fitlinkbe.domain.trainer.AvailableTime;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -24,6 +23,7 @@ public interface AvailableTimeJpaRepository extends JpaRepository<AvailableTimeE
     LocalDate getScheduledAppliedDate(Long trainerId);
 
     @Query("SELECT at FROM AvailableTimeEntity at " +
+            "JOIN FETCH at.trainer " +
             "WHERE at.trainer.trainerId = :trainerId " +
             "AND at.applyAt = :appliedDate")
     List<AvailableTimeEntity> findAllAvailableTimes(Long trainerId, LocalDate appliedDate);

--- a/src/main/java/spring/fitlinkbe/infra/trainer/AvailableTimeJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/trainer/AvailableTimeJpaRepository.java
@@ -2,11 +2,29 @@ package spring.fitlinkbe.infra.trainer;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import spring.fitlinkbe.domain.trainer.AvailableTime;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface AvailableTimeJpaRepository extends JpaRepository<AvailableTimeEntity, Long> {
 
     @EntityGraph(attributePaths = {"trainer"})
     List<AvailableTimeEntity> findAllByTrainer_TrainerId(Long trainerId);
+
+    @Query("SELECT MAX(at.applyAt) FROM AvailableTimeEntity at " +
+            "WHERE at.trainer.trainerId = :trainerId " +
+            "AND at.applyAt <= CURRENT_TIMESTAMP")
+    LocalDate getCurrentAppliedDate(Long trainerId);
+
+    @Query("SELECT MIN(at.applyAt) FROM AvailableTimeEntity at " +
+            "WHERE at.trainer.trainerId = :trainerId " +
+            "AND at.applyAt > CURRENT_TIMESTAMP")
+    LocalDate getScheduledAppliedDate(Long trainerId);
+
+    @Query("SELECT at FROM AvailableTimeEntity at " +
+            "WHERE at.trainer.trainerId = :trainerId " +
+            "AND at.applyAt = :appliedDate")
+    List<AvailableTimeEntity> findAllAvailableTimes(Long trainerId, LocalDate appliedDate);
 }

--- a/src/main/java/spring/fitlinkbe/infra/trainer/AvailableTimeRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/trainer/AvailableTimeRepositoryImpl.java
@@ -1,0 +1,32 @@
+package spring.fitlinkbe.infra.trainer;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import spring.fitlinkbe.domain.trainer.AvailableTime;
+import spring.fitlinkbe.domain.trainer.AvailableTimeRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class AvailableTimeRepositoryImpl implements AvailableTimeRepository {
+
+    private final AvailableTimeJpaRepository availableTimeJpaRepository;
+
+    @Override
+    public LocalDate getCurrentAppliedDate(Long trainerId) {
+        return availableTimeJpaRepository.getCurrentAppliedDate(trainerId);
+    }
+
+    @Override
+    public LocalDate getScheduledAppliedDate(Long trainerId) {
+        return availableTimeJpaRepository.getScheduledAppliedDate(trainerId);
+    }
+
+    @Override
+    public List<AvailableTime> getAvailableTimes(Long trainerId, LocalDate appliedDate) {
+        return availableTimeJpaRepository.findAllAvailableTimes(trainerId, appliedDate)
+                .stream().map(AvailableTimeEntity::toDomain).toList();
+    }
+}

--- a/src/main/java/spring/fitlinkbe/infra/trainer/TrainerRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/trainer/TrainerRepositoryImpl.java
@@ -78,6 +78,14 @@ public class TrainerRepositoryImpl implements TrainerRepository {
     }
 
     @Override
+    public AvailableTime saveAvailableTime(AvailableTime availableTime) {
+        AvailableTimeEntity savedEntity =
+                availableTimeJpaRepository.save(AvailableTimeEntity.from(availableTime));
+
+        return savedEntity.toDomain();
+    }
+
+    @Override
     public Trainer getTrainerByCode(String trainerCode) {
         return trainerJpaRepository.findByTrainerCode(trainerCode)
                 .orElseThrow(() -> new CustomException(ErrorCode.TRAINER_IS_NOT_FOUND)).toDomain();

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/trainer/TrainerController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/trainer/TrainerController.java
@@ -4,8 +4,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import spring.fitlinkbe.application.trainer.TrainerFacade;
+import spring.fitlinkbe.application.trainer.criteria.AvailableTimesResult;
 import spring.fitlinkbe.application.trainer.criteria.TrainerInfoResult;
 import spring.fitlinkbe.domain.common.enums.UserRole;
+import spring.fitlinkbe.interfaces.controller.trainer.dto.AvailableTimesDto;
 import spring.fitlinkbe.interfaces.controller.trainer.dto.TrainerInfoDto;
 import spring.fitlinkbe.support.aop.RoleCheck;
 import spring.fitlinkbe.support.argumentresolver.Login;
@@ -39,5 +41,12 @@ public class TrainerController {
         TrainerInfoResult.TrainerCodeResponse response = trainerFacade.getTrainerCode(user.getTrainerId());
 
         return TrainerInfoDto.TrainerCodeResponse.from(response);
+    }
+
+    @GetMapping("/me/available-times")
+    public AvailableTimesDto.Response getAvailableTimes(@Login SecurityUser user) {
+        AvailableTimesResult.Response response = trainerFacade.getAvailableTimes(user.getTrainerId());
+
+        return AvailableTimesDto.Response.from(response);
     }
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/trainer/TrainerController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/trainer/TrainerController.java
@@ -2,11 +2,13 @@ package spring.fitlinkbe.interfaces.controller.trainer;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import spring.fitlinkbe.application.trainer.TrainerFacade;
 import spring.fitlinkbe.application.trainer.criteria.AvailableTimesResult;
 import spring.fitlinkbe.application.trainer.criteria.TrainerInfoResult;
 import spring.fitlinkbe.domain.common.enums.UserRole;
+import spring.fitlinkbe.interfaces.controller.common.dto.ApiResultResponse;
 import spring.fitlinkbe.interfaces.controller.trainer.dto.AvailableTimesDto;
 import spring.fitlinkbe.interfaces.controller.trainer.dto.TrainerInfoDto;
 import spring.fitlinkbe.support.aop.RoleCheck;
@@ -48,5 +50,15 @@ public class TrainerController {
         AvailableTimesResult.Response response = trainerFacade.getAvailableTimes(user.getTrainerId());
 
         return AvailableTimesDto.Response.from(response);
+    }
+
+    @PostMapping("/me/available-times")
+    public ApiResultResponse<Object> saveAvailableTimes(
+            @Login SecurityUser user,
+            @Valid @RequestBody AvailableTimesDto.AddRequest request
+    ) {
+        trainerFacade.saveAvailableTimes(user.getTrainerId(), request.toCriteria());
+
+        return ApiResultResponse.of(HttpStatus.CREATED, true, null);
     }
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/trainer/dto/AvailableTimesDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/trainer/dto/AvailableTimesDto.java
@@ -1,0 +1,42 @@
+package spring.fitlinkbe.interfaces.controller.trainer.dto;
+
+import lombok.Builder;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public class AvailableTimesDto {
+
+    @Builder
+    public record Response(
+            List<AvailableTimeResponse> currentSchedules,
+
+            ScheduledChangeResponse scheduledChanges
+    ) {
+    }
+
+    @Builder
+    public record AvailableTimeResponse(
+            Long availableTimeId,
+
+            DayOfWeek dayOfWeek,
+
+            Boolean isHoliday,
+
+            LocalTime startTime,
+
+            LocalTime endTime
+    ) {
+    }
+
+    @Builder
+    public record ScheduledChangeResponse(
+            LocalDate applyAt,
+
+            List<AvailableTimeResponse> schedules
+    ) {
+    }
+}
+

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/trainer/dto/AvailableTimesDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/trainer/dto/AvailableTimesDto.java
@@ -66,5 +66,24 @@ public class AvailableTimesDto {
                     .build();
         }
     }
+
+    public record AddRequest(
+            LocalDate applyAt,
+            List<AvailableTimeRequest> scheduledChanges
+    ) {
+
+    }
+
+    public record AvailableTimeRequest(
+
+            DayOfWeek dayOfWeek,
+
+            Boolean isHoliday,
+
+            LocalTime startTime,
+
+            LocalTime endTime
+    ) {
+    }
 }
 

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/trainer/dto/AvailableTimesDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/trainer/dto/AvailableTimesDto.java
@@ -1,6 +1,7 @@
 package spring.fitlinkbe.interfaces.controller.trainer.dto;
 
 import lombok.Builder;
+import spring.fitlinkbe.application.trainer.criteria.AvailableTimesResult;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -15,6 +16,14 @@ public class AvailableTimesDto {
 
             ScheduledChangeResponse scheduledChanges
     ) {
+        public static Response from(AvailableTimesResult.Response response) {
+            return Response.builder()
+                    .currentSchedules(response.currentSchedules().stream()
+                            .map(AvailableTimeResponse::from)
+                            .toList())
+                    .scheduledChanges(ScheduledChangeResponse.from(response.scheduledChanges()))
+                    .build();
+        }
     }
 
     @Builder
@@ -29,6 +38,15 @@ public class AvailableTimesDto {
 
             LocalTime endTime
     ) {
+        public static AvailableTimeResponse from(AvailableTimesResult.AvailableTimeResponse availableTimeResponse) {
+            return AvailableTimeResponse.builder()
+                    .availableTimeId(availableTimeResponse.availableTimeId())
+                    .dayOfWeek(availableTimeResponse.dayOfWeek())
+                    .isHoliday(availableTimeResponse.isHoliday())
+                    .startTime(availableTimeResponse.startTime())
+                    .endTime(availableTimeResponse.endTime())
+                    .build();
+        }
     }
 
     @Builder
@@ -37,6 +55,16 @@ public class AvailableTimesDto {
 
             List<AvailableTimeResponse> schedules
     ) {
+        public static ScheduledChangeResponse from(AvailableTimesResult.ScheduledChangeResponse scheduledChangeResponse) {
+            if (scheduledChangeResponse == null) return null;
+
+            return ScheduledChangeResponse.builder()
+                    .applyAt(scheduledChangeResponse.applyAt())
+                    .schedules(scheduledChangeResponse.schedules().stream()
+                            .map(AvailableTimeResponse::from)
+                            .toList())
+                    .build();
+        }
     }
 }
 

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/trainer/dto/AvailableTimesDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/trainer/dto/AvailableTimesDto.java
@@ -1,6 +1,10 @@
 package spring.fitlinkbe.interfaces.controller.trainer.dto;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
+import spring.fitlinkbe.application.trainer.criteria.AvailableTimeCriteria;
 import spring.fitlinkbe.application.trainer.criteria.AvailableTimesResult;
 
 import java.time.DayOfWeek;
@@ -68,11 +72,44 @@ public class AvailableTimesDto {
     }
 
     public record AddRequest(
-            LocalDate applyAt,
-            List<AvailableTimeRequest> scheduledChanges
+            @NotNull LocalDate applyAt,
+            @Valid List<AvailableTimeRequest> availableTimes
     ) {
 
+        public AvailableTimeCriteria.AddRequest toCriteria() {
+            return AvailableTimeCriteria.AddRequest.builder()
+                    .applyAt(applyAt)
+                    .availableTimes(availableTimes.stream()
+                            .map(AvailableTimeRequest::toCriteria)
+                            .toList())
+                    .build();
+        }
+
+        @AssertTrue(message = "스케쥴 리스트는 비어있어선 안됩니다.")
+        public boolean isNotEmpty() {
+            return availableTimes != null && !availableTimes.isEmpty();
+        }
+
+        @AssertTrue(message = "요일은 겹칠 수 없습니다.")
+        public boolean isNotOverlap() {
+            return availableTimes == null || availableTimes.stream()
+                    .map(AvailableTimeRequest::dayOfWeek)
+                    .distinct()
+                    .count() == availableTimes.size();
+        }
+
+        @AssertTrue(message = "적용 날짜는 오늘 이후여야 합니다.")
+        public boolean isFutureApplyAt() {
+            return applyAt == null || applyAt.isAfter(LocalDate.now()) || applyAt.isEqual(LocalDate.now());
+        }
+
+        @AssertTrue(message = "시작 시간은 종료 시간보다 빨라야 합니다.")
+        public boolean isStartTimeBeforeEndTime() {
+            return availableTimes == null || availableTimes.stream()
+                    .allMatch(scheduledChange -> scheduledChange.startTime().isBefore(scheduledChange.endTime()));
+        }
     }
+
 
     public record AvailableTimeRequest(
 
@@ -80,10 +117,18 @@ public class AvailableTimesDto {
 
             Boolean isHoliday,
 
-            LocalTime startTime,
+            @NotNull LocalTime startTime,
 
-            LocalTime endTime
+            @NotNull LocalTime endTime
     ) {
+        public AvailableTimeCriteria.AvailableTimeRequest toCriteria() {
+            return AvailableTimeCriteria.AvailableTimeRequest.builder()
+                    .dayOfWeek(dayOfWeek)
+                    .isHoliday(isHoliday)
+                    .startTime(startTime)
+                    .endTime(endTime)
+                    .build();
+        }
     }
 }
 

--- a/src/test/java/spring/fitlinkbe/integration/TrainerIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/TrainerIntegrationTest.java
@@ -322,7 +322,7 @@ public class TrainerIntegrationTest extends BaseIntegrationTest {
 
                 AvailableTimesDto.Response availableTimes = readValue(result.body().jsonPath().prettify(), AvailableTimesDto.Response.class);
 
-                softly.assertThat(availableTimes.currentSchedules()).isNull();
+                softly.assertThat(availableTimes.currentSchedules()).isEmpty();
                 softly.assertThat(availableTimes.scheduledChanges().schedules().size()).isEqualTo(4);
                 softly.assertThat(availableTimes.scheduledChanges().applyAt()).isEqualTo(scheduledDate);
             });

--- a/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
+++ b/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
@@ -16,6 +16,7 @@ import spring.fitlinkbe.domain.member.WorkoutScheduleRepository;
 import spring.fitlinkbe.domain.reservation.Reservation;
 import spring.fitlinkbe.domain.reservation.ReservationRepository;
 import spring.fitlinkbe.domain.reservation.Session;
+import spring.fitlinkbe.domain.trainer.AvailableTime;
 import spring.fitlinkbe.domain.trainer.Trainer;
 import spring.fitlinkbe.domain.trainer.TrainerRepository;
 import spring.fitlinkbe.support.security.AuthTokenProvider;
@@ -287,5 +288,19 @@ public class TestDataHandler {
                 .isCompleted(true)
                 .build();
         return reservationRepository.saveSession(session).orElseThrow();
+    }
+
+    public void createAvailableTime(Trainer trainer, DayOfWeek dayOfWeek, LocalDate applyAt) {
+        AvailableTime availableTime = AvailableTime.builder()
+                .trainer(trainer)
+                .dayOfWeek(dayOfWeek)
+                .applyAt(applyAt)
+                .isHoliday(false)
+                .unavailable(false)
+                .startTime(LocalTime.of(10, 0))
+                .endTime(LocalTime.of(12, 0))
+                .build();
+
+        trainerRepository.saveAvailableTime(availableTime);
     }
 }


### PR DESCRIPTION
### 작업 사항
- GET `/v1/trainers/me/available-times` api 작업
- POST `/v1/trainers/me/available-times` api 작업

### DB 수정 사항
- available_time Table에 apply_at 컬럼 LocalDate 타입으로 추가했습니다.
- 적용 예정 시간 개념 때문에 추가했고, 기존에 unavailable 컬럼이 적용 예정 시간 때문에 추가한 것으로 보이는데 apply_at 컬럼으로 관리하는게 더 간단할 것 같아 새로 추가했습니다.
  - 이 방식이 괜찮다면 추후 unavailable 컬럼은 삭제해도 괜찮을 것 같아요