### PR TITLE
[Fliz-213] BE 고정예약 로직 보완

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 
     /* AWS SNS */
     implementation 'software.amazon.awssdk:sns:2.31.10'
+    /* AWS SQS */
+    implementation("io.awspring.cloud:spring-cloud-aws-starter-sqs:3.3.0")
+
     /* FCM */
     implementation 'com.google.firebase:firebase-admin:9.2.0'
 

--- a/docker/mysql/initdb.d/create_table.sql
+++ b/docker/mysql/initdb.d/create_table.sql
@@ -118,6 +118,8 @@ CREATE TABLE session_info
     member_id       BIGINT,
     total_count     INT,
     remaining_count INT,
+    created_at        DATETIME(6),
+    updated_at        DATETIME(6),
     PRIMARY KEY (session_info_id)
 );
 
@@ -148,6 +150,7 @@ CREATE TABLE reservation
     status            ENUM ('FIXED_RESERVATION','DISABLED_TIME_RESERVATION', 'RESERVATION_WAITING','RESERVATION_APPROVED',
         'RESERVATION_CANCELLED', 'RESERVATION_REFUSED', 'RESERVATION_CHANGE_REQUEST', 'RESERVATION_COMPLETED'),
     cancel_reason     VARCHAR(255),
+    day_of_week         ENUM ('MONDAY', 'TUESDAY', 'WEDNESDAY','THURSDAY','FRIDAY','SATURDAY','SUNDAY'),
     is_day_off        BOOLEAN,
     created_at        DATETIME(6),
     updated_at        DATETIME(6),
@@ -212,4 +215,21 @@ CREATE TABLE attachment
     created_at         DATETIME(6),
     updated_at         DATETIME(6),
     PRIMARY KEY (attachment_id)
+);
+
+-- outbox 정보 테이블
+CREATE TABLE IF NOT EXISTS outbox
+(
+    outbox_id BIGINT NOT NULL AUTO_INCREMENT,
+    aggregate_type ENUM('RESERVATION'),
+    aggregate_id BIGINT,
+    message_id VARCHAR(255),
+    event_status ENUM('INIT', 'SEND_SUCCESS', 'SEND_FAIL'),
+    event_type ENUM('CREATE_FIXED_RESERVATION'),
+    payload TEXT,
+    retry_count INT NOT NULL DEFAULT 0,
+    sent_at DATETIME(6),
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    PRIMARY KEY (outbox_id)
 );

--- a/src/main/java/spring/fitlinkbe/application/attachment/AttachmentFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/attachment/AttachmentFacade.java
@@ -1,6 +1,5 @@
 package spring.fitlinkbe.application.attachment;
 
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,8 +45,6 @@ public class AttachmentFacade {
                 .attachmentId(attachment.getAttachmentId())
                 .build();
     }
