### PR TITLE
[Fliz-152] BE 진행한 PT 처리 API

### DIFF
--- a/docker/mysql/initdb.d/create_table.sql
+++ b/docker/mysql/initdb.d/create_table.sql
@@ -86,7 +86,7 @@ CREATE TABLE token
 CREATE TABLE workout_schedule
 (
     workout_schedule_id BIGINT NOT NULL AUTO_INCREMENT,
-    day_of_week       ENUM ('MONDAY', 'TUESDAY', 'WEDNESDAY','THURSDAY','FRIDAY','SATURDAY','SUNDAY'),
+    day_of_week         ENUM ('MONDAY', 'TUESDAY', 'WEDNESDAY','THURSDAY','FRIDAY','SATURDAY','SUNDAY'),
     member_id           BIGINT,
     preference_times    JSON,
     created_at          DATETIME(6),
@@ -100,7 +100,7 @@ CREATE TABLE available_time
     available_time_id BIGINT NOT NULL AUTO_INCREMENT,
     trainer_id        BIGINT,
     is_holiday        BOOLEAN,
-    unavailable       BOOLEAN,
+    apply_at          DATETIME(6),
     day_of_week       ENUM ('MONDAY', 'TUESDAY', 'WEDNESDAY','THURSDAY','FRIDAY','SATURDAY','SUNDAY'),
     start_time        TIME,
     end_time          TIME,
@@ -136,19 +136,19 @@ CREATE TABLE session
 -- 예약 정보 테이블
 CREATE TABLE reservation
 (
-    reservation_id   BIGINT      NOT NULL AUTO_INCREMENT,
-    member_id        BIGINT,
-    trainer_id       BIGINT,
-    session_info_id  BIGINT,
-    name             VARCHAR(255),
-    reservation_dates JSON NOT NULL,
-    change_date      DATETIME(6),
-    status           ENUM ('FIXED_RESERVATION','DISABLED_TIME_RESERVATION', 'RESERVATION_WAITING','RESERVATION_APPROVED',
+    reservation_id    BIGINT NOT NULL AUTO_INCREMENT,
+    member_id         BIGINT,
+    trainer_id        BIGINT,
+    session_info_id   BIGINT,
+    name              VARCHAR(255),
+    reservation_dates JSON   NOT NULL,
+    change_date       DATETIME(6),
+    status            ENUM ('FIXED_RESERVATION','DISABLED_TIME_RESERVATION', 'RESERVATION_WAITING','RESERVATION_APPROVED',
         'RESERVATION_CANCELLED', 'RESERVATION_REFUSED', 'RESERVATION_CHANGE_REQUEST', 'RESERVATION_COMPLETED'),
-    cancel_reason    VARCHAR(255),
-    is_day_off       BOOLEAN,
-    created_at       DATETIME(6),
-    updated_at       DATETIME(6),
+    cancel_reason     VARCHAR(255),
+    is_day_off        BOOLEAN,
+    created_at        DATETIME(6),
+    updated_at        DATETIME(6),
     PRIMARY KEY (reservation_id)
 );
 

--- a/src/main/java/spring/fitlinkbe/application/reservation/criteria/ReservationCriteria.java
+++ b/src/main/java/spring/fitlinkbe/application/reservation/criteria/ReservationCriteria.java
@@ -95,4 +95,23 @@ public class ReservationCriteria {
                     .build();
         }
     }
+
+    @Builder(toBuilder = true)
+    public record CompleteSession(Long memberId, Long reservationId, Boolean isJoin) {
+        public ReservationCommand.CompleteSession toCompleteSessionCommand() {
+
+            return ReservationCommand.CompleteSession.builder()
+                    .reservationId(reservationId)
+                    .isJoin(isJoin)
+                    .build();
+        }
+
+        public ReservationCommand.CompleteReservation toCompleteReservationCommand() {
+            return ReservationCommand.CompleteReservation.builder()
+                    .reservationId(reservationId)
+                    .memberId(memberId)
+                    .build();
+        }
+    }
+
 }

