### PR TITLE
[Fliz 159] BE 예약 변경 요청 API

### DIFF
--- a/src/main/java/spring/fitlinkbe/application/reservation/ReservationFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/reservation/ReservationFacade.java
@@ -137,7 +137,8 @@ public class ReservationFacade {
                     memberService.getMemberDetail(reservation.getMember().getMemberId()), RESERVATION_REFUSE);
             return reservation;
         }
-        // 멤버 -> 트레이너에게 예약 취소됐다는 알림을 보낸다.
+        // 멤버의 경우
+        // 멤버 -> 트레이너에게 예약 취소 요청 알림을 보낸다.
         notificationService.sendCancelRequestReservationNotification(reservation.getReservationId(), reservation.getName(),
                 trainerService.getTrainerDetail(reservation.getTrainer().getTrainerId()), RESERVATION_CANCEL_REQUEST);
         return reservation;
@@ -199,6 +200,18 @@ public class ReservationFacade {
         return completedSession;
     }
 
+    @Transactional
+    public Reservation changeReqeustReservation(ReservationCriteria.ChangeReqeustReservation criteria) {
+        // 예약 변경 요청
+        Reservation requestedReservation = reservationService.changeReqeustReservation(criteria.toCommand());
+        // 알람 전송 멤버 -> 트레이너에게 예약 변경 요청했다는 알람 발송
+        notificationService.sendChangeRequestReservationNotification(requestedReservation.getReservationId(),
+                requestedReservation.getName(),
+                trainerService.getTrainerDetail(requestedReservation.getTrainer().getTrainerId()));
+
+        return requestedReservation;
+    }
+
     private void cancelExistingReservations(List<Reservation> reservations, String cancelMsg) {
         if (!reservations.isEmpty()) {
             reservations.forEach(Reservation::checkPossibleReserveStatus);
@@ -209,4 +222,6 @@ public class ReservationFacade {
                     memberService.getMemberDetail(r.getMember().getMemberId()), RESERVATION_REFUSE));
         }
     }
+
+
 }

--- a/src/main/java/spring/fitlinkbe/application/reservation/criteria/ReservationCriteria.java
+++ b/src/main/java/spring/fitlinkbe/application/reservation/criteria/ReservationCriteria.java
@@ -114,4 +114,16 @@ public class ReservationCriteria {
         }
     }
 
+    @Builder(toBuilder = true)
+    public record ChangeReqeustReservation(LocalDateTime reservationDate, LocalDateTime changeRequestDate,
+                                           Long reservationId) {
+
+        public ReservationCommand.ChangeReqeustReservation toCommand() {
+            return ReservationCommand.ChangeReqeustReservation.builder()
+                    .reservationId(reservationId)
+                    .reservationDate(reservationDate)
+                    .changeRequestDate(changeRequestDate)
+                    .build();
+        }
+    }
 }