-
-
 
     @Transactional
     public void updateProfile(Long personalDetailId, Long attachmentId) {

--- a/src/main/java/spring/fitlinkbe/application/reservation/criteria/ReservationCriteria.java
+++ b/src/main/java/spring/fitlinkbe/application/reservation/criteria/ReservationCriteria.java
@@ -66,6 +66,28 @@ public class ReservationCriteria {
     }
 
     @Builder(toBuilder = true)
+    public record EventCreateFixed(Long trainerId,
+                                   Long memberId,
+                                   Long sessionInfoId,
+                                   String name,
+                                   LocalDateTime confirmDate) {
+        public Reservation toDomain() {
+            LocalDateTime nextFixedDate = confirmDate.plusDays(7);
+
+            return Reservation.builder()
+                    .member(Member.builder().memberId(memberId).build())
+                    .trainer(Trainer.builder().trainerId(trainerId).build())
+                    .sessionInfo(SessionInfo.builder().SessionInfoId(sessionInfoId).build())
+                    .name(name)
+                    .reservationDates(List.of(nextFixedDate))
+                    .confirmDate(nextFixedDate)
+                    .dayOfWeek(nextFixedDate.getDayOfWeek())
+                    .status(FIXED_RESERVATION)
+                    .build();
+        }
+    }
+
+    @Builder(toBuilder = true)
     public record Cancel(Long reservationId, LocalDateTime cancelDate, String cancelReason) {
         public ReservationCommand.Cancel toCommand() {
             return ReservationCommand.Cancel.builder()

--- a/src/main/java/spring/fitlinkbe/domain/auth/AuthService.java
+++ b/src/main/java/spring/fitlinkbe/domain/auth/AuthService.java
@@ -31,7 +31,7 @@ public class AuthService {
         return tokenRepository.getByPersonalDetailId(personalDetailId)
                 .orElseThrow(() -> new CustomException(ErrorCode.TOKEN_NOT_FOUND));
     }
-  
+
     public PersonalDetail getPersonalDetailById(Long personalDetailId) {
         return personalDetailRepository.getById(personalDetailId);
     }

--- a/src/main/java/spring/fitlinkbe/domain/common/event/OutboxEvent.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/event/OutboxEvent.java
@@ -1,0 +1,15 @@
+package spring.fitlinkbe.domain.common.event;
+
+import spring.fitlinkbe.domain.outbox.command.OutboxCommand;
+
+public interface OutboxEvent {
+    String getTopic();
+
+    String getKey();
+
+    String toPayload();
+
+    String getMessageId();
+
+    OutboxCommand.Create toOutboxCommand();
+}

--- a/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
@@ -84,9 +84,16 @@ public enum ErrorCode {
     INVALID_CONTENT_TYPE("유효하지 않은 Content-Type 입니다.", 400),
     INVALID_CONTENT_LENGTH("유효하지 않은 Content-Length 입니다.", 400),
 
-
     // Attachment 관련 ErrorCode
     ATTACHMENT_NOT_FOUND("첨부파일을 찾을 수 없습니다.", 404),
+
+    // Outbox 관련
+    OUTBOX_IS_FAILED("outbox 데이터 생성에 실패하였습니다.", 400),
+    OUTBOX_IS_NOT_FOUND("outbox 데이터가 존재하지 않습니다.", 404),
+    OUTBOX_IS_ALREADY_DONE("이미 완료된 outbox 데이터 입니다.", 400),
+    OUTBOX_IS_ALREADY_FAIL("이미 실패한 outbox 데이터 입니다.", 400),
+    OUTBOX_IS_NOT_INIT_STATUS("outbox 데이터가 초기 상태가 아닙니다.", 400),
+    OUTBOX_PAYLOAD_INVALID("outbox 데이터가 정상 상태가 아닙니다.", 400),
 
     ;
 

--- a/src/main/java/spring/fitlinkbe/domain/common/model/PersonalDetail.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/model/PersonalDetail.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import spring.fitlinkbe.domain.attachment.model.Attachment;
 import spring.fitlinkbe.domain.common.enums.UserRole;
 import spring.fitlinkbe.domain.common.exception.CustomException;
 import spring.fitlinkbe.domain.common.exception.ErrorCode;
@@ -123,5 +122,4 @@ public class PersonalDetail {
         SUSPEND, // 중지된 상태
         DELETE // 삭제된 상태
     }
-
 }

--- a/src/main/java/spring/fitlinkbe/domain/outbox/Outbox.java
+++ b/src/main/java/spring/fitlinkbe/domain/outbox/Outbox.java
@@ -1,0 +1,85 @@
+package spring.fitlinkbe.domain.outbox;
+
+import lombok.*;
+import spring.fitlinkbe.domain.common.exception.CustomException;
+
+import java.time.LocalDateTime;
+
+import static spring.fitlinkbe.domain.common.exception.ErrorCode.OUTBOX_IS_ALREADY_DONE;
+import static spring.fitlinkbe.domain.common.exception.ErrorCode.OUTBOX_IS_ALREADY_FAIL;
+
+@Builder(toBuilder = true)
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Outbox {
+
+    private Long outboxId;
+
+    private AggregateType aggregateType;
+
+    private Long aggregateId;
+
+    private String messageId;
+
+    private EventStatus eventStatus;
+
+    private EventType eventType;
+
+    private String payload;
+
+    private int retryCount;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime sentAt;
+
+    public void publish() {
+        if (eventStatus == EventStatus.SEND_SUCCESS) {
+            throw new CustomException(OUTBOX_IS_ALREADY_DONE,
+                    OUTBOX_IS_ALREADY_DONE.getMsg());
+        }
+
+        if (eventStatus == EventStatus.SEND_FAIL) {
+            throw new CustomException(OUTBOX_IS_ALREADY_FAIL,
+                    OUTBOX_IS_ALREADY_FAIL.getMsg());
+        }
+        eventStatus = EventStatus.SEND_SUCCESS;
+    }
+
+
+    public void plusRetryCount() {
+        retryCount++;
+    }
+
+    public void fail() {
+        if (eventStatus == EventStatus.SEND_SUCCESS) {
+            throw new CustomException(OUTBOX_IS_ALREADY_DONE,
+                    OUTBOX_IS_ALREADY_DONE.getMsg());
+        }
+
+        eventStatus = EventStatus.SEND_FAIL;
+    }
+
+    public void restore() {
+        eventStatus = EventStatus.INIT;
+    }
+
+    public enum AggregateType {
+        RESERVATION
+    }
+
+    public enum EventStatus {
+        INIT,
+        SEND_SUCCESS,
+        SEND_FAIL
+    }
+
+    @RequiredArgsConstructor
+    @Getter
+    public enum EventType {
+        CREATE_FIXED_RESERVATION("고정 예약 생성");
+        private final String msg;
+    }
+
+}

--- a/src/main/java/spring/fitlinkbe/domain/outbox/OutboxRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/outbox/OutboxRepository.java
@@ -1,0 +1,15 @@
+package spring.fitlinkbe.domain.outbox;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface OutboxRepository {
+
+    Optional<Outbox> getOutbox(String messageId);
+
+    Optional<Outbox> saveOutbox(Outbox outbox);
+
+    List<Outbox> getRetryOutboxes();
+
+    List<Outbox> getOutboxes();
+}

--- a/src/main/java/spring/fitlinkbe/domain/outbox/OutboxService.java
+++ b/src/main/java/spring/fitlinkbe/domain/outbox/OutboxService.java
@@ -1,0 +1,76 @@
+package spring.fitlinkbe.domain.outbox;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import spring.fitlinkbe.domain.common.exception.CustomException;
+import spring.fitlinkbe.domain.outbox.command.OutboxCommand;
+import spring.fitlinkbe.domain.producer.EventProducer;
+import spring.fitlinkbe.domain.reservation.event.GenerateFixedReservationEvent;
+import spring.fitlinkbe.support.utils.JsonUtils;
+
+import java.util.List;
+
+import static spring.fitlinkbe.domain.common.exception.ErrorCode.OUTBOX_IS_FAILED;
+import static spring.fitlinkbe.domain.common.exception.ErrorCode.OUTBOX_IS_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class OutboxService {
+    private final OutboxRepository outboxRepository;
+    private final EventProducer eventProducer;
+
+    public Outbox save(OutboxCommand.Create command) {
+
+        return outboxRepository.saveOutbox(command.toDomain()).orElseThrow(() ->
+                new CustomException(OUTBOX_IS_FAILED, OUTBOX_IS_FAILED.getMsg()));
+    }
+
+    public Outbox publish(String messageId) {
+        Outbox outbox = outboxRepository.getOutbox(messageId).orElseThrow(() ->
+                new CustomException(OUTBOX_IS_NOT_FOUND, OUTBOX_IS_NOT_FOUND.getMsg()));
+        // outbox 메시지 발행 완료
+        outbox.publish();
+        outboxRepository.saveOutbox(outbox);
+
+        return outbox;
+    }
+
+    public void retryFailMessage() {
+        // Outbox 테이블에서 재시도가 필요한 메시지 조회
+        List<Outbox> retryOutboxes = outboxRepository.getRetryOutboxes();
+        if (retryOutboxes.isEmpty()) {
+            return;
+        }
+
+        for (Outbox outbox : retryOutboxes) {
+
+            if (outbox.getRetryCount() >= 3) {
+                // 이미 3회 이상 재시도한 메시지 실패 처리
+                outbox.fail();
+                outboxRepository.saveOutbox(outbox);
+                continue;
+            }
+            try {
+                // 재시도 로직, outbox message 발행 완료 변경, KafkaProducer 를 통해 메시지 재발행
+                outbox.publish();
+                outboxRepository.saveOutbox(outbox);
+                GenerateFixedReservationEvent payload = JsonUtils.toObject(outbox.getPayload(),
+                        GenerateFixedReservationEvent.class);
+                assert payload != null;
+                eventProducer.publish(outbox.getEventType().toString(), payload.getKey(), outbox.getPayload());
+
+            } catch (Exception e) {
+                log.error("send retry exception -> outboxId: {}, error: {}", outbox.getOutboxId(), e.getMessage());
+                outbox.restore();
+                outboxRepository.saveOutbox(outbox);
+            }
+            // 재시도 횟수 추가
+            outbox.plusRetryCount();
+            outboxRepository.saveOutbox(outbox);
+        }
+    }
+}

--- a/src/main/java/spring/fitlinkbe/domain/outbox/OutboxService.java
+++ b/src/main/java/spring/fitlinkbe/domain/outbox/OutboxService.java
@@ -23,13 +23,13 @@ public class OutboxService {
     private final OutboxRepository outboxRepository;
     private final EventProducer eventProducer;
 
-    public Outbox save(OutboxCommand.Create command) {
+    public Outbox createOutbox(OutboxCommand.Create command) {
 
         return outboxRepository.saveOutbox(command.toDomain()).orElseThrow(() ->
                 new CustomException(OUTBOX_IS_FAILED, OUTBOX_IS_FAILED.getMsg()));
     }
 
-    public Outbox publish(String messageId) {
+    public Outbox publishOutbox(String messageId) {
         Outbox outbox = outboxRepository.getOutbox(messageId).orElseThrow(() ->
                 new CustomException(OUTBOX_IS_NOT_FOUND, OUTBOX_IS_NOT_FOUND.getMsg()));
         // outbox 메시지 발행 완료

--- a/src/main/java/spring/fitlinkbe/domain/outbox/command/OutboxCommand.java
+++ b/src/main/java/spring/fitlinkbe/domain/outbox/command/OutboxCommand.java
@@ -1,0 +1,26 @@
+package spring.fitlinkbe.domain.outbox.command;
+
+import spring.fitlinkbe.domain.outbox.Outbox;
+
+
+public class OutboxCommand {
+    public record Create(
+            Outbox.AggregateType aggregateType,
+            Long aggregateId,
+            String messageId,
+            Outbox.EventStatus eventStatus,
+            Outbox.EventType eventType,
+            String payload) {
+
+        public Outbox toDomain() {
+            return Outbox.builder()
+                    .aggregateType(aggregateType)
+                    .aggregateId(aggregateId)
+                    .messageId(messageId)
+                    .eventStatus(eventStatus)
+                    .eventType(eventType)
+                    .payload(payload)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/spring/fitlinkbe/domain/outbox/command/OutboxCommand.java
+++ b/src/main/java/spring/fitlinkbe/domain/outbox/command/OutboxCommand.java
@@ -1,9 +1,12 @@
 package spring.fitlinkbe.domain.outbox.command;
 
+import lombok.Builder;
 import spring.fitlinkbe.domain.outbox.Outbox;
 
 
 public class OutboxCommand {
+
+    @Builder(toBuilder = true)
     public record Create(
             Outbox.AggregateType aggregateType,
             Long aggregateId,

--- a/src/main/java/spring/fitlinkbe/domain/outbox/listener/OutboxEventListener.java
+++ b/src/main/java/spring/fitlinkbe/domain/outbox/listener/OutboxEventListener.java
@@ -1,0 +1,34 @@
+package spring.fitlinkbe.domain.outbox.listener;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import spring.fitlinkbe.domain.common.event.OutboxEvent;
+import spring.fitlinkbe.domain.outbox.OutboxService;
+import spring.fitlinkbe.domain.producer.EventProducer;
+
+@Component
+@RequiredArgsConstructor
+public class OutboxEventListener {
+
+    private final OutboxService outboxService;
+    private final EventProducer eventProducer;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void saveOutbox(OutboxEvent event) {
+        // Outbox data 생성
+        outboxService.save(event.toOutboxCommand());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void publishOutbox(OutboxEvent event) {
+        // outbox 메시지 발행 완료 채크
+        outboxService.publish(event.getMessageId());
+        // 이벤트 메시지 발행
+        eventProducer.publish(event.getTopic(), event.getKey(), event.toPayload());
+    }
+}

--- a/src/main/java/spring/fitlinkbe/domain/outbox/listener/OutboxEventListener.java
+++ b/src/main/java/spring/fitlinkbe/domain/outbox/listener/OutboxEventListener.java
@@ -20,14 +20,14 @@ public class OutboxEventListener {
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void saveOutbox(OutboxEvent event) {
         // Outbox data 생성
-        outboxService.save(event.toOutboxCommand());
+        outboxService.createOutbox(event.toOutboxCommand());
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void publishOutbox(OutboxEvent event) {
         // outbox 메시지 발행 완료 채크
-        outboxService.publish(event.getMessageId());
+        outboxService.publishOutbox(event.getMessageId());
         // 이벤트 메시지 발행
         eventProducer.publish(event.getTopic(), event.getKey(), event.toPayload());
     }

--- a/src/main/java/spring/fitlinkbe/domain/producer/EventProducer.java
+++ b/src/main/java/spring/fitlinkbe/domain/producer/EventProducer.java
@@ -1,0 +1,6 @@
+package spring.fitlinkbe.domain.producer;
+
+public interface EventProducer {
+
+    void publish(String topic, String key, String payload);
+}

--- a/src/main/java/spring/fitlinkbe/domain/reservation/Reservation.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/Reservation.java
@@ -10,6 +10,7 @@ import spring.fitlinkbe.domain.trainer.Trainer;
 import spring.fitlinkbe.support.utils.DateUtils;
 
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -56,26 +57,6 @@ public class Reservation {
         RESERVATION_COMPLETED("예약 종료"); // 세션까지 완전 완료 되었을 때
 
         private final String name;
-    }
-
-    public Reservation toFixedDomain() {
-
-        return Reservation.builder()
-                .member(member)
-                .trainer(trainer)
-                .sessionInfo(sessionInfo)
-                .name(name)
-                .reservationDates(getAfterSevenDay())
-                .confirmDate(confirmDate)
-                .dayOfWeek(dayOfWeek)
-                .status(FIXED_RESERVATION)
-                .isDayOff(isDayOff)
-                .createdAt(createdAt)
-                .build();
-    }
-
-    public List<LocalDateTime> getAfterSevenDay() {
-        return this.reservationDates.stream().map(date -> date.plusDays(7)).toList();
     }
 
     public void changeFixedDate(LocalDateTime reservationDate, LocalDateTime changeDate) {
@@ -169,6 +150,15 @@ public class Reservation {
                 });
     }
 
+    public boolean isTodayReservation() {
+        LocalDate today = LocalDate.now();
+
+        return reservationDates
+                .stream()
+                .map(LocalDateTime::toLocalDate)
+                .anyMatch(today::isEqual);
+    }
+
     public boolean isReservationInRange(LocalDateTime startDate, LocalDateTime endDate) {
         LocalDateTime reservationDate = getReservationDate();
 
@@ -257,5 +247,4 @@ public class Reservation {
 
         return (this.isDayOff || (this.status == DISABLED_TIME_RESERVATION));
     }
-
 }

--- a/src/main/java/spring/fitlinkbe/domain/reservation/event/GenerateFixedReservationEvent.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/event/GenerateFixedReservationEvent.java
@@ -1,0 +1,50 @@
+package spring.fitlinkbe.domain.reservation.event;
+
+import lombok.Builder;
+import spring.fitlinkbe.domain.common.event.OutboxEvent;
+import spring.fitlinkbe.domain.outbox.Outbox;
+import spring.fitlinkbe.domain.outbox.command.OutboxCommand;
+import spring.fitlinkbe.support.utils.JsonUtils;
+
+import java.time.LocalDateTime;
+
+
+@Builder(toBuilder = true)
+public record GenerateFixedReservationEvent(
+        Long reservationId,
+        String messageId,
+        Long trainerId,
+        Long memberId,
+        Long sessionInfoId,
+        String name,
+        LocalDateTime confirmDate,
+        String topic
+) implements OutboxEvent {
+
+    @Override
+    public String getTopic() {
+        return topic;
+    }
+
+    @Override
+    public String getKey() {
+        return reservationId.toString();
+    }
+
+    @Override
+    public String toPayload() {
+        return JsonUtils.toJson(this);
+    }
+
+    @Override
+    public String getMessageId() {
+        return messageId;
+    }
+
+    @Override
+    public OutboxCommand.Create toOutboxCommand() {
+        return new OutboxCommand.Create(Outbox.AggregateType.RESERVATION, reservationId, messageId, Outbox.EventStatus.INIT,
+                Outbox.EventType.CREATE_FIXED_RESERVATION, toPayload());
+    }
+
+}

--- a/src/main/java/spring/fitlinkbe/domain/trainer/TrainerService.java
+++ b/src/main/java/spring/fitlinkbe/domain/trainer/TrainerService.java
@@ -3,7 +3,6 @@ package spring.fitlinkbe.domain.trainer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import spring.fitlinkbe.domain.auth.command.AuthCommand;
 import spring.fitlinkbe.domain.common.ConnectingInfoRepository;
 import spring.fitlinkbe.domain.common.PersonalDetailRepository;
 import spring.fitlinkbe.domain.common.exception.CustomException;

--- a/src/main/java/spring/fitlinkbe/infra/attachment/AttachmentEntity.java
+++ b/src/main/java/spring/fitlinkbe/infra/attachment/AttachmentEntity.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.stereotype.Component;
 import spring.fitlinkbe.domain.attachment.model.Attachment;
 import spring.fitlinkbe.infra.common.model.BaseTimeEntity;
 import spring.fitlinkbe.infra.common.personaldetail.PersonalDetailEntity;

--- a/src/main/java/spring/fitlinkbe/infra/outbox/OutboxEntity.java
+++ b/src/main/java/spring/fitlinkbe/infra/outbox/OutboxEntity.java
@@ -1,0 +1,74 @@
+package spring.fitlinkbe.infra.outbox;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import spring.fitlinkbe.domain.outbox.Outbox;
+import spring.fitlinkbe.infra.common.model.BaseTimeEntity;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "outbox")
+public class OutboxEntity extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long outboxId;
+
+    @Enumerated(EnumType.STRING)
+    private Outbox.AggregateType aggregateType;
+
+    private Long aggregateId;
+
+    private String messageId;
+
+    @Enumerated(EnumType.STRING)
+    private Outbox.EventStatus eventStatus;
+
+    @Enumerated(EnumType.STRING)
+    private Outbox.EventType eventType;
+
+    @Column(columnDefinition = "TEXT")
+    private String payload;
+
+    private int retryCount;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    private LocalDateTime sentAt;
+
+    public static OutboxEntity toEntity(Outbox outbox) {
+        return OutboxEntity.builder()
+                .outboxId(outbox.getOutboxId())
+                .aggregateType(outbox.getAggregateType())
+                .aggregateId(outbox.getAggregateId())
+                .messageId(outbox.getMessageId())
+                .eventStatus(outbox.getEventStatus())
+                .eventType(outbox.getEventType())
+                .payload(outbox.getPayload())
+                .retryCount(outbox.getRetryCount())
+                .createdAt(outbox.getCreatedAt())
+                .sentAt(outbox.getSentAt())
+                .build();
+    }
+
+    public Outbox toDomain() {
+        return Outbox.builder()
+                .outboxId(outboxId)
+                .aggregateType(aggregateType)
+                .aggregateId(aggregateId)
+                .messageId(messageId)
+                .eventStatus(eventStatus)
+                .eventType(eventType)
+                .payload(payload)
+                .retryCount(retryCount)
+                .createdAt(createdAt)
+                .sentAt(sentAt)
+                .build();
+    }
+}

--- a/src/main/java/spring/fitlinkbe/infra/outbox/OutboxJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/outbox/OutboxJpaRepository.java
@@ -1,0 +1,13 @@
+package spring.fitlinkbe.infra.outbox;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import spring.fitlinkbe.domain.outbox.Outbox;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface OutboxJpaRepository extends JpaRepository<OutboxEntity, Long> {
+    List<OutboxEntity> findByEventStatusIs(Outbox.EventStatus status);
+
+    Optional<OutboxEntity> findByMessageId(String messageId);
+}

--- a/src/main/java/spring/fitlinkbe/infra/outbox/OutboxRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/outbox/OutboxRepositoryImpl.java
@@ -1,0 +1,49 @@
+package spring.fitlinkbe.infra.outbox;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import spring.fitlinkbe.domain.outbox.Outbox;
+import spring.fitlinkbe.domain.outbox.OutboxRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class OutboxRepositoryImpl implements OutboxRepository {
+
+    private final OutboxJpaRepository outboxJpaRepository;
+
+    @Override
+    public Optional<Outbox> getOutbox(String messageId) {
+        Optional<OutboxEntity> outboxEntity = outboxJpaRepository.findByMessageId(messageId);
+        if (outboxEntity.isPresent()) {
+            return outboxEntity.map(OutboxEntity::toDomain);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public List<Outbox> getOutboxes() {
+        return outboxJpaRepository.findAll()
+                .stream()
+                .map(OutboxEntity::toDomain)
+                .toList();
+    }
+
+    @Override
+    public Optional<Outbox> saveOutbox(Outbox outbox) {
+        OutboxEntity outboxEntity = outboxJpaRepository.save(OutboxEntity.toEntity(outbox));
+        return Optional.of(outboxEntity.toDomain());
+
+    }
+
+    @Override
+    public List<Outbox> getRetryOutboxes() {
+
+        return outboxJpaRepository.findByEventStatusIs(Outbox.EventStatus.INIT).stream()
+                .map(OutboxEntity::toDomain)
+                .toList();
+
+    }
+}

--- a/src/main/java/spring/fitlinkbe/infra/producer/EventProducerImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/producer/EventProducerImpl.java
@@ -1,0 +1,17 @@
+package spring.fitlinkbe.infra.producer;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import spring.fitlinkbe.domain.producer.EventProducer;
+
+@Component
+@RequiredArgsConstructor
+public class EventProducerImpl implements EventProducer {
+
+    private final SqsProducer sqsProducer;
+
+    @Override
+    public void publish(String topic, String key, String payload) {
+        sqsProducer.publish(topic, payload);
+    }
+}

--- a/src/main/java/spring/fitlinkbe/infra/producer/EventTopic.java
+++ b/src/main/java/spring/fitlinkbe/infra/producer/EventTopic.java
@@ -1,0 +1,13 @@
+package spring.fitlinkbe.infra.producer;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class EventTopic {
+
+    @Value("${spring.cloud.aws.sqs.queue-name}")
+    private String reservationQueue;
+}

--- a/src/main/java/spring/fitlinkbe/infra/producer/SqsProducer.java
+++ b/src/main/java/spring/fitlinkbe/infra/producer/SqsProducer.java
@@ -1,0 +1,25 @@
+package spring.fitlinkbe.infra.producer;
+
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SqsProducer {
+
+    private final SqsTemplate sqsTemplate;
+
+    public void publish(String topic, String payload) {
+        log.info("[SQS] :: PUBLISH :: sending to queue={}, payload={}", topic, payload);
+
+        try {
+            sqsTemplate.send(to -> to.queue(topic).payload(payload));
+            log.info("[SQS] :: SUCCESS :: queue={}, payload={}", topic, payload);
+        } catch (Exception ex) {
+            log.error("[SQS] :: FAILED :: queue={}, payload={}, error={}", topic, payload, ex.getMessage(), ex);
+        }
+    }
+}

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationJpaRepository.java
@@ -26,16 +26,14 @@ public interface ReservationJpaRepository extends JpaRepository<ReservationEntit
             "LEFT JOIN FETCH r.member " +
             "LEFT JOIN FETCH r.trainer " +
             "LEFT JOIN FETCH r.sessionInfo " +
-            "WHERE r.member.memberId = :memberId " +
-            "AND r.createdAt > CURRENT_TIMESTAMP")
+            "WHERE r.member.memberId = :memberId")
     List<ReservationEntity> findByMember_MemberId(Long memberId);
 
     @Query("SELECT r FROM ReservationEntity r " +
             "LEFT JOIN FETCH r.member " +
             "LEFT JOIN FETCH r.trainer " +
             "LEFT JOIN FETCH r.sessionInfo " +
-            "WHERE r.trainer.trainerId = :trainerId " +
-            "AND r.createdAt > CURRENT_TIMESTAMP")
+            "WHERE r.trainer.trainerId = :trainerId")
     List<ReservationEntity> findByTrainer_TrainerId(Long trainerId);
 
     @Query("SELECT r FROM ReservationEntity r " +
@@ -43,23 +41,20 @@ public interface ReservationJpaRepository extends JpaRepository<ReservationEntit
             "LEFT JOIN FETCH r.trainer " +
             "LEFT JOIN FETCH r.sessionInfo " +
             "WHERE r.trainer.trainerId = :trainerId " +
-            "AND r.status = spring.fitlinkbe.domain.reservation.Reservation.Status.RESERVATION_WAITING " +
-            "AND r.createdAt > CURRENT_TIMESTAMP")
+            "AND r.status = spring.fitlinkbe.domain.reservation.Reservation.Status.RESERVATION_WAITING")
     List<ReservationEntity> findWaitingStatus(Long trainerId);
 
     @Query("SELECT r FROM ReservationEntity r " +
             "LEFT JOIN FETCH r.member " +
             "LEFT JOIN FETCH r.trainer " +
-            "LEFT JOIN FETCH r.sessionInfo " +
-            "WHERE r.createdAt > CURRENT_TIMESTAMP")
+            "LEFT JOIN FETCH r.sessionInfo")
     List<ReservationEntity> findAllAfterToday();
 
     @Query("SELECT r FROM ReservationEntity r " +
             "LEFT JOIN FETCH r.member " +
             "LEFT JOIN FETCH r.trainer " +
             "LEFT JOIN FETCH r.sessionInfo " +
-            "WHERE r.status = spring.fitlinkbe.domain.reservation.Reservation.Status.FIXED_RESERVATION " +
-            "AND r.createdAt > CURRENT_TIMESTAMP")
+            "WHERE r.status = spring.fitlinkbe.domain.reservation.Reservation.Status.FIXED_RESERVATION")
     List<ReservationEntity> findFixedStatus();
 
     @Query("SELECT COUNT(r) > 0 FROM ReservationEntity r " +

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationRepositoryImpl.java
@@ -67,8 +67,8 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     }
 
     @Override
-    public List<Reservation> saveReservations(List<Reservation> canceledReservations) {
-        List<ReservationEntity> entities = canceledReservations.stream()
+    public List<Reservation> saveReservations(List<Reservation> reservations) {
+        List<ReservationEntity> entities = reservations.stream()
                 .map(r -> ReservationEntity.from(r, em))
                 .toList();
 

--- a/src/main/java/spring/fitlinkbe/interfaces/comsumer/Dummy.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/comsumer/Dummy.java
@@ -1,4 +1,0 @@
-package spring.fitlinkbe.interfaces.comsumer;
-
-public class Dummy {
-}

--- a/src/main/java/spring/fitlinkbe/interfaces/comsumer/ReservationConsumer.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/comsumer/ReservationConsumer.java
@@ -1,0 +1,35 @@
+package spring.fitlinkbe.interfaces.comsumer;
+
+import io.awspring.cloud.sqs.annotation.SqsListener;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import spring.fitlinkbe.application.reservation.ReservationFacade;
+import spring.fitlinkbe.application.reservation.criteria.ReservationCriteria;
+import spring.fitlinkbe.domain.common.exception.CustomException;
+import spring.fitlinkbe.domain.common.exception.ErrorCode;
+import spring.fitlinkbe.domain.reservation.event.GenerateFixedReservationEvent;
+import spring.fitlinkbe.support.utils.JsonUtils;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ReservationConsumer {
+
+    private final ReservationFacade reservationFacade;
+
+    @SqsListener(queueNames = "${spring.cloud.aws.sqs.queue-name}")
+    public void handleReservationMessage(String message) {
+        GenerateFixedReservationEvent payload = JsonUtils.toObject(message, GenerateFixedReservationEvent.class);
+        if (payload == null) {
+            throw new CustomException(ErrorCode.OUTBOX_PAYLOAD_INVALID);
+        }
+        // 일주일 뒤 예약 진행
+        reservationFacade.executeCreateFixedReservation(ReservationCriteria.EventCreateFixed.builder()
+                .memberId(payload.memberId())
+                .trainerId(payload.trainerId())
+                .sessionInfoId(payload.sessionInfoId())
+                .confirmDate(payload.confirmDate())
+                .build());
+    }
+}

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/notification/dto/NotificationResponseDto.java
@@ -51,6 +51,7 @@ public class NotificationResponseDto {
 
             return Detail.builder()
                     .notificationId(notification.getNotificationId())
+                    .refId(notification.getRefId())
                     .type(notification.getRefType().getName())
                     .content(notification.getContent())
                     .sendDate(notification.getSendDate())

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/trainer/dto/AvailableTimesDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/trainer/dto/AvailableTimesDto.java
@@ -31,7 +31,7 @@ public class AvailableTimesDto {
     @Builder
     public record CurrentAvailableTimesResponse(
             ScheduledChangeResponse currentSchedules
-    ){
+    ) {
         public static CurrentAvailableTimesResponse from(AvailableTimesResult.CurrentAvailableTimesResponse response) {
             return CurrentAvailableTimesResponse.builder()
                     .currentSchedules(ScheduledChangeResponse.from(response.currentSchedules()))
@@ -140,4 +140,3 @@ public class AvailableTimesDto {
         }
     }
 }
-

--- a/src/main/java/spring/fitlinkbe/interfaces/scheduler/ReservationScheduler.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/scheduler/ReservationScheduler.java
@@ -22,7 +22,7 @@ public class ReservationScheduler { //
     }
 
     /**
-     * 매일 정각마다, 오늘 수입인 사람을 찾아서 알림을 보낸다.
+     * 매일 정각마다, 오늘 수업인 사람을 찾아서 알림을 보낸다.
      */
     @Scheduled(cron = "0 0 0 * * *") // 매일 00:00:00에 실행
     public void sessionReminder() {

--- a/src/main/java/spring/fitlinkbe/support/config/AsyncConfig.java
+++ b/src/main/java/spring/fitlinkbe/support/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package spring.fitlinkbe.support.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/spring/fitlinkbe/support/config/AwsProperties.java
+++ b/src/main/java/spring/fitlinkbe/support/config/AwsProperties.java
@@ -13,7 +13,7 @@ public class AwsProperties {
     private final Credentials credentials;
     private final Region region;
     private final S3 s3;
-
+    private final Sqs sqs;
 
     public String getAccessKey() {
         return credentials != null ? credentials.getAccessKey() : null;
@@ -48,5 +48,11 @@ public class AwsProperties {
     @RequiredArgsConstructor(onConstructor_ = @ConstructorBinding)
     public static class S3 {
         private final String bucketName;
+    }
+
+    @Getter
+    @RequiredArgsConstructor(onConstructor_ = @ConstructorBinding)
+    public static class Sqs {
+        private final String queueName;
     }
 }

--- a/src/main/java/spring/fitlinkbe/support/config/JpaAuditConfig.java
+++ b/src/main/java/spring/fitlinkbe/support/config/JpaAuditConfig.java
@@ -1,0 +1,9 @@
+package spring.fitlinkbe.support.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditConfig {
+}

--- a/src/main/java/spring/fitlinkbe/support/config/SchedulerConfig.java
+++ b/src/main/java/spring/fitlinkbe/support/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package spring.fitlinkbe.support.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/spring/fitlinkbe/support/utils/JsonUtils.java
+++ b/src/main/java/spring/fitlinkbe/support/utils/JsonUtils.java
@@ -1,0 +1,42 @@
+package spring.fitlinkbe.support.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Slf4j
+public class JsonUtils {
+
+    private static final ObjectMapper objectMapper;
+
+    static {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    public static String toJson(Object object) {
+        try {
+            return objectMapper.writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            log.error("Error serializing object to JSON: {}", e.getMessage());
+            return "";
+        }
+    }
+
+    public static <T> T toObject(String jsonModel, Class<T> targetClass) {
+        try {
+            return objectMapper.readValue(jsonModel, targetClass);
+        } catch (RuntimeException | JsonProcessingException e) {
+            log.error("Error deserializing JSON to object: {}", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/test/java/spring/fitlinkbe/config/TestSqsConfig.java
+++ b/src/test/java/spring/fitlinkbe/config/TestSqsConfig.java
@@ -1,0 +1,38 @@
+package spring.fitlinkbe.config;
+
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest;
+import software.amazon.awssdk.services.sqs.model.GetQueueUrlResponse;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@TestConfiguration
+public class TestSqsConfig {
+
+    @Bean
+    public SqsAsyncClient sqsAsyncClient() {
+        SqsAsyncClient mockClient = mock(SqsAsyncClient.class);
+
+        // getQueueUrl 호출에 대한 mock 설정
+        GetQueueUrlResponse response = GetQueueUrlResponse.builder()
+                .queueUrl("https://sqs/test-queue")
+                .build();
+
+        when(mockClient.getQueueUrl(any(GetQueueUrlRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        return mockClient;
+    }
+
+    @Bean
+    public SqsTemplate sqsTemplate(SqsAsyncClient sqsAsyncClient) {
+        return SqsTemplate.newTemplate(sqsAsyncClient);
+    }
+}

--- a/src/test/java/spring/fitlinkbe/domain/outbox/OutboxServiceTest.java
+++ b/src/test/java/spring/fitlinkbe/domain/outbox/OutboxServiceTest.java
@@ -1,0 +1,108 @@
+package spring.fitlinkbe.domain.outbox;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import spring.fitlinkbe.domain.outbox.command.OutboxCommand;
+import spring.fitlinkbe.domain.producer.EventProducer;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+public class OutboxServiceTest {
+
+    @Mock
+    private OutboxRepository outboxRepository;
+
+    @Mock
+    private EventProducer eventProducer;
+
+    @InjectMocks
+    private OutboxService outboxService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Nested
+    @DisplayName("outbox 생성 TEST")
+    class CreateOutboxServiceTest {
+        @Test
+        @DisplayName("outbox 생성 - 성공")
+        void createOutbox() {
+            //given
+            String messageId = UUID.randomUUID().toString();
+            String payload = "good";
+
+            OutboxCommand.Create command = OutboxCommand.Create.builder()
+                    .aggregateId(1L)
+                    .aggregateType(Outbox.AggregateType.RESERVATION)
+                    .eventStatus(Outbox.EventStatus.INIT)
+                    .eventType(Outbox.EventType.CREATE_FIXED_RESERVATION)
+                    .messageId(messageId)
+                    .payload(payload)
+                    .build();
+
+            Outbox outbox = Outbox.builder()
+                    .outboxId(1L)
+                    .aggregateId(1L)
+                    .aggregateType(Outbox.AggregateType.RESERVATION)
+                    .eventStatus(Outbox.EventStatus.INIT)
+                    .eventType(Outbox.EventType.CREATE_FIXED_RESERVATION)
+                    .messageId(messageId)
+                    .payload(payload)
+                    .build();
+
+            when(outboxRepository.saveOutbox(any(Outbox.class))).thenReturn(Optional.ofNullable(outbox));
+
+            //when
+            Outbox result = outboxService.createOutbox(command);
+
+            //then
+            assertThat(result).isNotNull();
+            assertThat(result.getPayload()).isEqualTo(payload);
+            assertThat(result.getEventStatus()).isEqualTo(Outbox.EventStatus.INIT);
+        }
+    }
+
+    @Nested
+    @DisplayName("outbox 발행 TEST")
+    class PublishOutboxServiceTest {
+        @Test
+        @DisplayName("outbox 발행 - 성공")
+        void createOutbox() {
+            //given
+            String messageId = UUID.randomUUID().toString();
+            String payload = "good";
+
+            Outbox outbox = Outbox.builder()
+                    .outboxId(1L)
+                    .aggregateId(1L)
+                    .aggregateType(Outbox.AggregateType.RESERVATION)
+                    .eventStatus(Outbox.EventStatus.INIT)
+                    .eventType(Outbox.EventType.CREATE_FIXED_RESERVATION)
+                    .messageId(messageId)
+                    .payload(payload)
+                    .build();
+
+            when(outboxRepository.getOutbox(messageId)).thenReturn(Optional.ofNullable(outbox));
+
+            //when
+            Outbox result = outboxService.publishOutbox(messageId);
+
+            //then
+            assertThat(result).isNotNull();
+            assertThat(result.getPayload()).isEqualTo(payload);
+            assertThat(result.getEventStatus()).isEqualTo(Outbox.EventStatus.SEND_SUCCESS);
+        }
+    }
+}

--- a/src/test/java/spring/fitlinkbe/integration/ReservationIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/ReservationIntegrationTest.java
@@ -16,6 +16,8 @@ import spring.fitlinkbe.domain.member.Member;
 import spring.fitlinkbe.domain.member.MemberRepository;
 import spring.fitlinkbe.domain.notification.Notification;
 import spring.fitlinkbe.domain.notification.NotificationRepository;
+import spring.fitlinkbe.domain.outbox.Outbox;
+import spring.fitlinkbe.domain.outbox.OutboxRepository;
 import spring.fitlinkbe.domain.reservation.Reservation;
 import spring.fitlinkbe.domain.reservation.ReservationRepository;
 import spring.fitlinkbe.domain.reservation.Session;
@@ -69,6 +71,9 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
     @Autowired
     MemberRepository memberRepository;
+
+    @Autowired
+    OutboxRepository outboxRepository;
 
     @Autowired
     TestDataHandler testDataHandler;
@@ -1417,6 +1422,15 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                 softly.assertThat(reservations).hasSize(1);
                 softly.assertThat(reservations.get(0).getReservationId()).isEqualTo(1L);
                 softly.assertThat(reservations.get(0).getStatus()).isEqualTo(FIXED_RESERVATION);
+
+                // outbox 데이터 잘 쌓였나 확인
+                List<Outbox> outboxes = outboxRepository.getOutboxes();
+                softly.assertThat(outboxes).hasSize(1);
+                softly.assertThat(outboxes.get(0).getOutboxId()).isEqualTo(1L);
+                softly.assertThat(outboxes.get(0).getAggregateType()).isEqualTo(Outbox.AggregateType.RESERVATION);
+                softly.assertThat(outboxes.get(0).getEventType()).isEqualTo(Outbox.EventType.CREATE_FIXED_RESERVATION);
+                softly.assertThat(outboxes.get(0).getEventStatus()).isEqualTo(Outbox.EventStatus.SEND_SUCCESS);
+                softly.assertThat(outboxes.get(0).getRetryCount()).isEqualTo(0);
             });
         }
 

--- a/src/test/java/spring/fitlinkbe/integration/ReservationIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/ReservationIntegrationTest.java
@@ -1400,6 +1400,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                     .reservationDates(List.of(requestDate))
                     .trainer(Trainer.builder().trainerId(1L).build())
                     .member(Member.builder().memberId(1L).build())
+                    .sessionInfo(SessionInfo.builder().SessionInfoId(1L).build())
                     .status(FIXED_RESERVATION)
                     .createdAt(LocalDateTime.now().plusSeconds(2))
                     .build();
@@ -1413,11 +1414,9 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
             assertSoftly(softly -> {
                 // 예약이 잘 됐는지 확인
                 List<Reservation> reservations = reservationRepository.getReservations();
-                softly.assertThat(reservations).hasSize(2);
+                softly.assertThat(reservations).hasSize(1);
                 softly.assertThat(reservations.get(0).getReservationId()).isEqualTo(1L);
                 softly.assertThat(reservations.get(0).getStatus()).isEqualTo(FIXED_RESERVATION);
-                softly.assertThat(reservations.get(1).getReservationId()).isEqualTo(2L);
-                softly.assertThat(reservations.get(1).getStatus()).isEqualTo(FIXED_RESERVATION);
             });
         }
 

--- a/src/test/java/spring/fitlinkbe/integration/common/BaseIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/common/BaseIntegrationTest.java
@@ -10,15 +10,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import spring.fitlinkbe.config.TestSqsConfig;
 import spring.fitlinkbe.infra.notification.PushManager;
 
 import java.util.Map;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
+@Import(TestSqsConfig.class) // 테스트 전용 설정 등록
 public class BaseIntegrationTest {
 
     @Autowired

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -8,6 +8,8 @@ spring:
         name: region
       s3:
         bucket-name: bucket
+      sqs:
+        endpoint:
   profiles:
     active: test
     include: secret


### PR DESCRIPTION
### 구현 기능

- 고정 예약 로직 변경
- DB 스키마 변경 사항 적용

### 세부 사항

- 고정 예약 로직 변경
    - EDA 도입, SQS와 연동
- 추가적인 Config Bean 추가
    - TestSqsConfig
    - SchedulerConfig
    - JpaAuditConfig
    - AsyncConfig
- 메세지 큐 발행 보장하기 위해 outbox 패턴 도입

### DB 변동사항

- Attachment 테이블 추가
- Outbox 테이블 추가
- SessionInfo 빠졌던 컬럼 추가
    - createdAt, updatedAt