### PR TITLE
[Fliz-160] BE 예약 변경 승인 API

### DIFF
--- a/src/main/java/spring/fitlinkbe/application/reservation/criteria/ReservationCriteria.java
+++ b/src/main/java/spring/fitlinkbe/application/reservation/criteria/ReservationCriteria.java
@@ -47,14 +47,6 @@ public class ReservationCriteria {
     @Builder(toBuilder = true)
     public record FixedReserveSession(List<LocalDateTime> reservationDates, Long memberId, String name) {
 
-        public ReservationCommand.GetReservationThatTimes toCommand(SecurityUser user) {
-
-            return ReservationCommand.GetReservationThatTimes.builder()
-                    .date(reservationDates)
-                    .trainerId(user.getTrainerId())
-                    .build();
-        }
-
         public List<Reservation> toDomain(SessionInfo sessionInfo, SecurityUser user) {
             return reservationDates.stream()
                     .map((date) -> Reservation.builder()
@@ -104,16 +96,11 @@ public class ReservationCriteria {
 
             return ReservationCommand.CompleteSession.builder()
                     .reservationId(reservationId)
+                    .memberId(memberId)
                     .isJoin(isJoin)
                     .build();
         }
 
-        public ReservationCommand.CompleteReservation toCompleteReservationCommand() {
-            return ReservationCommand.CompleteReservation.builder()
-                    .reservationId(reservationId)
-                    .memberId(memberId)
-                    .build();
-        }
     }
 
     @Builder(toBuilder = true)
@@ -130,7 +117,8 @@ public class ReservationCriteria {
     }
 
     @Builder(toBuilder = true)
-    public record ChangeApproveReservation(Long reservationId, Long memberId, boolean isApprove) {
+    public record ChangeApproveReservation(Long reservationId, Long memberId, LocalDateTime approveDate,
+                                           boolean isApprove) {
 
         public ReservationCommand.ChangeApproveReservation toCommand() {
             return ReservationCommand.ChangeApproveReservation.builder()

--- a/src/main/java/spring/fitlinkbe/application/reservation/criteria/ReservationCriteria.java
+++ b/src/main/java/spring/fitlinkbe/application/reservation/criteria/ReservationCriteria.java
@@ -126,4 +126,16 @@ public class ReservationCriteria {
                     .build();
         }
     }
+
+    @Builder(toBuilder = true)
+    public record ChangeApproveReservation(Long reservationId, Long memberId, boolean isApprove) {
+
+        public ReservationCommand.ChangeApproveReservation toCommand() {
+            return ReservationCommand.ChangeApproveReservation.builder()
+                    .reservationId(reservationId)
+                    .memberId(memberId)
+                    .isApprove(isApprove)
+                    .build();
+        }
+    }
 }

--- a/src/main/java/spring/fitlinkbe/application/reservation/criteria/ReservationCriteria.java
+++ b/src/main/java/spring/fitlinkbe/application/reservation/criteria/ReservationCriteria.java
@@ -19,9 +19,10 @@ public class ReservationCriteria {
     @Builder(toBuilder = true)
     public record SetDisabledTime(LocalDateTime date) {
 
-        public ReservationCommand.SetDisabledTime toCommand() {
+        public ReservationCommand.SetDisabledTime toCommand(Long trainerId) {
             return ReservationCommand.SetDisabledTime.builder()
                     .date(date)
+                    .trainerId(trainerId)
                     .build();
         }
     }
@@ -70,10 +71,11 @@ public class ReservationCriteria {
     }
 
     @Builder(toBuilder = true)
-    public record CancelReservation(Long reservationId, String cancelReason) {
+    public record CancelReservation(Long reservationId, LocalDateTime cancelDate, String cancelReason) {
         public ReservationCommand.CancelReservation toCommand() {
             return ReservationCommand.CancelReservation.builder()
                     .reservationId(reservationId)
+                    .cancelDate(cancelDate)
                     .cancelReason(cancelReason)
                     .build();
         }

--- a/src/main/java/spring/fitlinkbe/application/reservation/criteria/ReservationResult.java
+++ b/src/main/java/spring/fitlinkbe/application/reservation/criteria/ReservationResult.java
@@ -5,8 +5,6 @@ import spring.fitlinkbe.domain.common.model.PersonalDetail;
 import spring.fitlinkbe.domain.reservation.Reservation;
 import spring.fitlinkbe.domain.reservation.Session;
 
-import java.util.List;
-
 public class ReservationResult {
 
     @Builder(toBuilder = true)
@@ -18,29 +16,6 @@ public class ReservationResult {
                     .reservation(reservation)
                     .session(session)
                     .personalDetail(personalDetail)
-                    .build();
-        }
-    }
-
-    @Builder(toBuilder = true)
-    public record ReservationWaitingMember(Reservation reservation, PersonalDetail personalDetail) {
-
-        public static ReservationWaitingMember from(Reservation reservation, PersonalDetail personalDetail) {
-
-            return ReservationResult.ReservationWaitingMember.builder()
-                    .reservation(reservation)
-                    .personalDetail(personalDetail)
-                    .build();
-        }
-    }
-
-    @Builder(toBuilder = true)
-    public record Reservations(List<Reservation> reservations) {
-
-        public static Reservations from(List<Reservation> reservations) {
-
-            return ReservationResult.Reservations.builder()
-                    .reservations(reservations)
                     .build();
         }
     }

--- a/src/main/java/spring/fitlinkbe/domain/notification/Notification.java
+++ b/src/main/java/spring/fitlinkbe/domain/notification/Notification.java
@@ -5,6 +5,7 @@ import spring.fitlinkbe.domain.common.model.PersonalDetail;
 import spring.fitlinkbe.domain.reservation.Reservation;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 @Builder(toBuilder = true)
 @Getter
@@ -76,16 +77,15 @@ public class Notification {
     }
 
     public static Notification cancelRequestReservationNotification(Long reservationId, String name,
-                                                                    PersonalDetail memberDetail, Reason reason) {
-        String content = "회원 %s 님의 %s를 요청하였습니다.".formatted(
-                name,
-                reason.name);
+                                                                    LocalDateTime cancelDate, String cancelReason,
+                                                                    PersonalDetail trainerDetail, Reason reason) {
+        String content = ("회원 %s 님의 %s를 요청하였습니다.\n +%s\n +취소 사유: %s").formatted(name, reason.name, cancelDate.truncatedTo(ChronoUnit.HOURS), cancelReason);
 
         return Notification.builder()
                 .refId(reservationId)
                 .refType(ReferenceType.RESERVATION)
                 .notificationType(NotificationType.RESERVATION_CANCEL)
-                .personalDetail(memberDetail)
+                .personalDetail(trainerDetail)
                 .name(NotificationType.RESERVATION_CANCEL.getName())
                 .content(content)
                 .isSent(true)
@@ -185,10 +185,13 @@ public class Notification {
     }
 
     public static Notification changeRequestReservationNotification(Long reservationId,
-                                                                    String name,
+                                                                    String name, LocalDateTime reservationDate,
+                                                                    LocalDateTime changeDate,
                                                                     PersonalDetail trainerDetail) {
 
-        String content = "%s 회원님의 PT 예약 변경이 요청되었습니다.".formatted(name);
+        String content = ("%s 회원님의 PT 예약 변경이 요청되었습니다. \n " +
+                "%s -> %s").formatted(name, reservationDate.truncatedTo(ChronoUnit.HOURS),
+                changeDate.truncatedTo(ChronoUnit.HOURS));
 
         return Notification.builder()
                 .refId(reservationId)
@@ -246,8 +249,7 @@ public class Notification {
     public enum Reason {
         DAY_OFF("연차"),
         RESERVATION_REFUSE("예약 거절"),
-        RESERVATION_CANCEL("예약 취소"),
-        RESERVATION_CANCEL_REQUEST("예약 취소 요청");
+        RESERVATION_CANCEL("예약 취소");
         private final String name;
     }
 }

--- a/src/main/java/spring/fitlinkbe/domain/notification/Notification.java
+++ b/src/main/java/spring/fitlinkbe/domain/notification/Notification.java
@@ -112,6 +112,27 @@ public class Notification {
                 .build();
     }
 
+    public static Notification approveRequestReservationNotification(Long reservationId, PersonalDetail memberDetail,
+                                                                     boolean isApprove) {
+
+        String content = "%s 님의 예약 변경이 %s되었습니다."
+                .formatted(memberDetail.getName(), isApprove ? "승인" : "거절");
+
+        return Notification.builder()
+                .refId(reservationId)
+                .refType(ReferenceType.RESERVATION)
+                .notificationType(isApprove ? NotificationType.RESERVATION_CHANGE_REQUEST_APPROVED :
+                        NotificationType.RESERVATION_CHANGE_REQUEST_REFUSED)
+                .personalDetail(memberDetail)
+                .name(isApprove ? NotificationType.RESERVATION_CHANGE_REQUEST_APPROVED.name :
+                        NotificationType.RESERVATION_CHANGE_REQUEST_REFUSED.name)
+                .content(content)
+                .isSent(true)
+                .isProcessed(false)
+                .sendDate(LocalDateTime.now())
+                .build();
+    }
+
     public static Notification refuseReservationNotification(Long reservationId, PersonalDetail memberDetail) {
 
         String content = " %s 님의 예약이 거절되었습니다.".formatted(memberDetail.getName());
@@ -204,7 +225,8 @@ public class Notification {
         DISCONNECT("트레이너 연동 해제", "회원과 연동이 해제되었습니다."),
 
         //회원
-        RESERVATION_CHANGE_REQUEST_REFUSED("세션 변경 요청 거절", "세션 변경 요청이 거절 되었습니다"),
+        RESERVATION_CHANGE_REQUEST_APPROVED("예약 변경 요청 승인", "예약 변경 요청이 승인 되었습니다"),
+        RESERVATION_CHANGE_REQUEST_REFUSED("예약 변경 요청 거절", "예약 변경 요청이 거절 되었습니다"),
         RESERVATION_APPROVE("예약 승인", "예약이 승인되었습니다."),
         RESERVATION_CANCEL("예약 취소", "예약이 취소되었습니다."),
         RESERVATION_REFUSE("예약 거절", "예약이 거절되었습니다."),

--- a/src/main/java/spring/fitlinkbe/domain/notification/NotificationService.java
+++ b/src/main/java/spring/fitlinkbe/domain/notification/NotificationService.java
@@ -39,6 +39,12 @@ public class NotificationService {
         notificationRepository.save(notification);
     }
 
+    public void sendApproveRequestReservationNotification(Long reservationId, PersonalDetail memberDetail,
+                                                          boolean isApprove) {
+        Notification notification = approveRequestReservationNotification(reservationId, memberDetail, isApprove);
+        notificationRepository.save(notification);
+    }
+
     public void sendRefuseReservationNotification(Long reservationId, PersonalDetail trainerDetail) {
         Notification notification = refuseReservationNotification(reservationId, trainerDetail);
         notificationRepository.save(notification);

--- a/src/main/java/spring/fitlinkbe/domain/notification/NotificationService.java
+++ b/src/main/java/spring/fitlinkbe/domain/notification/NotificationService.java
@@ -6,6 +6,8 @@ import org.springframework.transaction.annotation.Transactional;
 import spring.fitlinkbe.domain.common.model.PersonalDetail;
 import spring.fitlinkbe.domain.reservation.Reservation;
 
+import java.time.LocalDateTime;
+
 import static spring.fitlinkbe.domain.notification.Notification.*;
 
 @Service
@@ -29,8 +31,12 @@ public class NotificationService {
         notificationRepository.save(notification);
     }
 
-    public void sendCancelRequestReservationNotification(Long reservationId, String name, PersonalDetail memberDetail, Reason reason) {
-        Notification notification = cancelRequestReservationNotification(reservationId, name, memberDetail, reason);
+    public void sendCancelRequestReservationNotification(Long reservationId, String name,
+                                                         LocalDateTime cancelDate, String cancelReason,
+                                                         PersonalDetail trainerDetail,
+                                                         Reason reason) {
+        Notification notification = cancelRequestReservationNotification(reservationId, name,
+                cancelDate, cancelReason, trainerDetail, reason);
         notificationRepository.save(notification);
     }
 
@@ -60,8 +66,11 @@ public class NotificationService {
         notificationRepository.save(notification);
     }
 
-    public void sendChangeRequestReservationNotification(Long reservationId, String name, PersonalDetail memberDetail) {
-        Notification notification = changeRequestReservationNotification(reservationId, name, memberDetail);
+    public void sendChangeRequestReservationNotification(Long reservationId, String name, LocalDateTime reservationDate,
+                                                         LocalDateTime changeDate,
+                                                         PersonalDetail memberDetail) {
+        Notification notification = changeRequestReservationNotification(reservationId, name,
+                reservationDate, changeDate, memberDetail);
         notificationRepository.save(notification);
     }
 }

--- a/src/main/java/spring/fitlinkbe/domain/reservation/Reservation.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/Reservation.java
@@ -13,6 +13,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Objects;
 
 import static spring.fitlinkbe.domain.common.enums.UserRole.MEMBER;
 import static spring.fitlinkbe.domain.common.exception.ErrorCode.*;
@@ -37,6 +38,23 @@ public class Reservation {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
+    @RequiredArgsConstructor
+    @Getter
+    public enum Status {
+        FIXED_RESERVATION("고정 예약"), // 고정 예약
+        DISABLED_TIME_RESERVATION("예약 불가 설정"), // 예약 불가 시간 설정
+        RESERVATION_WAITING("예약 대기"), // 예약 대기
+        RESERVATION_APPROVED("예약 확정"), // 예약 확정
+        RESERVATION_CANCELLED("예약 취소"), // 예약 취소
+        RESERVATION_CANCEL_REQUEST("예약 취소 요청"), // 예약 취소
+        RESERVATION_REFUSED("예약 거절"),  // 예약 거부
+        RESERVATION_CHANGE_REQUEST("예약 변경 요청"), //예약 변경 요청
+        RESERVATION_CHANGE_REQUEST_REFUSED("예약 변경 거절"), //예약 변경 거절
+        RESERVATION_COMPLETED("예약 종료"); // 세션까지 완전 완료 되었을 때
+
+        private final String name;
+    }
+
     public Reservation toFixedDomain() {
 
         return Reservation.builder()
@@ -54,18 +72,18 @@ public class Reservation {
     }
 
     public List<LocalDateTime> getAfterSevenDay() {
-        return reservationDates.stream().map(date -> date.plusDays(7)).toList();
+        return this.reservationDates.stream().map(date -> date.plusDays(7)).toList();
     }
 
     public void changeRequestDate(LocalDateTime reservationDate, LocalDateTime changeDate) {
 
-        if (status != RESERVATION_APPROVED && status != RESERVATION_WAITING) {
+        if (this.status != RESERVATION_APPROVED && this.status != RESERVATION_WAITING) {
             throw new CustomException(RESERVATION_CHANGE_REQUEST_NOT_ALLOWED);
         }
 
         LocalDateTime targetDate = reservationDate.truncatedTo(ChronoUnit.HOURS);
 
-        boolean dateExists = reservationDates.stream()
+        boolean dateExists = this.reservationDates.stream()
                 .map(date -> date.truncatedTo(ChronoUnit.HOURS))
                 .anyMatch(targetDate::isEqual);
 
@@ -73,42 +91,30 @@ public class Reservation {
             throw new CustomException(RESERVATION_DATE_NOT_FOUND);
         }
 
-        if (reservationDates.size() > 1) {
-            LocalDateTime remainingDate = reservationDates.stream()
-                    .map(date -> date.truncatedTo(ChronoUnit.HOURS))
-                    .filter(date -> !date.isEqual(targetDate))
-                    .findFirst()
-                    .orElseThrow(() -> new CustomException(RESERVATION_DATE_NOT_FOUND));
+        this.changeDate = changeDate;
 
-            reservationDates = List.of(changeDate, remainingDate);
-        }
-
-        status = RESERVATION_CHANGE_REQUEST;
+        this.status = RESERVATION_CHANGE_REQUEST;
     }
 
+    public void approveChangeReqeust(Long memberId, boolean isApprove) {
 
-    @RequiredArgsConstructor
-    @Getter
-    public enum Status {
-        FIXED_RESERVATION("고정 예약"), // 고정 예약
-        DISABLED_TIME_RESERVATION("예약 불가 설정"), // 예약 불가 시간 설정
-        RESERVATION_WAITING("예약 대기"), // 예약 대기
-        RESERVATION_APPROVED("예약 확정"), // 예약 확정
-        RESERVATION_CANCELLED("예약 취소"), // 예약 취소
-        RESERVATION_CANCEL_REQUEST("예약 취소 요청"), // 예약 취소
-        RESERVATION_REFUSED("예약 거절"),  // 예약 거부
-        RESERVATION_CHANGE_REQUEST("예약 변경 요청"), //예약 변경 요청
-        RESERVATION_COMPLETED("예약 종료"); // 세션까지 완전 완료 되었을 때
+        if (!Objects.equals(this.member.getMemberId(), memberId)) {
+            throw new CustomException(MEMBER_NOT_FOUND, "잘못된 멤버의 예약을 변경하려고 합니다.");
+        }
 
-        private final String name;
+        if (this.status != RESERVATION_CHANGE_REQUEST) {
+            throw new CustomException(RESERVATION_APPROVE_NOT_ALLOWED, "예약 변경을 할 수 있는 상태가 아닙니다.");
+        }
+
+        this.status = isApprove ? RESERVATION_APPROVED : RESERVATION_CHANGE_REQUEST_REFUSED;
     }
 
     public boolean isAlreadyCancel() {
-        return status != RESERVATION_CANCELLED && status != RESERVATION_REFUSED;
+        return this.status != RESERVATION_CANCELLED && this.status != RESERVATION_REFUSED;
     }
 
     public void checkPossibleReserveStatus() {
-        if (status == DISABLED_TIME_RESERVATION || status == RESERVATION_COMPLETED) {
+        if (this.status == DISABLED_TIME_RESERVATION || this.status == RESERVATION_COMPLETED) {
             throw new CustomException(RESERVATION_NOT_ALLOWED);
         }
     }
@@ -123,14 +129,14 @@ public class Reservation {
                 .stream()
                 .anyMatch(reqDate -> {
                     LocalDateTime truncatedRequestDate = reqDate.truncatedTo(ChronoUnit.HOURS);
-                    return reservationDates.stream()
+                    return this.reservationDates.stream()
                             .map(date -> date.truncatedTo(ChronoUnit.HOURS))
                             .anyMatch(truncatedRequestDate::isEqual);
                 });
     }
 
     public boolean isWaitingStatus() {
-        if (status != RESERVATION_WAITING) {
+        if (this.status != RESERVATION_WAITING) {
             throw new CustomException(RESERVATION_IS_NOT_WAITING_STATUS, "예약 상태가 대기 상태가 아닙니다.");
         }
 
@@ -146,10 +152,10 @@ public class Reservation {
 
     public LocalDateTime getReservationDate() {
 
-        if (reservationDates == null) return LocalDateTime.now().minusYears(1);
+        if (this.reservationDates == null) return LocalDateTime.now().minusYears(1);
 
-        return reservationDates.size() == 1 ? reservationDates.get(0)
-                : findEarlierDate(reservationDates);
+        return this.reservationDates.size() == 1 ? this.reservationDates.get(0)
+                : findEarlierDate(this.reservationDates);
     }
 
     private LocalDateTime findEarlierDate(List<LocalDateTime> dates) {
@@ -162,7 +168,7 @@ public class Reservation {
     }
 
     public void complete(Long trainerId, Long memberId) {
-        if (!trainerId.equals(trainer.getTrainerId()) || !memberId.equals(member.getMemberId())) {
+        if (!trainerId.equals(this.trainer.getTrainerId()) || !memberId.equals(this.member.getMemberId())) {
             throw new CustomException(RESERVATION_COMPLETE_NOT_ALLOWED);
         }
 
@@ -174,51 +180,50 @@ public class Reservation {
     }
 
     public void cancel(String message) {
-        if (status == RESERVATION_CANCELLED) {
+        if (this.status == RESERVATION_CANCELLED) {
             throw new CustomException(RESERVATION_IS_ALREADY_CANCEL);
         }
-        if (status == DISABLED_TIME_RESERVATION || status == RESERVATION_REFUSED) {
+        if (this.status == DISABLED_TIME_RESERVATION || this.status == RESERVATION_REFUSED) {
             throw new CustomException(RESERVATION_CANCEL_NOT_ALLOWED);
         }
-        cancelReason = message;
+        this.cancelReason = message;
         this.status = RESERVATION_CANCELLED;
     }
 
     public void approve(LocalDateTime reservationDate) {
-        if (status == DISABLED_TIME_RESERVATION || status == RESERVATION_REFUSED) {
+        if (this.status == DISABLED_TIME_RESERVATION || this.status == RESERVATION_REFUSED) {
             throw new CustomException(RESERVATION_APPROVE_NOT_ALLOWED);
         }
-        if (status == RESERVATION_APPROVED) {
+        if (this.status == RESERVATION_APPROVED) {
             throw new CustomException(RESERVATION_IS_ALREADY_APPROVED);
         }
 
-        if (reservationDates.size() > 1) {
-            reservationDates = List.of(reservationDate);
+        if (this.reservationDates.size() > 1) {
+            this.reservationDates = List.of(reservationDate);
         }
 
         this.status = RESERVATION_APPROVED;
     }
-
 
     public void cancelRequest(String message) {
         // 당일 예약 취소는 불가능 함
         if (LocalDateTime.now().isAfter(reservationDates.get(0).minusDays(1).truncatedTo(ChronoUnit.DAYS).plusHours(23))) {
             throw new CustomException(RESERVATION_CANCEL_NOT_ALLOWED, "당일 예약 취소 요청은 불가합니다.");
         }
-        if (status == DISABLED_TIME_RESERVATION || status == RESERVATION_REFUSED) {
+        if (this.status == DISABLED_TIME_RESERVATION || this.status == RESERVATION_REFUSED) {
             throw new CustomException(RESERVATION_CANCEL_NOT_ALLOWED);
         }
-        if (status == RESERVATION_CANCELLED) {
+        if (this.status == RESERVATION_CANCELLED) {
             throw new CustomException(RESERVATION_IS_ALREADY_CANCEL);
         }
-        cancelReason = message;
+        this.cancelReason = message;
         this.status = RESERVATION_CANCEL_REQUEST;
 
     }
 
     public boolean isReservationNotAllowed() {
 
-        return (isDayOff || (status == DISABLED_TIME_RESERVATION));
+        return (this.isDayOff || (this.status == DISABLED_TIME_RESERVATION));
     }
 
 }

--- a/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
@@ -263,6 +263,26 @@ public class ReservationService {
     }
 
     @Transactional
+    public Reservation changeApproveReservation(ReservationCommand.ChangeApproveReservation command) {
+
+        Reservation getReservation = this.getReservation(command.reservationId());
+        getReservation.approveChangeReqeust(command.memberId(), command.isApprove());
+
+        //만약 만들어진 세션이 없다면 생성
+        Optional<Session> getSession = reservationRepository.getSession(getReservation.getReservationId());
+
+        if (getSession.isEmpty()) {
+            Session session = Session.createSession(getReservation.getReservationId());
+            reservationRepository.saveSession(session);
+        }
+
+        return reservationRepository.saveReservation(getReservation)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_IS_FAILED,
+                        "예약 요청 변경에 실패하였습니다."));
+
+    }
+
+    @Transactional
     public Session saveSession(Reservation savedReservation) {
 
         Session session = Session.builder()

--- a/src/main/java/spring/fitlinkbe/domain/reservation/Session.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/Session.java
@@ -30,6 +30,15 @@ public class Session {
         private final String name;
     }
 
+    public static Session createSession(Long reservationId) {
+
+        return Session.builder()
+                .reservation(Reservation.builder().reservationId(reservationId).build())
+                .status(Status.SESSION_WAITING)
+                .build();
+    }
+
+
     public void cancel(String message) {
         if (status == Status.SESSION_CANCELLED) {
             throw new CustomException(SESSION_IS_ALREADY_CANCEL);

--- a/src/main/java/spring/fitlinkbe/domain/reservation/command/ReservationCommand.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/command/ReservationCommand.java
@@ -73,4 +73,8 @@ public class ReservationCommand {
     public record ChangeReqeustReservation(LocalDateTime reservationDate, LocalDateTime changeRequestDate,
                                            Long reservationId) {
     }
+
+    @Builder(toBuilder = true)
+    public record ChangeApproveReservation(Long reservationId, Long memberId, boolean isApprove) {
+    }
 }

--- a/src/main/java/spring/fitlinkbe/domain/reservation/command/ReservationCommand.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/command/ReservationCommand.java
@@ -57,7 +57,8 @@ public class ReservationCommand {
     }
 
     @Builder(toBuilder = true)
-    public record CancelReservation(Long reservationId, String cancelReason) {
+    public record CancelReservation(Long reservationId, LocalDateTime cancelDate,
+                                    String cancelReason) {
 
     }
 

--- a/src/main/java/spring/fitlinkbe/domain/reservation/command/ReservationCommand.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/command/ReservationCommand.java
@@ -7,7 +7,6 @@ import spring.fitlinkbe.domain.reservation.Session;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
 
 public class ReservationCommand {
 
@@ -27,11 +26,6 @@ public class ReservationCommand {
                     .userId(userId)
                     .build();
         }
-    }
-
-    @Builder(toBuilder = true)
-    public record GetReservationThatTimes(List<LocalDateTime> date, Long trainerId) {
-
     }
 
     @Builder(toBuilder = true)
@@ -63,11 +57,7 @@ public class ReservationCommand {
     }
 
     @Builder(toBuilder = true)
-    public record CompleteSession(Long reservationId, Boolean isJoin) {
-    }
-
-    @Builder(toBuilder = true)
-    public record CompleteReservation(Long reservationId, Long memberId) {
+    public record CompleteSession(Long reservationId, Long memberId, Boolean isJoin) {
     }
 
     @Builder(toBuilder = true)

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
@@ -217,14 +217,31 @@ public class ReservationController {
      */
     @RoleCheck(allowedRoles = {UserRole.MEMBER})
     @PostMapping("{reservationId}/change-request")
-    public ApiResultResponse<ReservationResponseDto.Success> changeReqeustReservation(
-            @PathVariable("reservationId")
-            @NotNull(message = "예약 ID는 필수값입니다.")
-            Long reservationId,
-            @RequestBody @Valid
-            ReservationRequestDto.ChangeReqeustReservation
-                    request) {
+    public ApiResultResponse<ReservationResponseDto.Success> changeReqeustReservation(@PathVariable("reservationId")
+                                                                                      @NotNull(message = "예약 ID는 필수값입니다.")
+                                                                                      Long reservationId,
+                                                                                      @RequestBody @Valid
+                                                                                      ReservationRequestDto.ChangeReqeustReservation
+                                                                                              request) {
         Reservation result = reservationFacade.changeReqeustReservation(request.toCriteria(reservationId));
+
+        return ApiResultResponse.ok(ReservationResponseDto.Success.of(result));
+    }
+
+    /**
+     * @param request // memberId 정보
+     * @return ApiResultResponse 변경 승인 된 reservationId 결과를 반환한다.
+     */
+    @RoleCheck(allowedRoles = {UserRole.TRAINER})
+    @PostMapping("{reservationId}/change-approve")
+    public ApiResultResponse<ReservationResponseDto.Success> changeApproveReservation(@PathVariable("reservationId")
+                                                                                      @NotNull(message = "예약 ID는 필수값입니다.")
+                                                                                      Long reservationId,
+                                                                                      @RequestBody @Valid
+                                                                                      ReservationRequestDto.ChangeApproveReservation
+                                                                                              request) {
+
+        Reservation result = reservationFacade.changeApproveReservation(request.toCriteria(reservationId));
 
         return ApiResultResponse.ok(ReservationResponseDto.Success.of(result));
     }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationRequestDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationRequestDto.java
@@ -134,11 +134,15 @@ public class ReservationRequestDto {
 
     @Builder(toBuilder = true)
     public record ChangeApproveReservation(@NotNull(message = "유저 ID는 필수값 입니다.") Long memberId,
+                                           @NotNull(message = "승인 날짜는 필수입니다.")
+                                           @FutureOrPresent(message = "현재 날짜보다 이전일 수 없습니다.")
+                                           LocalDateTime approveDate,
                                            @NotNull(message = "승인 여부는 필수값 입니다.") Boolean isApprove) {
 
         public ReservationCriteria.ChangeApproveReservation toCriteria(Long reservationId) {
             return ReservationCriteria.ChangeApproveReservation.builder()
                     .reservationId(reservationId)
+                    .approveDate(approveDate)
                     .memberId(memberId)
                     .isApprove(isApprove)
                     .build();

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationRequestDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationRequestDto.java
@@ -127,4 +127,17 @@ public class ReservationRequestDto {
                     .build();
         }
     }
+
+    @Builder(toBuilder = true)
+    public record ChangeApproveReservation(@NotNull(message = "유저 ID는 필수값 입니다.") Long memberId,
+                                           @NotNull(message = "승인 여부는 필수값 입니다.") Boolean isApprove) {
+
+        public ReservationCriteria.ChangeApproveReservation toCriteria(Long reservationId) {
+            return ReservationCriteria.ChangeApproveReservation.builder()
+                    .reservationId(reservationId)
+                    .memberId(memberId)
+                    .isApprove(isApprove)
+                    .build();
+        }
+    }
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationRequestDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationRequestDto.java
@@ -63,12 +63,16 @@ public class ReservationRequestDto {
     }
 
     @Builder(toBuilder = true)
-    public record CancelReservation(@NotEmpty(message = "취소 사유는 필수값 입니다.") String cancelReason) {
+    public record CancelReservation(@NotEmpty(message = "취소 사유는 필수값 입니다.") String cancelReason,
+                                    @NotNull(message = "취소 날짜는 필수입니다.")
+                                    @FutureOrPresent(message = "현재 날짜보다 이전일 수 없습니다.")
+                                    LocalDateTime cancelDate) {
 
         public ReservationCriteria.CancelReservation toCriteria(Long reservationId) {
 
             return ReservationCriteria.CancelReservation.builder()
                     .reservationId(reservationId)
+                    .cancelDate(cancelDate)
                     .cancelReason(cancelReason)
                     .build();
         }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationResponseDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationResponseDto.java
@@ -91,17 +91,17 @@ public class ReservationResponseDto {
                                    LocalDate birthDate, String phoneNumber, String profilePictureUrl,
                                    DayOfWeek dayOfWeek, List<LocalDateTime> reservationDates) {
 
-        public static ReservationResponseDto.GetWaitingMember of(ReservationResult.ReservationWaitingMember member) {
+        public static ReservationResponseDto.GetWaitingMember of(Reservation reservation) {
 
             return GetWaitingMember.builder()
-                    .memberId(member.personalDetail().getMemberId())
-                    .name(member.personalDetail().getName())
-                    .birthDate(member.personalDetail().getBirthDate())
-                    .phoneNumber(member.personalDetail().getPhoneNumber())
-                    .profilePictureUrl(member.personalDetail().getProfilePictureUrl())
-                    .reservationId(member.reservation().getReservationId())
-                    .reservationDates(member.reservation().getReservationDates())
-                    .dayOfWeek(member.reservation().getReservationDates().get(0).getDayOfWeek())
+                    .memberId(reservation.getMember().getMemberId())
+                    .name(reservation.getMember().getName())
+                    .birthDate(reservation.getMember().getBirthDate())
+                    .phoneNumber(reservation.getMember().getPhoneNumber())
+                    .profilePictureUrl(reservation.getMember().getProfilePictureUrl())
+                    .reservationId(reservation.getReservationId())
+                    .reservationDates(reservation.getReservationDates())
+                    .dayOfWeek(reservation.getReservationDates().get(0).getDayOfWeek())
                     .build();
         }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -150,8 +150,8 @@ spring:
         default_batch_fetch_size: 500
 logging:
   level:
-    com.zaxxer.hikari: debug
+    com.zaxxer.hikari: info
     org:
-      web: debug
+      web: info
       hibernate:
-        SQL: debug
+        SQL: warn

--- a/src/test/java/spring/fitlinkbe/domain/reservation/ReservationServiceTest.java
+++ b/src/test/java/spring/fitlinkbe/domain/reservation/ReservationServiceTest.java
@@ -276,7 +276,7 @@ class ReservationServiceTest {
                     .thenReturn(Optional.ofNullable(savedReservation));
 
             //when
-            Reservation result = reservationService.setDisabledTime(command, trainer);
+            Reservation result = reservationService.setDisabledReservation(command);
 
             //then
             assertThat(result.getStatus()).isEqualTo(DISABLED_TIME_RESERVATION);

--- a/src/test/java/spring/fitlinkbe/integration/ReservationIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/ReservationIntegrationTest.java
@@ -648,6 +648,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .name(member.getName())
                     .dayOfWeek(reservationDate.getDayOfWeek())
                     .status(RESERVATION_WAITING)
+                    .createdAt(LocalDateTime.now().plusSeconds(3))
                     .build();
 
             reservationRepository.saveReservation(reservation).orElseThrow();
@@ -698,7 +699,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .name(member.getName())
                     .dayOfWeek(reservationDate.getDayOfWeek())
                     .status(RESERVATION_WAITING)
-                    .createdAt(LocalDateTime.now().plusSeconds(2))
+                    .createdAt(LocalDateTime.now().plusSeconds(3))
                     .build();
 
             Reservation savedReservation = reservationRepository.saveReservation(reservation).orElseThrow();
@@ -709,11 +710,10 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
             reservationRepository.saveSession(session);
 
-            LocalDateTime requestDate = LocalDateTime.now().plusHours(1);
 
             ReservationRequestDto.SetDisabledTime request = ReservationRequestDto.SetDisabledTime
                     .builder()
-                    .date(requestDate)
+                    .date(reservationDate)
                     .build();
 
             // when
@@ -1458,11 +1458,12 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             String accessToken = tokenProvider.createAccessToken(PersonalDetail.Status.NORMAL,
                     personalDetail.getPersonalDetailId(), personalDetail.getUserRole());
 
+            LocalDateTime requestDate = LocalDateTime.now().plusDays(1);
+
             ReservationRequestDto.CancelReservation request = ReservationRequestDto.CancelReservation.builder()
+                    .cancelDate(requestDate)
                     .cancelReason("개인 사정")
                     .build();
-
-            LocalDateTime requestDate = LocalDateTime.now().plusDays(1);
 
             // 예약 생성
             Reservation reservation = Reservation.builder()
@@ -1518,17 +1519,19 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             String accessToken = tokenProvider.createAccessToken(PersonalDetail.Status.NORMAL,
                     personalDetail.getPersonalDetailId(), personalDetail.getUserRole());
 
+            LocalDateTime requestDate = LocalDateTime.now().plusDays(1);
+
             ReservationRequestDto.CancelReservation request = ReservationRequestDto.CancelReservation.builder()
+                    .cancelDate(requestDate)
                     .cancelReason("개인 사정")
                     .build();
-
-            LocalDateTime requestDate = LocalDateTime.now().plusDays(1);
 
             // 예약 생성
             Reservation reservation = Reservation.builder()
                     .reservationDates(List.of(requestDate))
                     .trainer(Trainer.builder().trainerId(1L).build())
                     .member(Member.builder().memberId(1L).build())
+                    .name("길동")
                     .status(RESERVATION_APPROVED)
                     .createdAt(LocalDateTime.now().plusSeconds(2))
                     .build();
@@ -1578,11 +1581,12 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             String accessToken = tokenProvider.createAccessToken(PersonalDetail.Status.NORMAL,
                     personalDetail.getPersonalDetailId(), personalDetail.getUserRole());
 
+            LocalDateTime requestDate = LocalDateTime.now().plusDays(1);
+
             ReservationRequestDto.CancelReservation request = ReservationRequestDto.CancelReservation.builder()
+                    .cancelDate(requestDate)
                     .cancelReason("")
                     .build();
-
-            LocalDateTime requestDate = LocalDateTime.now().plusDays(1);
 
             // 예약 생성
             Reservation reservation = Reservation.builder()
@@ -1630,6 +1634,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
             ReservationRequestDto.CancelReservation request = ReservationRequestDto.CancelReservation.builder()
                     .cancelReason("개인 사유")
+                    .cancelDate(LocalDateTime.now().plusHours(3))
                     .build();
 
             // when
@@ -1657,11 +1662,12 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             String accessToken = tokenProvider.createAccessToken(PersonalDetail.Status.NORMAL,
                     personalDetail.getPersonalDetailId(), personalDetail.getUserRole());
 
+            LocalDateTime requestDate = LocalDateTime.now().plusDays(1);
+
             ReservationRequestDto.CancelReservation request = ReservationRequestDto.CancelReservation.builder()
                     .cancelReason("개인 사유")
+                    .cancelDate(requestDate)
                     .build();
-
-            LocalDateTime requestDate = LocalDateTime.now().plusDays(1);
 
             // 취소된 예약 생성
             Reservation reservation = Reservation.builder()
@@ -1699,11 +1705,12 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             String accessToken = tokenProvider.createAccessToken(PersonalDetail.Status.NORMAL,
                     personalDetail.getPersonalDetailId(), personalDetail.getUserRole());
 
+            LocalDateTime requestDate = LocalDateTime.now().plusDays(1);
+
             ReservationRequestDto.CancelReservation request = ReservationRequestDto.CancelReservation.builder()
                     .cancelReason("개인 사유")
+                    .cancelDate(requestDate)
                     .build();
-
-            LocalDateTime requestDate = LocalDateTime.now().plusDays(1);
 
             // 예약 승인이 거절된 예약 생성
             Reservation reservation = Reservation.builder()
@@ -1741,11 +1748,12 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             String accessToken = tokenProvider.createAccessToken(PersonalDetail.Status.NORMAL,
                     personalDetail.getPersonalDetailId(), personalDetail.getUserRole());
 
+            LocalDateTime requestDate = LocalDateTime.now().plusHours(1);
+
             ReservationRequestDto.CancelReservation request = ReservationRequestDto.CancelReservation.builder()
                     .cancelReason("개인 사유")
+                    .cancelDate(requestDate)
                     .build();
-
-            LocalDateTime requestDate = LocalDateTime.now().plusHours(1);
 
             // 예약 생성
             Reservation reservation = Reservation.builder()
@@ -2584,6 +2592,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             Reservation reservation = Reservation.builder()
                     .trainer(Trainer.builder().trainerId(1L).build())
                     .member(Member.builder().memberId(1L).build())
+                    .name("길동")
                     .reservationDates(List.of(reservationDate, reservationDate.plusHours(2)))
                     .status(RESERVATION_WAITING)
                     .createdAt(LocalDateTime.now().plusSeconds(2))
@@ -2701,6 +2710,51 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                 softly.assertThat(result.body().jsonPath().getObject("status", Integer.class)).isEqualTo(404);
                 softly.assertThat(result.body().jsonPath().getObject("success", Boolean.class)).isEqualTo(false);
                 softly.assertThat(result.body().jsonPath().getObject("msg", String.class)).contains("예약 날짜를 찾지 못하였습니다.");
+                softly.assertThat(result.body().jsonPath().getObject("data", ReservationResponseDto.Success.class)).isNull();
+            });
+        }
+
+        @Test
+        @DisplayName("멤버의 예약 변경 요청 실패 - 예약 변경 요청할 수 있는 시간이 아님")
+        void changeReqeustReservationNotAllowChangeRequestHours() {
+            // given
+            PersonalDetail personalDetail = personalDetailRepository.getMemberDetail(1L)
+                    .orElseThrow();
+
+            String accessToken = tokenProvider.createAccessToken(PersonalDetail.Status.NORMAL,
+                    personalDetail.getPersonalDetailId(), personalDetail.getUserRole());
+
+            LocalDateTime reservationDate = LocalDateTime.now().plusDays(1);
+            LocalDateTime changeRequestDate = LocalDateTime.now().plusHours(1);
+
+            ReservationRequestDto.ChangeReqeustReservation request = ReservationRequestDto.ChangeReqeustReservation
+                    .builder()
+                    .reservationDate(reservationDate)
+                    .changeRequestDate(changeRequestDate)
+                    .build();
+
+            // 예약 생성
+            Reservation reservation = Reservation.builder()
+                    .trainer(Trainer.builder().trainerId(1L).build())
+                    .member(Member.builder().memberId(1L).build())
+                    .reservationDates(List.of(reservationDate))
+                    .status(RESERVATION_APPROVED)
+                    .createdAt(LocalDateTime.now().plusSeconds(2))
+                    .build();
+
+            reservationRepository.saveReservation(reservation).orElseThrow();
+
+            // when
+            ExtractableResponse<Response> result = post(LOCAL_HOST + port + PATH + "/%s/change-request".formatted(1),
+                    request,
+                    accessToken);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.statusCode()).isEqualTo(200);
+                softly.assertThat(result.body().jsonPath().getObject("status", Integer.class)).isEqualTo(400);
+                softly.assertThat(result.body().jsonPath().getObject("success", Boolean.class)).isEqualTo(false);
+                softly.assertThat(result.body().jsonPath().getObject("msg", String.class)).contains("현재시간보다 2시간 이후부터 변경 가능합니다.");
                 softly.assertThat(result.body().jsonPath().getObject("data", ReservationResponseDto.Success.class)).isNull();
             });
         }

--- a/src/test/java/spring/fitlinkbe/integration/ReservationIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/ReservationIntegrationTest.java
@@ -2780,6 +2780,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .builder()
                     .memberId(1L)
                     .isApprove(true)
+                    .approveDate(reservationDate)
                     .build();
 
             // 예약 생성
@@ -2788,7 +2789,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .member(Member.builder().memberId(1L).build())
                     .reservationDates(List.of(reservationDate))
                     .status(RESERVATION_CHANGE_REQUEST)
-                    .createdAt(LocalDateTime.now().plusSeconds(2))
+                    .createdAt(LocalDateTime.now().plusSeconds(3))
                     .build();
 
             Reservation savedReservation = reservationRepository.saveReservation(reservation).orElseThrow();
@@ -2842,6 +2843,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .builder()
                     .memberId(1L)
                     .isApprove(false)
+                    .approveDate(reservationDate)
                     .build();
 
             // 예약 생성
@@ -2850,7 +2852,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .member(Member.builder().memberId(1L).build())
                     .reservationDates(List.of(reservationDate))
                     .status(RESERVATION_CHANGE_REQUEST)
-                    .createdAt(LocalDateTime.now().plusSeconds(2))
+                    .createdAt(LocalDateTime.now().plusSeconds(3))
                     .build();
 
             Reservation savedReservation = reservationRepository.saveReservation(reservation).orElseThrow();
@@ -2904,6 +2906,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .builder()
                     .memberId(1L)
                     .isApprove(true)
+                    .approveDate(reservationDate)
                     .build();
 
             // 예약 생성
@@ -2912,7 +2915,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .member(Member.builder().memberId(1L).build())
                     .reservationDates(List.of(reservationDate))
                     .status(RESERVATION_CHANGE_REQUEST)
-                    .createdAt(LocalDateTime.now().plusSeconds(2))
+                    .createdAt(LocalDateTime.now().plusSeconds(3))
                     .build();
 
             Reservation reservation1 = reservationRepository.saveReservation(reservation).orElseThrow();
@@ -2925,7 +2928,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .member(member2)
                     .reservationDates(List.of(reservationDate))
                     .status(RESERVATION_WAITING)
-                    .createdAt(LocalDateTime.now().plusSeconds(2))
+                    .createdAt(LocalDateTime.now().plusSeconds(3))
                     .build();
 
             Reservation savedReservation2 = reservationRepository.saveReservation(reservation2).orElseThrow();
@@ -2985,6 +2988,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .builder()
                     .memberId(1L)
                     .isApprove(true)
+                    .approveDate(reservationDate)
                     .build();
 
             // 예약 생성
@@ -3029,6 +3033,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .builder()
                     .memberId(2L)
                     .isApprove(true)
+                    .approveDate(reservationDate)
                     .build();
 
             // 예약 생성

--- a/src/test/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationControllerTest.java
+++ b/src/test/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationControllerTest.java
@@ -98,7 +98,7 @@ class ReservationControllerTest {
 
             String accessToken = getAccessToken(personalDetail);
 
-            when(reservationFacade.getReservations(any(LocalDate.class), any(SecurityUser.class))).thenReturn(ReservationResult.Reservations.from(response));
+            when(reservationFacade.getReservations(any(LocalDate.class), any(SecurityUser.class))).thenReturn(response);
 
             //when & then
             mockMvc.perform(get("/v1/reservations")
@@ -142,7 +142,7 @@ class ReservationControllerTest {
             SecurityUser user = new SecurityUser(personalDetail);
             String accessToken = getAccessToken(personalDetail);
 
-            when(reservationFacade.getReservations(any(LocalDate.class), any(SecurityUser.class))).thenReturn(ReservationResult.Reservations.from(response));
+            when(reservationFacade.getReservations(any(LocalDate.class), any(SecurityUser.class))).thenReturn(response);
 
             //when & then
             mockMvc.perform(get("/v1/reservations")
@@ -177,7 +177,7 @@ class ReservationControllerTest {
             SecurityUser user = new SecurityUser(personalDetail);
             String accessToken = getAccessToken(personalDetail);
 
-            when(reservationFacade.getReservations(any(LocalDate.class), any(SecurityUser.class))).thenReturn(ReservationResult.Reservations.from(response));
+            when(reservationFacade.getReservations(any(LocalDate.class), any(SecurityUser.class))).thenReturn(response);
 
             //when //then
             mockMvc.perform(get("/v1/reservations")
@@ -219,7 +219,7 @@ class ReservationControllerTest {
 
             String accessToken = getAccessToken(personalDetail);
 
-            when(reservationFacade.getReservations(any(LocalDate.class), any(SecurityUser.class))).thenReturn(ReservationResult.Reservations.from(response));
+            when(reservationFacade.getReservations(any(LocalDate.class), any(SecurityUser.class))).thenReturn(response);
 
             //when & then
             mockMvc.perform(get("/v1/reservations")
@@ -261,7 +261,7 @@ class ReservationControllerTest {
 
             String accessToken = getAccessToken(personalDetail);
 
-            when(reservationFacade.getReservations(any(LocalDate.class), any(SecurityUser.class))).thenReturn(ReservationResult.Reservations.from(response));
+            when(reservationFacade.getReservations(any(LocalDate.class), any(SecurityUser.class))).thenReturn(response);
 
             //when & then
             mockMvc.perform(get("/v1/reservations")
@@ -302,7 +302,7 @@ class ReservationControllerTest {
 
             SecurityUser user = new SecurityUser(personalDetail);
 
-            when(reservationFacade.getReservations(any(LocalDate.class), any(SecurityUser.class))).thenReturn(ReservationResult.Reservations.from(response));
+            when(reservationFacade.getReservations(any(LocalDate.class), any(SecurityUser.class))).thenReturn(response);
 
             //when & then
             mockMvc.perform(get("/v1/reservations")
@@ -417,12 +417,10 @@ class ReservationControllerTest {
 
             String accessToken = getAccessToken(personalDetail);
 
-            ReservationResult.ReservationWaitingMember result =
-                    ReservationResult.ReservationWaitingMember.builder()
-                            .reservation(Reservation.builder()
-                                    .reservationDates(List.of(requestDate.plusDays(1))).build())
-                            .personalDetail(PersonalDetail.builder().personalDetailId(2L).build())
-                            .build();
+            Reservation result =
+                    Reservation.builder()
+                            .member(Member.builder().memberId(1L).build())
+                            .reservationDates(List.of(requestDate.plusDays(1))).build();
 
             when(reservationFacade.getWaitingMembers(any(LocalDateTime.class), any(SecurityUser.class)))
                     .thenReturn(List.of(result));
@@ -453,12 +451,9 @@ class ReservationControllerTest {
             SecurityUser user = new SecurityUser(personalDetail);
 
             String accessToken = getAccessToken(personalDetail);
-
-            ReservationResult.ReservationWaitingMember result =
-                    ReservationResult.ReservationWaitingMember.builder()
-                            .reservation(Reservation.builder()
-                                    .reservationDates(List.of(LocalDateTime.now().plusDays(1))).build())
-                            .personalDetail(PersonalDetail.builder().personalDetailId(2L).build())
+            Reservation result =
+                    Reservation.builder()
+                            .reservationDates(List.of(LocalDateTime.now().plusDays(1)))
                             .build();
 
             when(reservationFacade.getWaitingMembers(any(LocalDateTime.class), any(SecurityUser.class)))
@@ -843,7 +838,7 @@ class ReservationControllerTest {
                     .build();
 
             Reservation reservation = Reservation.builder().reservationId(1L).status(RESERVATION_APPROVED).build();
-            ReservationResult.Reservations reservations = ReservationResult.Reservations.from(List.of(reservation));
+            List<Reservation> reservations = List.of(reservation);
 
             PersonalDetail personalDetail = PersonalDetail.builder()
                     .personalDetailId(1L)
@@ -886,7 +881,7 @@ class ReservationControllerTest {
                     .build();
 
             Reservation reservation = Reservation.builder().reservationId(1L).status(RESERVATION_APPROVED).build();
-            ReservationResult.Reservations reservations = ReservationResult.Reservations.from(List.of(reservation));
+            List<Reservation> reservations = List.of(reservation);
 
             PersonalDetail personalDetail = PersonalDetail.builder()
                     .personalDetailId(1L)
@@ -927,7 +922,7 @@ class ReservationControllerTest {
                     .build();
 
             Reservation reservation = Reservation.builder().reservationId(1L).status(RESERVATION_APPROVED).build();
-            ReservationResult.Reservations reservations = ReservationResult.Reservations.from(List.of(reservation));
+            List<Reservation> reservations = List.of(reservation);
 
             PersonalDetail personalDetail = PersonalDetail.builder()
                     .personalDetailId(1L)
@@ -968,7 +963,7 @@ class ReservationControllerTest {
                     .build();
 
             Reservation reservation = Reservation.builder().reservationId(1L).status(RESERVATION_APPROVED).build();
-            ReservationResult.Reservations reservations = ReservationResult.Reservations.from(List.of(reservation));
+            List<Reservation> reservations = List.of(reservation);
 
             PersonalDetail personalDetail = PersonalDetail.builder()
                     .personalDetailId(1L)
@@ -1010,7 +1005,7 @@ class ReservationControllerTest {
                     .build();
 
             Reservation reservation = Reservation.builder().reservationId(1L).status(RESERVATION_APPROVED).build();
-            ReservationResult.Reservations reservations = ReservationResult.Reservations.from(List.of(reservation));
+            List<Reservation> reservations = List.of(reservation);
 
             PersonalDetail personalDetail = PersonalDetail.builder()
                     .personalDetailId(1L)
@@ -1652,10 +1647,13 @@ class ReservationControllerTest {
         @DisplayName("멤버의 예약 변경 승인 성공")
         void changeApproveReservation() throws Exception {
             //given
+            LocalDateTime approveDate = LocalDateTime.now().plusHours(1);
+
             ReservationRequestDto.ChangeApproveReservation request = ReservationRequestDto.ChangeApproveReservation
                     .builder()
                     .memberId(1L)
                     .isApprove(true)
+                    .approveDate(approveDate)
                     .build();
 
             Long reservationId = 1L;
@@ -1698,9 +1696,12 @@ class ReservationControllerTest {
         @DisplayName("멤버의 예약 변경 승인 실패 - 멤버 ID 부재")
         void changeApproveReservationNoMemberId() throws Exception {
             //given
+            LocalDateTime approveDate = LocalDateTime.now().plusHours(1);
+
             ReservationRequestDto.ChangeApproveReservation request = ReservationRequestDto.ChangeApproveReservation
                     .builder()
                     .isApprove(true)
+                    .approveDate(approveDate)
                     .build();
 
             Long reservationId = 1L;
@@ -1742,10 +1743,13 @@ class ReservationControllerTest {
         @Test
         @DisplayName("멤버의 예약 변경 승인 실패 - 승인 여부 부재")
         void changeApproveReservationNoIsApprove() throws Exception {
+            LocalDateTime approveDate = LocalDateTime.now().plusHours(1);
+
             //given
             ReservationRequestDto.ChangeApproveReservation request = ReservationRequestDto.ChangeApproveReservation
                     .builder()
                     .memberId(1L)
+                    .approveDate(approveDate)
                     .build();
 
             Long reservationId = 1L;

--- a/src/test/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationControllerTest.java
+++ b/src/test/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationControllerTest.java
@@ -1051,8 +1051,11 @@ class ReservationControllerTest {
         @DisplayName("트레이너가 예약 취소 성공")
         void cancelReservationWithTrainer() throws Exception {
             //given
+            LocalDateTime cancelDate = LocalDateTime.now().plusHours(2);
+
             ReservationRequestDto.CancelReservation request = ReservationRequestDto.CancelReservation.builder()
                     .cancelReason("개인 사정으로 인한 취소")
+                    .cancelDate(cancelDate)
                     .build();
 
             Long reservationId = 1L;
@@ -1094,8 +1097,11 @@ class ReservationControllerTest {
         @DisplayName("멤버가 예약 취소 성공")
         void cancelReservationWithMember() throws Exception {
             //given
+            LocalDateTime cancelDate = LocalDateTime.now().plusHours(2);
+
             ReservationRequestDto.CancelReservation request = ReservationRequestDto.CancelReservation.builder()
                     .cancelReason("개인 사정으로 인한 취소")
+                    .cancelDate(cancelDate)
                     .build();
 
             Long reservationId = 1L;
@@ -1137,7 +1143,10 @@ class ReservationControllerTest {
         @DisplayName("예약 취소 실패 - 취소 사유 부재")
         void cancelReservationWithNoReason() throws Exception {
             //given
+            LocalDateTime cancelDate = LocalDateTime.now().plusHours(2);
+
             ReservationRequestDto.CancelReservation request = ReservationRequestDto.CancelReservation.builder()
+                    .cancelDate(cancelDate)
                     .build();
 
             Long reservationId = 1L;

--- a/src/test/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationControllerTest.java
+++ b/src/test/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationControllerTest.java
@@ -1636,6 +1636,146 @@ class ReservationControllerTest {
 
     }
 
+    @Nested
+    @DisplayName("예약 변경 승인 Controller TEST")
+    class ChangeApproveReservationControllerTest {
+        @Test
+        @DisplayName("멤버의 예약 변경 승인 성공")
+        void changeApproveReservation() throws Exception {
+            //given
+            ReservationRequestDto.ChangeApproveReservation request = ReservationRequestDto.ChangeApproveReservation
+                    .builder()
+                    .memberId(1L)
+                    .isApprove(true)
+                    .build();
+
+            Long reservationId = 1L;
+
+            Reservation result = Reservation.builder()
+                    .reservationId(1L)
+                    .status(RESERVATION_APPROVED)
+                    .build();
+
+            PersonalDetail personalDetail = PersonalDetail.builder()
+                    .personalDetailId(1L)
+                    .name("트레이너1")
+                    .memberId(null)
+                    .trainerId(1L)
+                    .build();
+
+            SecurityUser user = new SecurityUser(personalDetail);
+
+            String accessToken = getAccessToken(personalDetail);
+
+            when(reservationFacade.changeApproveReservation(any(ReservationCriteria.ChangeApproveReservation.class)))
+                    .thenReturn(result);
+
+            //when & then
+            mockMvc.perform(post("/v1/reservations/%s/change-approve".formatted(reservationId))
+                            .header("Authorization", "Bearer " + accessToken)
+                            .with(oauth2Login().oauth2User(user))
+                            .with(csrf())
+                            .content(objectMapper.writeValueAsString(request))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.msg").value("OK"))
+                    .andExpect(jsonPath("$.data.status").value(RESERVATION_APPROVED.getName()));
+        }
+
+        @Test
+        @DisplayName("멤버의 예약 변경 승인 실패 - 멤버 ID 부재")
+        void changeApproveReservationNoMemberId() throws Exception {
+            //given
+            ReservationRequestDto.ChangeApproveReservation request = ReservationRequestDto.ChangeApproveReservation
+                    .builder()
+                    .isApprove(true)
+                    .build();
+
+            Long reservationId = 1L;
+
+            Reservation result = Reservation.builder()
+                    .reservationId(1L)
+                    .status(RESERVATION_APPROVED)
+                    .build();
+
+            PersonalDetail personalDetail = PersonalDetail.builder()
+                    .personalDetailId(1L)
+                    .name("트레이너1")
+                    .memberId(null)
+                    .trainerId(1L)
+                    .build();
+
+            SecurityUser user = new SecurityUser(personalDetail);
+
+            String accessToken = getAccessToken(personalDetail);
+
+            when(reservationFacade.changeApproveReservation(any(ReservationCriteria.ChangeApproveReservation.class)))
+                    .thenReturn(result);
+
+            //when & then
+            mockMvc.perform(post("/v1/reservations/%s/change-approve".formatted(reservationId))
+                            .header("Authorization", "Bearer " + accessToken)
+                            .with(oauth2Login().oauth2User(user))
+                            .with(csrf())
+                            .content(objectMapper.writeValueAsString(request))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(400))
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.msg").value("유저 ID는 필수값 입니다."))
+                    .andExpect(jsonPath("$.data").isEmpty());
+        }
+
+        @Test
+        @DisplayName("멤버의 예약 변경 승인 실패 - 승인 여부 부재")
+        void changeApproveReservationNoIsApprove() throws Exception {
+            //given
+            ReservationRequestDto.ChangeApproveReservation request = ReservationRequestDto.ChangeApproveReservation
+                    .builder()
+                    .memberId(1L)
+                    .build();
+
+            Long reservationId = 1L;
+
+            Reservation result = Reservation.builder()
+                    .reservationId(1L)
+                    .status(RESERVATION_APPROVED)
+                    .build();
+
+            PersonalDetail personalDetail = PersonalDetail.builder()
+                    .personalDetailId(1L)
+                    .name("트레이너1")
+                    .memberId(null)
+                    .trainerId(1L)
+                    .build();
+
+            SecurityUser user = new SecurityUser(personalDetail);
+
+            String accessToken = getAccessToken(personalDetail);
+
+            when(reservationFacade.changeApproveReservation(any(ReservationCriteria.ChangeApproveReservation.class)))
+                    .thenReturn(result);
+
+            //when & then
+            mockMvc.perform(post("/v1/reservations/%s/change-approve".formatted(reservationId))
+                            .header("Authorization", "Bearer " + accessToken)
+                            .with(oauth2Login().oauth2User(user))
+                            .with(csrf())
+                            .content(objectMapper.writeValueAsString(request))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(400))
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.msg").value("승인 여부는 필수값 입니다."))
+                    .andExpect(jsonPath("$.data").isEmpty());
+        }
+    }
+
     private String getAccessToken(PersonalDetail personalDetail) {
 
         String accessToken = "mockedAccessToken";


### PR DESCRIPTION
### 구현 기능

- `POST` "/v1/reservations/{reservationId}/change-approve" 예약 변경 승인 API

### 세부 사항

- 예약 변경 승인 API 개발 완료
- 테스트 코드 추가
- dev 환경 로깅 레벨 조정
    - 로깅 레벨이 debug라서, 배포 환경에서 로깅 파일이 너무 컨테이너에 많이 쌓여서 서버가 죽는 것 같아 조정했습니다!

### DB 변동사항

- 없음