### PR TITLE
[FLIZ-156] 이메일 인증 토큰 발급 api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+    /* Redis */
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/spring/fitlinkbe/application/auth/AuthFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/auth/AuthFacade.java
@@ -71,4 +71,8 @@ public class AuthFacade {
 
         return AuthCommand.Response.of(accessToken, refreshToken);
     }
+
+    public String getEmailVerificationToken(Long personalDetailId) {
+        return authService.createEmailVerificationToken(personalDetailId);
+    }
 }

--- a/src/main/java/spring/fitlinkbe/domain/auth/AuthService.java
+++ b/src/main/java/spring/fitlinkbe/domain/auth/AuthService.java
@@ -3,8 +3,12 @@ package spring.fitlinkbe.domain.auth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import spring.fitlinkbe.domain.common.EmailTokenRepository;
 import spring.fitlinkbe.domain.common.TokenRepository;
 import spring.fitlinkbe.domain.common.model.Token;
+
+import java.security.SecureRandom;
+import java.util.Base64;
 
 @Service
 @Transactional
@@ -12,8 +16,26 @@ import spring.fitlinkbe.domain.common.model.Token;
 public class AuthService {
 
     private final TokenRepository tokenRepository;
+    private final EmailTokenRepository emailTokenRepository;
 
     public void saveOrUpdateToken(Token token) {
         tokenRepository.saveOrUpdate(token);
+    }
+
+    public String createEmailVerificationToken(Long personalDetailId) {
+        String emailVerificationToken = generateToken();
+        emailTokenRepository.saveToken(personalDetailId, emailVerificationToken);
+
+        return emailVerificationToken;
+    }
+
+    public static String generateToken() {
+        // 128비트(16바이트) 난수 생성
+        SecureRandom secureRandom = new SecureRandom();
+        byte[] randomBytes = new byte[16];
+        secureRandom.nextBytes(randomBytes);
+
+        // URL-safe Base64 인코딩, 패딩 없이
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
     }
 }

--- a/src/main/java/spring/fitlinkbe/domain/common/EmailTokenRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/EmailTokenRepository.java
@@ -1,0 +1,5 @@
+package spring.fitlinkbe.domain.common;
+
+public interface EmailTokenRepository {
+    void saveToken(Long personalDetailId, String emailVerificationToken);
+}

--- a/src/main/java/spring/fitlinkbe/infra/common/token/EmailTokenRedisRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/common/token/EmailTokenRedisRepository.java
@@ -1,0 +1,22 @@
+package spring.fitlinkbe.infra.common.token;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+import spring.fitlinkbe.domain.common.EmailTokenRepository;
+
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@RequiredArgsConstructor
+public class EmailTokenRedisRepository implements EmailTokenRepository {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final long TOKEN_EXPIRATION_TIME = 5 * 60; // 5분
+
+    @Override
+    public void saveToken(Long personalDetailId, String emailVerificationToken) {
+        redisTemplate.opsForValue().set(emailVerificationToken, personalDetailId.toString(), TOKEN_EXPIRATION_TIME, TimeUnit.SECONDS);
+    }
+}

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/auth/AuthController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/auth/AuthController.java
@@ -2,10 +2,7 @@ package spring.fitlinkbe.interfaces.controller.auth;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import spring.fitlinkbe.application.auth.AuthFacade;
 import spring.fitlinkbe.domain.auth.command.AuthCommand;
 import spring.fitlinkbe.domain.common.enums.UserRole;
@@ -52,6 +49,21 @@ public class AuthController {
         return ApiResultResponse.ok(AuthDto.Response.from(result));
     }
 