--- a/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
@@ -27,12 +27,15 @@ public enum ErrorCode {
     // Reservation 관련 ErrorCode
 
     RESERVATION_IS_FAILED("예약에 실패하였습니다.", 400),
+
     RESERVATION_NOT_ALLOWED("예약을 할 수 있는 상태가 아닙니다.", 400),
     SET_DISABLE_DATE_FAILED("예약 불가 설정에 실패하였습니다.", 400),
     RESERVATION_CANCEL_FAILED("예약 취소에 실패하였습니다.", 400),
     RESERVATION_IS_ALREADY_CANCEL("이미 예약이 취소되었습니다.", 400),
     RESERVATION_IS_NOT_WAITING_STATUS("예약 상태가 대기 상태가 아닙니다.", 400),
     RESERVATION_WAITING_MEMBERS_EMPTY("이 날짜에 예약 대기자가 없습니다.", 400),
+    RESERVATION_COMPLETE_NOT_ALLOWED("다른 사람의 예약을 완료시킬 수 없습니다.", 400),
+    RESERVATION_IS_ALREADY_COMPLETED("이미 예약이 완료되었습니다.", 400),
     RESERVATION_CANCEL_NOT_ALLOWED("예약 취소를 할 수 없는 상태입니다.", 400),
     RESERVATION_REFUSE_NOT_ALLOWED("예약 거절을 할 수 없는 상태입니다.", 400),
     RESERVATION_APPROVE_NOT_ALLOWED("예약 확정을 할 수 없는 상태입니다.", 400),
@@ -46,6 +49,7 @@ public enum ErrorCode {
     SESSION_NOT_FOUND("세션 정보를 찾지 못하였습니다.", 404),
     SESSION_IS_ALREADY_CANCEL("이미 세션이 취소되었습니다.", 400),
     SESSION_IS_ALREADY_END("이미 세션이 종료되었습니다.", 400),
+    SESSION_REMAINING_COUNT_NOT_VALID("세션 남은 횟수가 0보다 작습니다", 400),
 
     // Notification 관련 ErrorCode
     NOTIFICATION_NOT_FOUND("알림 정보를 찾지 못하였습니다.", 404),

--- a/src/main/java/spring/fitlinkbe/domain/common/model/SessionInfo.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/model/SessionInfo.java
@@ -55,4 +55,12 @@ public class SessionInfo {
     public void restoreSession() {
         remainingCount++;
     }
+
+    public void deductSession() {
+        if (remainingCount <= 0) {
+            throw new CustomException(ErrorCode.SESSION_REMAINING_COUNT_NOT_VALID,
+                    "남은 PT 횟수가 0보다 작습니다. [count: %d]".formatted(remainingCount));
+        }
+        remainingCount--;
+    }
 }

--- a/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
+++ b/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
@@ -63,7 +63,7 @@ public class MemberService {
     /**
      * 이미 연결된, 연결 시도중인 트레이너가 있는지 확인
      *
-     * @param memberId
+     * @param memberId 연결 확인할 멤버 ID
      * @throws CustomException 이미 연결된, 연결 시도중인 트레이너가 있을 경우
      */
     public void checkMemberAlreadyConnected(Long memberId) {
@@ -152,6 +152,7 @@ public class MemberService {
 
     /**
      * 연결된 정보 조회
+     *
      * @return 해당 회원과 연동 완료된 (Connected) 상태의 연결 정보
      */
     public ConnectingInfo findConnectedInfo(Long memberId) {
@@ -171,6 +172,15 @@ public class MemberService {
 
     public List<SessionInfo> findAllSessionInfo(List<Long> memberIds, Long trainerId) {
         return sessionInfoRepository.findAllSessionInfo(memberIds, trainerId);
+    }
+
+    /**
+     * 세션 차감
+     */
+    public void deductSession(Long trainerId, Long memberId) {
+        SessionInfo getSessionInfo = this.getSessionInfo(trainerId, memberId);
+        getSessionInfo.deductSession();
+        this.saveSessionInfo(getSessionInfo);
     }
 
     /**

--- a/src/main/java/spring/fitlinkbe/domain/notification/Notification.java
+++ b/src/main/java/spring/fitlinkbe/domain/notification/Notification.java
@@ -146,6 +146,23 @@ public class Notification {
                 .build();
     }
 
+    public static Notification completeSessionNotification(Long sessionId, PersonalDetail memberDetail) {
+
+        String content = " PT 완료로 횟수가 1회 차감되었습니다.";
+
+        return Notification.builder()
+                .refId(sessionId)
+                .refType(ReferenceType.SESSION)
+                .notificationType(NotificationType.SESSION_DEDUCTED)
+                .personalDetail(memberDetail)
+                .name(NotificationType.SESSION_DEDUCTED.name)
+                .content(content)
+                .isSent(true)
+                .isProcessed(false)
+                .sendDate(LocalDateTime.now())
+                .build();
+    }
+
     @RequiredArgsConstructor
     @Getter
     public enum ReferenceType {

--- a/src/main/java/spring/fitlinkbe/domain/notification/NotificationService.java
+++ b/src/main/java/spring/fitlinkbe/domain/notification/NotificationService.java
@@ -48,4 +48,10 @@ public class NotificationService {
         Notification notification = requestReservationNotification(reservation, trainerDetail);
         notificationRepository.save(notification);
     }
+
+    public void sendCompleteSessionNotification(Long sessionId, PersonalDetail memberDetail) {
+        Notification notification = completeSessionNotification(sessionId, memberDetail);
+        notificationRepository.save(notification);
+
+    }
 }

--- a/src/main/java/spring/fitlinkbe/domain/reservation/Reservation.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/Reservation.java
@@ -132,6 +132,18 @@ public class Reservation {
         this.status = RESERVATION_REFUSED;
     }
 
+    public void complete(Long trainerId, Long memberId) {
+        if (!trainerId.equals(trainer.getTrainerId()) || !memberId.equals(member.getMemberId())) {
+            throw new CustomException(RESERVATION_COMPLETE_NOT_ALLOWED);
+        }
+
+        if (this.status == RESERVATION_COMPLETED) {
+            throw new CustomException(RESERVATION_IS_ALREADY_COMPLETED);
+        }
+
+        this.status = RESERVATION_COMPLETED;
+    }
+
     public void cancel(String message) {
         if (status == RESERVATION_CANCELLED) {
             throw new CustomException(RESERVATION_IS_ALREADY_CANCEL);

--- a/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
@@ -226,6 +226,32 @@ public class ReservationService {
     }
 
     @Transactional
+    public Session completeSession(ReservationCommand.CompleteSession command) {
+
+        Session getSession = reservationRepository.getSession(command.reservationId()).orElseThrow(() ->
+                new CustomException(ErrorCode.SESSION_NOT_FOUND,
+                        "세션 정보를 찾지 못하였습니다. [reservationId: %d].".formatted(command.reservationId())));
+
+        getSession.complete(command.isJoin());
+
+        return reservationRepository.saveSession(getSession).orElseThrow(() ->
+                new CustomException(ErrorCode.SESSION_CREATE_FAILED));
+
+    }
+
+    @Transactional
+    public Reservation completeReservation(ReservationCommand.CompleteReservation command, SecurityUser user) {
+        Reservation getReservation = reservationRepository.getReservation(command.reservationId()).orElseThrow(() ->
+                new CustomException(ErrorCode.RESERVATION_NOT_FOUND,
+                        "예약 정보를 찾지 못하였습니다. [reservationId: %d].".formatted(command.reservationId())));
+
+        getReservation.complete(user.getTrainerId(), command.memberId());
+
+        return reservationRepository.saveReservation(getReservation).orElseThrow(() ->
+                new CustomException(ErrorCode.RESERVATION_IS_FAILED));
+    }
+
+    @Transactional
     public Session saveSession(Reservation savedReservation) {
 
         Session session = Session.builder()

--- a/src/main/java/spring/fitlinkbe/domain/reservation/Session.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/Session.java
@@ -1,10 +1,7 @@
 package spring.fitlinkbe.domain.reservation;
 
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import spring.fitlinkbe.domain.common.exception.CustomException;
 
 import static spring.fitlinkbe.domain.common.exception.ErrorCode.SESSION_IS_ALREADY_CANCEL;
@@ -21,12 +18,16 @@ public class Session {
     private String cancelReason;
     private boolean isCompleted;
 
+    @RequiredArgsConstructor
+    @Getter
     public enum Status {
 
-        SESSION_CANCELLED, // 세션 취소
-        SESSION_WAITING, // 세션 대기
-        SESSION_NOT_ATTEND, // 세션 불참석
-        SESSION_COMPLETED, // 세션 완료
+        SESSION_CANCELLED("세션 취소"), // 세션 취소
+        SESSION_WAITING("세션 대기"), // 세션 대기
+        SESSION_NOT_ATTEND("세션 불참석"), // 세션 불참석
+        SESSION_COMPLETED("세션 완료"); // 세션 완료
+
+        private final String name;
     }
 
     public void cancel(String message) {
@@ -38,6 +39,14 @@ public class Session {
         }
         cancelReason = message;
         status = Status.SESSION_CANCELLED;
+    }
+
+    public void complete(boolean join) {
+        if (status == Status.SESSION_NOT_ATTEND || status == Status.SESSION_COMPLETED) {
+            throw new CustomException(SESSION_IS_ALREADY_END);
+        }
+
+        status = join ? Status.SESSION_COMPLETED : Status.SESSION_NOT_ATTEND;
     }
 
 

--- a/src/main/java/spring/fitlinkbe/domain/reservation/command/ReservationCommand.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/command/ReservationCommand.java
@@ -60,4 +60,12 @@ public class ReservationCommand {
     public record CancelReservation(Long reservationId, String cancelReason) {
 
     }
+
+    @Builder(toBuilder = true)
+    public record CompleteSession(Long reservationId, Boolean isJoin) {
+    }
+
+    @Builder(toBuilder = true)
+    public record CompleteReservation(Long reservationId, Long memberId) {
+    }
 }

--- a/src/main/java/spring/fitlinkbe/domain/trainer/AvailableTime.java
+++ b/src/main/java/spring/fitlinkbe/domain/trainer/AvailableTime.java
@@ -26,8 +26,6 @@ public class AvailableTime {
 
     private Boolean isHoliday;
 
-    private Boolean unavailable;
-
     private LocalTime startTime;
 
     private LocalTime endTime;

--- a/src/main/java/spring/fitlinkbe/infra/trainer/AvailableTimeEntity.java
+++ b/src/main/java/spring/fitlinkbe/infra/trainer/AvailableTimeEntity.java
@@ -31,8 +31,6 @@ public class AvailableTimeEntity extends BaseTimeEntity {
 
     private Boolean isHoliday;
 
-    private Boolean unavailable;
-
     private LocalTime startTime;
 
     private LocalTime endTime;
@@ -44,7 +42,6 @@ public class AvailableTimeEntity extends BaseTimeEntity {
                 .dayOfWeek(availableTime.getDayOfWeek())
                 .isHoliday(availableTime.getIsHoliday())
                 .applyAt(availableTime.getApplyAt())
-                .unavailable(availableTime.getUnavailable())
                 .startTime(availableTime.getStartTime())
                 .endTime(availableTime.getEndTime())
                 .build();
@@ -56,7 +53,6 @@ public class AvailableTimeEntity extends BaseTimeEntity {
                 .trainer(trainer.toDomain())
                 .dayOfWeek(dayOfWeek)
                 .isHoliday(isHoliday)
-                .unavailable(unavailable)
                 .startTime(startTime)
                 .endTime(endTime)
                 .applyAt(applyAt)

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
@@ -9,6 +9,7 @@ import spring.fitlinkbe.application.reservation.ReservationFacade;
 import spring.fitlinkbe.application.reservation.criteria.ReservationResult;
 import spring.fitlinkbe.domain.common.enums.UserRole;
 import spring.fitlinkbe.domain.reservation.Reservation;
+import spring.fitlinkbe.domain.reservation.Session;
 import spring.fitlinkbe.interfaces.controller.common.dto.ApiResultResponse;
 import spring.fitlinkbe.interfaces.controller.reservation.dto.ReservationRequestDto;
 import spring.fitlinkbe.interfaces.controller.reservation.dto.ReservationResponseDto;
@@ -183,6 +184,28 @@ public class ReservationController {
         Reservation result = reservationFacade.approveReservation(request.toCriteria(reservationId), user);
 
         return ApiResultResponse.ok(ReservationResponseDto.Success.of(result));
+
+    }
+
+    /**
+     * 진행한 PT 처리
+     *
+     * @param request isJoin 정보
+     * @return ApiResultResponse 진행한 sessionId 결과를 반환한다.
+     */
+    @RoleCheck(allowedRoles = {UserRole.TRAINER})
+    @PostMapping("{reservationId}/sessions/complete")
+    public ApiResultResponse<ReservationResponseDto.SuccessSession> completeSession(@PathVariable("reservationId")
+                                                                                    @NotNull(message = "예약 ID는 필수값입니다.")
+                                                                                    Long reservationId,
+                                                                                    @RequestBody @Valid
+                                                                                    ReservationRequestDto.CompleteSession
+                                                                                            request,
+                                                                                    @Login SecurityUser user
+    ) {
+        Session result = reservationFacade.completeSession(request.toCriteria(reservationId), user);
+
+        return ApiResultResponse.ok(ReservationResponseDto.SuccessSession.of(result));
 
     }
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationRequestDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationRequestDto.java
@@ -89,4 +89,17 @@ public class ReservationRequestDto {
                     .build();
         }
     }
+
+    @Builder(toBuilder = true)
+    public record CompleteSession(@NotNull(message = "유저 ID는 필수값 입니다.") Long memberId,
+                                  @NotNull(message = "참석 여부는 필수값 입니다.") Boolean isJoin) {
+
+        public ReservationCriteria.CompleteSession toCriteria(Long reservationId) {
+            return ReservationCriteria.CompleteSession.builder()
+                    .reservationId(reservationId)
+                    .memberId(memberId)
+                    .isJoin(isJoin)
+                    .build();
+        }
+    }
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationResponseDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationResponseDto.java
@@ -3,6 +3,7 @@ package spring.fitlinkbe.interfaces.controller.reservation.dto;
 import lombok.Builder;
 import spring.fitlinkbe.application.reservation.criteria.ReservationResult;
 import spring.fitlinkbe.domain.reservation.Reservation;
+import spring.fitlinkbe.domain.reservation.Session;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -19,6 +20,17 @@ public class ReservationResponseDto {
             return Success.builder()
                     .reservationId(reservation.getReservationId())
                     .status(reservation.getStatus().getName())
+                    .build();
+        }
+    }
+
+    @Builder(toBuilder = true)
+    public record SuccessSession(Long sessionId, String status) {
+        public static ReservationResponseDto.SuccessSession of(Session session) {
+
+            return SuccessSession.builder()
+                    .sessionId(session.getSessionId())
+                    .status(session.getStatus().getName())
                     .build();
         }
     }

--- a/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
+++ b/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
@@ -183,6 +183,7 @@ public class TestDataHandler {
         SessionInfo sessionInfo = SessionInfo.builder()
                 .trainer(trainer)
                 .member(member)
+                .remainingCount(10)
                 .build();
 
         sessionInfoRepository.saveSessionInfo(sessionInfo);
@@ -296,7 +297,6 @@ public class TestDataHandler {
                 .dayOfWeek(dayOfWeek)
                 .applyAt(applyAt)
                 .isHoliday(false)
-                .unavailable(false)
                 .startTime(LocalTime.of(10, 0))
                 .endTime(LocalTime.of(12, 0))
                 .build();


### PR DESCRIPTION
### 구현 기능

- `POST` "/v1/reservations/{reservationId}/sessions/complete" 진행한 PT 처리 API

### 세부 사항

- 진행한 PT 처리 API 개발 완료
- 테스트 코드 추가
- 예외 상황에서 커스텀 메세지 추가

### DB 변동사항

- available_time 테이블 변경
    - apply_at 컬럼 추가, unavailable 컬럼 제거
    - unavailable 컬럼 도메인에서 제거