--- a/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
@@ -36,11 +36,13 @@ public enum ErrorCode {
     RESERVATION_WAITING_MEMBERS_EMPTY("이 날짜에 예약 대기자가 없습니다.", 400),
     RESERVATION_COMPLETE_NOT_ALLOWED("다른 사람의 예약을 완료시킬 수 없습니다.", 400),
     RESERVATION_IS_ALREADY_COMPLETED("이미 예약이 완료되었습니다.", 400),
+    RESERVATION_CHANGE_REQUEST_NOT_ALLOWED("예약 변경을 요청할 수 없는 상태입니다.", 400),
     RESERVATION_CANCEL_NOT_ALLOWED("예약 취소를 할 수 없는 상태입니다.", 400),
     RESERVATION_REFUSE_NOT_ALLOWED("예약 거절을 할 수 없는 상태입니다.", 400),
     RESERVATION_APPROVE_NOT_ALLOWED("예약 확정을 할 수 없는 상태입니다.", 400),
     RESERVATION_IS_ALREADY_APPROVED("이미 예약이 승인 되었습니다.", 400),
     RESERVATION_NOT_FOUND("예약 정보를 찾지 못하였습니다.", 404),
+    RESERVATION_DATE_NOT_FOUND("예약 날짜를 찾지 못하였습니다.", 404),
     FAILED_TO_CONVERT_JSON("Failed to convert LocalDateTime list to JSON", 400),
     FAILED_TO_CONVERT_LIST("Failed to convert LocalDateTime list to List", 400),
 

--- a/src/main/java/spring/fitlinkbe/domain/notification/Notification.java
+++ b/src/main/java/spring/fitlinkbe/domain/notification/Notification.java
@@ -163,6 +163,25 @@ public class Notification {
                 .build();
     }
 
+    public static Notification changeRequestReservationNotification(Long reservationId,
+                                                                    String name,
+                                                                    PersonalDetail trainerDetail) {
+
+        String content = "%s 회원님의 PT 예약 변경이 요청되었습니다.".formatted(name);
+
+        return Notification.builder()
+                .refId(reservationId)
+                .refType(ReferenceType.RESERVATION)
+                .notificationType(NotificationType.RESERVATION_CHANGE_REQUEST)
+                .personalDetail(trainerDetail)
+                .name(NotificationType.RESERVATION_CHANGE_REQUEST.name)
+                .content(content)
+                .isSent(true)
+                .isProcessed(false)
+                .sendDate(LocalDateTime.now())
+                .build();
+    }
+
     @RequiredArgsConstructor
     @Getter
     public enum ReferenceType {

--- a/src/main/java/spring/fitlinkbe/domain/notification/NotificationService.java
+++ b/src/main/java/spring/fitlinkbe/domain/notification/NotificationService.java
@@ -52,6 +52,10 @@ public class NotificationService {
     public void sendCompleteSessionNotification(Long sessionId, PersonalDetail memberDetail) {
         Notification notification = completeSessionNotification(sessionId, memberDetail);
         notificationRepository.save(notification);
+    }
 
+    public void sendChangeRequestReservationNotification(Long reservationId, String name, PersonalDetail memberDetail) {
+        Notification notification = changeRequestReservationNotification(reservationId, name, memberDetail);
+        notificationRepository.save(notification);
     }
 }

--- a/src/main/java/spring/fitlinkbe/domain/reservation/Reservation.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/Reservation.java
@@ -57,6 +57,35 @@ public class Reservation {
         return reservationDates.stream().map(date -> date.plusDays(7)).toList();
     }
 
+    public void changeRequestDate(LocalDateTime reservationDate, LocalDateTime changeDate) {
+
+        if (status != RESERVATION_APPROVED && status != RESERVATION_WAITING) {
+            throw new CustomException(RESERVATION_CHANGE_REQUEST_NOT_ALLOWED);
+        }
+
+        LocalDateTime targetDate = reservationDate.truncatedTo(ChronoUnit.HOURS);
+
+        boolean dateExists = reservationDates.stream()
+                .map(date -> date.truncatedTo(ChronoUnit.HOURS))
+                .anyMatch(targetDate::isEqual);
+
+        if (!dateExists) {
+            throw new CustomException(RESERVATION_DATE_NOT_FOUND);
+        }
+
+        if (reservationDates.size() > 1) {
+            LocalDateTime remainingDate = reservationDates.stream()
+                    .map(date -> date.truncatedTo(ChronoUnit.HOURS))
+                    .filter(date -> !date.isEqual(targetDate))
+                    .findFirst()
+                    .orElseThrow(() -> new CustomException(RESERVATION_DATE_NOT_FOUND));
+
+            reservationDates = List.of(changeDate, remainingDate);
+        }
+
+        status = RESERVATION_CHANGE_REQUEST;
+    }
+
 
     @RequiredArgsConstructor
     @Getter

--- a/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
@@ -252,6 +252,17 @@ public class ReservationService {
     }
 
     @Transactional
+    public Reservation changeReqeustReservation(ReservationCommand.ChangeReqeustReservation command) {
+
+        Reservation getReservation = this.getReservation(command.reservationId());
+        getReservation.changeRequestDate(command.reservationDate(), command.changeRequestDate());
+
+        return reservationRepository.saveReservation(getReservation)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_IS_FAILED,
+                        "예약 요청 변경에 실패하였습니다."));
+    }
+
+    @Transactional
     public Session saveSession(Reservation savedReservation) {
 
         Session session = Session.builder()

--- a/src/main/java/spring/fitlinkbe/domain/reservation/command/ReservationCommand.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/command/ReservationCommand.java
@@ -68,4 +68,9 @@ public class ReservationCommand {
     @Builder(toBuilder = true)
     public record CompleteReservation(Long reservationId, Long memberId) {
     }
+
+    @Builder(toBuilder = true)
+    public record ChangeReqeustReservation(LocalDateTime reservationDate, LocalDateTime changeRequestDate,
+                                           Long reservationId) {
+    }
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
@@ -208,4 +208,24 @@ public class ReservationController {
         return ApiResultResponse.ok(ReservationResponseDto.SuccessSession.of(result));
 
     }
+
+    /**
+     * 예약 변경 요청
+     *
+     * @param request reservationDate, changeDate 정보
+     * @return ApiResultResponse 변경 요청이 된 reservationId 결과를 반환한다.
+     */
+    @RoleCheck(allowedRoles = {UserRole.MEMBER})
+    @PostMapping("{reservationId}/change-request")
+    public ApiResultResponse<ReservationResponseDto.Success> changeReqeustReservation(
+            @PathVariable("reservationId")
+            @NotNull(message = "예약 ID는 필수값입니다.")
+            Long reservationId,
+            @RequestBody @Valid
+            ReservationRequestDto.ChangeReqeustReservation
+                    request) {
+        Reservation result = reservationFacade.changeReqeustReservation(request.toCriteria(reservationId));
+
+        return ApiResultResponse.ok(ReservationResponseDto.Success.of(result));
+    }
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationRequestDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationRequestDto.java
@@ -1,13 +1,12 @@
 package spring.fitlinkbe.interfaces.controller.reservation.dto;
 
-import jakarta.validation.constraints.FutureOrPresent;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.validation.constraints.*;
 import lombok.Builder;
 import spring.fitlinkbe.application.reservation.criteria.ReservationCriteria;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 public class ReservationRequestDto {
@@ -99,6 +98,32 @@ public class ReservationRequestDto {
                     .reservationId(reservationId)
                     .memberId(memberId)
                     .isJoin(isJoin)
+                    .build();
+        }
+    }
+
+    @Builder(toBuilder = true)
+    public record ChangeReqeustReservation(@NotNull(message = "예약 날짜는 필수입니다.")
+                                           @FutureOrPresent(message = "현재 날짜보다 이전일 수 없습니다.")
+                                           LocalDateTime reservationDate,
+                                           @NotNull(message = "변경 날짜는 필수입니다.")
+                                           @FutureOrPresent(message = "현재 날짜보다 이전일 수 없습니다.")
+                                           LocalDateTime changeRequestDate) {
+
+        @JsonIgnore
+        @AssertTrue(message = "예약 날짜와 변경 날짜가 같을 수 없습니다.")
+        private boolean isSameDate() {
+            if (reservationDate == null || changeRequestDate == null) {
+                return true;
+            }
+            return !reservationDate.truncatedTo(ChronoUnit.HOURS).isEqual(changeRequestDate.truncatedTo(ChronoUnit.HOURS));
+        }
+
+        public ReservationCriteria.ChangeReqeustReservation toCriteria(Long reservationId) {
+            return ReservationCriteria.ChangeReqeustReservation.builder()
+                    .reservationId(reservationId)
+                    .reservationDate(reservationDate)
+                    .changeRequestDate(changeRequestDate)
                     .build();
         }
     }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/trainer/dto/TrainerInfoDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/trainer/dto/TrainerInfoDto.java
@@ -62,8 +62,8 @@ public class TrainerInfoDto {
     @Builder
     public record TrainerCodeResponse(
             String trainerCode
-    ){
-        public static TrainerCodeResponse from(TrainerInfoResult.TrainerCodeResponse response){
+    ) {
+        public static TrainerCodeResponse from(TrainerInfoResult.TrainerCodeResponse response) {
             return TrainerCodeResponse.builder()
                     .trainerCode(response.trainerCode())
                     .build();


### PR DESCRIPTION
### 구현 기능

- `POST` "/v1/reservations/{reservationId}/change-request" 예약 변경 요청 API

### 세부 사항

- 예약 변경 요청 API 개발 완료
- 테스트 코드 추가
- 예외 상황에서 커스텀 메세지 추가

### DB 변동사항

- 없음