+    @GetMapping("/email-verification-token")
+    public ApiResultResponse<AuthDto.EmailAuthTokenResponse> getEmailVerificationToken(
+            @Login SecurityUser user
+    ) {
+        checkUserStatusOrThrow(user);
+        String verificationToken = authFacade.getEmailVerificationToken(user.getPersonalDetailId());
+
+        return ApiResultResponse.ok(new AuthDto.EmailAuthTokenResponse(verificationToken));
+    }
+
+    /**
+     * 유저의 상태가 REQUIRED_SMS 상태인지 확인
+     *
+     * @throws CustomException REQUIRED_SMS 상태가 아닐 경우
+     */
     private void checkUserStatusOrThrow(SecurityUser user) {
         if (user.getStatus() != PersonalDetail.Status.REQUIRED_SMS) {
             throw new CustomException(ErrorCode.NEED_REQUIRED_SMS_STATUS);

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/auth/dto/AuthDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/auth/dto/AuthDto.java
@@ -18,6 +18,12 @@ import java.util.List;
 public class AuthDto {
 
     @Builder
+    public record EmailAuthTokenResponse(
+            String verificationToken
+    ){}
+
+
+    @Builder
     public record Response(String accessToken, String refreshToken) {
 
         public static Response from(AuthCommand.Response so) {

--- a/src/main/java/spring/fitlinkbe/support/config/RedisConfig.java
+++ b/src/main/java/spring/fitlinkbe/support/config/RedisConfig.java
@@ -1,0 +1,18 @@
+package spring.fitlinkbe.support.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        final RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        return redisTemplate;
+    }
+}

--- a/src/main/java/spring/fitlinkbe/support/config/SecurityConfig.java
+++ b/src/main/java/spring/fitlinkbe/support/config/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
     private static final WhiteListUrl registerUrls = new WhiteListUrl(List.of(
             "v1/auth/members/register",
             "v1/auth/trainers/register",
+            "v1/auth/email-verification-token",
             "/oauth2/authorization/**"
     ));
 

--- a/src/test/java/spring/fitlinkbe/integration/AuthIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/AuthIntegrationTest.java
@@ -721,7 +721,7 @@ public class AuthIntegrationTest extends BaseIntegrationTest {
 
             // when
             // 이메일 인증 코드 발급 요청을 보낸다면
-            ExtractableResponse<Response> result = post(EMAIL_AUTH_API, null, accessToken);
+            ExtractableResponse<Response> result = get(EMAIL_AUTH_API, accessToken);
 
             // then
             // 요청에 성공해야 한다
@@ -745,7 +745,7 @@ public class AuthIntegrationTest extends BaseIntegrationTest {
 
             // when
             // 이메일 인증 코드 발급 요청을 보낸다면
-            ExtractableResponse<Response> result = post(EMAIL_AUTH_API, null, accessToken);
+            ExtractableResponse<Response> result = get(EMAIL_AUTH_API, accessToken);
 
             // then
             // 에러를 반환한다

--- a/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
+++ b/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
@@ -87,7 +87,7 @@ public class TestDataHandler {
                 .build();
 
         Member saved = memberRepository.saveMember(member).orElseThrow();
-        createPersonalDetail(status, member.getMemberId());
+        createPersonalDetail(status, saved.getMemberId());
         return saved;
     }
 

--- a/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
+++ b/src/test/java/spring/fitlinkbe/integration/common/TestDataHandler.java
@@ -78,6 +78,19 @@ public class TestDataHandler {
         return saved;
     }
 
+    public Member createMember(PersonalDetail.Status status) {
+        Member member = Member.builder()
+                .name("김민수")
+                .birthDate(LocalDate.of(1995, 1, 1))
+                .phoneNumber(new PhoneNumber("01012345678"))
+                .isConnected(false)
+                .build();
+
+        Member saved = memberRepository.saveMember(member).orElseThrow();
+        createPersonalDetail(status, member.getMemberId());
+        return saved;
+    }
+
     public Member createMember(String name) {
         Member member = Member.builder()
                 .name(name)
@@ -132,6 +145,22 @@ public class TestDataHandler {
         PersonalDetail personalDetail = PersonalDetail.builder()
                 .name("홍길동")
                 .email("test@testcode.co.kr")
+                .status(status)
+                .oauthProvider(PersonalDetail.OauthProvider.GOOGLE)
+                .providerId(UUID.randomUUID().toString())
+                .build();
+
+        return personalDetailRepository.savePersonalDetail(personalDetail).orElseThrow();
+    }
+
+    public PersonalDetail createPersonalDetail(
+            PersonalDetail.Status status,
+            Long memberId
+    ) {
+        PersonalDetail personalDetail = PersonalDetail.builder()
+                .name("홍길동")
+                .email("test@testcode.co.kr")
+                .memberId(memberId)
                 .status(status)
                 .oauthProvider(PersonalDetail.OauthProvider.GOOGLE)
                 .providerId(UUID.randomUUID().toString())
@@ -303,4 +332,5 @@ public class TestDataHandler {
 
         trainerRepository.saveAvailableTime(availableTime);
     }
+
 }


### PR DESCRIPTION
### 작업 사항
- GET `/v1/auth/email-verification-token` 작업입니다

### 세부 사항
- 인증 토큰은 Redis에서 <token, personal_detail_id> 형태로 저장했습니다
  - 나중에 이메일에서 토큰 수신시 어떤 유저의 토큰인지 식별하기 위해 Redis의 String 자료구조 사용했습니다.
  - 토큰의 TTL을 주기에도 Redis가 적합해 보여서 선택했습니다
  - 혹시 더 좋은 저장 방식 있으면 알려주세요!
- 이메일 인증 (전화번호 인증) 플로우
  - 1. 유저 소셜 로그인 후 인증 토큰 발급
  - 2. 유저는 인증 토큰을 핸드폰 메세지에 넣고 서버 이메일 주소 (AWS SES 사용 예정)에 전송
  - 3. 서버는 SES로부터 수신한 이메일을 받아 토큰으로 유저 식별 + 핸드폰 번호 등록 과정, 상태를 REGISTERED로 수정
- 기존엔 Register api에서 전화번호 + PT 가능시간을 받았지만 전화번호는 이제 SES를 통해 받아올 것이기 때문에 기존 Register api는 REGISTERED 상태에서만 요청 가능하게 REQUIRED_SMS 상태에서는 토큰 발급 요청만 가능하도록 수정 예정입니다.