### PR TITLE
[Fliz-227] BE 예약 로직 2차 보완

### DIFF
--- a/src/main/java/spring/fitlinkbe/application/reservation/ReservationFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/reservation/ReservationFacade.java
@@ -132,7 +132,7 @@ public class ReservationFacade {
         // 예약 거절된 예약은 -> 멤버에게 예약 거절됐다는 메세지 전송
         refuseReservations(refusedReservations);
         // 고정 예약 진행
-        reservationService.createFixedReservations(List.of(nextFixedReservation),1);
+        reservationService.createFixedReservations(List.of(nextFixedReservation), 1);
     }
 
     @Transactional
@@ -328,6 +328,7 @@ public class ReservationFacade {
         return completedSession;
     }
 
+    @Transactional
     public void checkTodaySessionReminder() {
         List<Reservation> todayReservations = reservationService.getTodayReservations();
 
@@ -342,6 +343,7 @@ public class ReservationFacade {
         });
     }
 
+    @Transactional
     public void refuseReservations(List<Reservation> refusedReservations) {
         refusedReservations.forEach((r) -> {
             PersonalDetail memberDetail = memberService.getMemberDetail(r.getMember().getMemberId());
@@ -350,4 +352,18 @@ public class ReservationFacade {
                     r.getReservationDate(), r.getTrainer().getTrainerId(), false, token.getPushToken()));
         });
     }
+
+    @Transactional
+    public List<Reservation> releaseFixedReservation(Long reservationId) {
+        // 관련 고정 예약 모두 해지
+        List<Reservation> reservations = reservationService.releaseFixedReservation(reservationId);
+        Reservation reservation = reservations.get(0);
+        int restoreCount = reservations.size();
+        // 세션 복구
+        memberService.restoreSession(reservation.getTrainer().getTrainerId(), reservation.getMember().getMemberId(),
+                restoreCount);
+
+        return reservations;
+    }
+
 }

--- a/src/main/java/spring/fitlinkbe/application/reservation/ReservationFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/reservation/ReservationFacade.java
@@ -86,7 +86,7 @@ public class ReservationFacade {
     @Transactional
     public List<Reservation> createFixedReservation(ReservationCriteria.CreateFixed criteria, SecurityUser user) {
         // 세션이 충분한지 확인
-        SessionInfo sessionInfo = memberService.isSessionCountEnough(user.getTrainerId(), criteria.memberId());
+        memberService.isSessionCountEnough(user.getTrainerId(), criteria.memberId());
         // 기존에 확정된 예약이 있는지 확인
         reservationService.checkConfirmedReservationsExistOrThrow(user.getTrainerId(), criteria.reservationDates());
         // 대기중인 예약이 있으면 거절
@@ -96,6 +96,7 @@ public class ReservationFacade {
         // 고정 예약 진행
         List<Reservation> reservationDomains = criteria.toDomain(memberService.getSessionInfo(user.getTrainerId(),
                 criteria.memberId()), user);
+        SessionInfo sessionInfo = memberService.getSessionInfo(user.getTrainerId(), criteria.memberId());
         // 세션 차감
         memberService.deductSession(user.getTrainerId(), criteria.memberId(), sessionInfo.getRemainingCount());
         List<Reservation> fixedReservations = reservationService.createFixedReservations(reservationDomains,

--- a/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
     RESERVATION_COMPLETE_NOT_ALLOWED("다른 사람의 예약을 완료시킬 수 없습니다.", 400),
     RESERVATION_IS_ALREADY_COMPLETED("이미 예약이 완료되었습니다.", 400),
     RESERVATION_CHANGE_REQUEST_NOT_ALLOWED("예약 변경을 요청할 수 없는 상태입니다.", 400),
+    RESERVATION_RELEASE_NOT_ALLOWED("예약 해지를 할 수 없는 상태입니다.", 400),
     RESERVATION_CANCEL_NOT_ALLOWED("예약 취소를 할 수 없는 상태입니다.", 400),
     RESERVATION_REFUSE_NOT_ALLOWED("예약 거절을 할 수 없는 상태입니다.", 400),
     RESERVATION_APPROVE_NOT_ALLOWED("예약 확정을 할 수 없는 상태입니다.", 400),

--- a/src/main/java/spring/fitlinkbe/domain/common/model/SessionInfo.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/model/SessionInfo.java
@@ -52,16 +52,16 @@ public class SessionInfo {
         return member.getMemberId();
     }
 
-    public void restoreSession() {
-        remainingCount++;
+    public void restoreSession(int count) {
+        remainingCount += count;
     }
 
-    public void deductSession() {
-        if (remainingCount <= 0) {
+    public void deductSession(int count) {
+        if (remainingCount - count < 0) {
             throw new CustomException(ErrorCode.SESSION_REMAINING_COUNT_NOT_VALID,
                     "남은 PT 횟수가 0보다 작습니다. [count: %d]".formatted(remainingCount));
         }
-        remainingCount--;
+        remainingCount -= count;
     }
 
     public void checkEnoughSession() {

--- a/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
+++ b/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
@@ -152,14 +152,12 @@ public class MemberService {
     /**
      * 세션 잔여횟수가 충분한지 확인
      */
-    public SessionInfo isSessionCountEnough(Long trainerId, Long memberId) {
+    public void isSessionCountEnough(Long trainerId, Long memberId) {
         SessionInfo sessionInfo = sessionInfoRepository.getSessionInfo(trainerId, memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.SESSION_NOT_FOUND));
 
         sessionInfo.checkEnoughSession();
-        return sessionInfo;
     }
-
 
     /**
      * 연결된 정보 조회

--- a/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
+++ b/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
@@ -189,18 +189,18 @@ public class MemberService {
     /**
      * 세션 차감
      */
-    public SessionInfo deductSession(Long trainerId, Long memberId) {
+    public SessionInfo deductSession(Long trainerId, Long memberId, int count) {
         SessionInfo getSessionInfo = this.getSessionInfo(trainerId, memberId);
-        getSessionInfo.deductSession();
+        getSessionInfo.deductSession(count);
         return this.saveSessionInfo(getSessionInfo);
     }
 
     /**
      * 세션 복구
      */
-    public void restoreSession(Long trainerId, Long memberId) {
+    public void restoreSession(Long trainerId, Long memberId, int count) {
         SessionInfo getSessionInfo = this.getSessionInfo(trainerId, memberId);
-        getSessionInfo.restoreSession();
+        getSessionInfo.restoreSession(count);
         this.saveSessionInfo(getSessionInfo);
     }
 

--- a/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
+++ b/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
@@ -152,11 +152,12 @@ public class MemberService {
     /**
      * 세션 잔여횟수가 충분한지 확인
      */
-    public void isSessionCountEnough(Long trainerId, Long memberId) {
+    public SessionInfo isSessionCountEnough(Long trainerId, Long memberId) {
         SessionInfo sessionInfo = sessionInfoRepository.getSessionInfo(trainerId, memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.SESSION_NOT_FOUND));
 
         sessionInfo.checkEnoughSession();
+        return sessionInfo;
     }
 
 

--- a/src/main/java/spring/fitlinkbe/domain/notification/Notification.java
+++ b/src/main/java/spring/fitlinkbe/domain/notification/Notification.java
@@ -70,7 +70,7 @@ public class Notification {
 
         return Notification.builder()
                 .refId(reservationId)
-                .refType(ReferenceType.RESERVATION_CHANGE_CANCEL)
+                .refType(ReferenceType.RESERVATION_CANCEL)
                 .target(UserRole.MEMBER)
                 .notificationType(NotificationType.RESERVATION_CANCEL)
                 .personalDetail(memberDetail)
@@ -89,7 +89,7 @@ public class Notification {
 
         return Notification.builder()
                 .refId(reservationId)
-                .refType(ReferenceType.RESERVATION_CHANGE_CANCEL)
+                .refType(ReferenceType.RESERVATION_CANCEL)
                 .target(UserRole.TRAINER)
                 .notificationType(NotificationType.RESERVATION_CANCEL)
                 .personalDetail(trainerDetail)
@@ -127,7 +127,7 @@ public class Notification {
 
         return Notification.builder()
                 .refId(reservationId)
-                .refType(ReferenceType.RESERVATION_CHANGE_CANCEL)
+                .refType(ReferenceType.RESERVATION_CHANGE)
                 .target(UserRole.MEMBER)
                 .notificationType(isApprove ? NotificationType.RESERVATION_CHANGE_REQUEST_APPROVED :
                         NotificationType.RESERVATION_CHANGE_REQUEST_REFUSED)
@@ -204,7 +204,7 @@ public class Notification {
 
         return Notification.builder()
                 .refId(reservationId)
-                .refType(ReferenceType.RESERVATION_CHANGE_CANCEL)
+                .refType(ReferenceType.RESERVATION_CHANGE)
                 .target(UserRole.TRAINER)
                 .notificationType(NotificationType.RESERVATION_CHANGE_REQUEST)
                 .personalDetail(trainerDetail)
@@ -224,7 +224,7 @@ public class Notification {
 
         return Notification.builder()
                 .refId(reservationId)
-                .refType(ReferenceType.RESERVATION_CHANGE_CANCEL)
+                .refType(ReferenceType.RESERVATION_CANCEL)
                 .target(UserRole.MEMBER)
                 .notificationType(isApprove ? NotificationType.RESERVATION_CANCEL_REQUEST_APPROVED :
                         NotificationType.RESERVATION_CANCEL_REQUEST_REFUSED)
@@ -301,7 +301,8 @@ public class Notification {
         CONNECT("트레이너 연동"),
         DISCONNECT("트레이너 연동 해제"),
         RESERVATION_REQUEST("예약 요청"),
-        RESERVATION_CHANGE_CANCEL("예약 변경/취소"),
+        RESERVATION_CHANGE("예약 변경"),
+        RESERVATION_CANCEL("예약 취소"),
         SESSION("세션");
 
         private final String name;

--- a/src/main/java/spring/fitlinkbe/domain/reservation/Reservation.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/Reservation.java
@@ -13,6 +13,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -40,6 +41,40 @@ public class Reservation {
     private boolean isDayOff;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    public static List<Reservation> createFixedReservations(List<Reservation> baseReservations, int remainingCount) {
+        List<Reservation> generatedReservations = new ArrayList<>();
+
+        List<Reservation> currentReservations = new ArrayList<>(baseReservations);
+
+        while (generatedReservations.size() < remainingCount) {
+            int remainingToCreate = remainingCount - generatedReservations.size();
+
+            List<Reservation> nextReservations = currentReservations.stream()
+                    .map(reservation -> reservation.copyWithNewDate(reservation.getReservationDate().plusDays(7)))
+                    .limit(remainingToCreate)
+                    .toList();
+
+            generatedReservations.addAll(nextReservations);
+            currentReservations = nextReservations;
+        }
+
+        return generatedReservations;
+    }
+
+    public Reservation copyWithNewDate(LocalDateTime newDate) {
+
+        return Reservation.builder()
+                .member(member)
+                .trainer(trainer)
+                .sessionInfo(sessionInfo)
+                .name(name)
+                .reservationDates(List.of(newDate))
+                .confirmDate(newDate)
+                .dayOfWeek(newDate.getDayOfWeek())
+                .status(status)
+                .build();
+    }
 
     @RequiredArgsConstructor
     @Getter

--- a/src/main/java/spring/fitlinkbe/domain/reservation/Reservation.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/Reservation.java
@@ -59,11 +59,11 @@ public class Reservation {
         private final String name;
     }
 
-    public void changeFixedDate(LocalDateTime reservationDate, LocalDateTime changeDate) {
+    public void changeFixedDate(LocalDateTime beforeDate, LocalDateTime changeDate) {
         if (this.status != FIXED_RESERVATION) {
             throw new CustomException(RESERVATION_CHANGE_REQUEST_NOT_ALLOWED, "고정 예약 상태가 아닙니다.");
         }
-        LocalDateTime targetDate = reservationDate.truncatedTo(ChronoUnit.HOURS);
+        LocalDateTime targetDate = beforeDate.truncatedTo(ChronoUnit.HOURS);
 
         boolean dateExists = this.reservationDates.stream()
                 .map(date -> date.truncatedTo(ChronoUnit.HOURS))
@@ -246,5 +246,9 @@ public class Reservation {
     public boolean isReservationNotAllowed() {
 
         return (this.isDayOff || (this.status == DISABLED_TIME_RESERVATION));
+    }
+
+    public boolean isSameReservationAndMember(Long reservationId, Long memberId) {
+        return !Objects.equals(this.reservationId, reservationId) && Objects.equals(this.member.getMemberId(), memberId);
     }
 }

--- a/src/main/java/spring/fitlinkbe/domain/reservation/ReservationRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/ReservationRepository.java
@@ -13,6 +13,8 @@ public interface ReservationRepository {
 
     List<Reservation> getFixedReservations();
 
+    List<Reservation> getFixedReservations(Long memberId);
+
     List<Reservation> getFixedReservations(Long trainerId, LocalDateTime fixedReservationDate);
 
     List<Reservation> getReservationsWithWaitingStatus(Long trainerId);

--- a/src/main/java/spring/fitlinkbe/domain/reservation/ReservationRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/ReservationRepository.java
@@ -13,6 +13,8 @@ public interface ReservationRepository {
 
     List<Reservation> getFixedReservations();
 
+    List<Reservation> getFixedReservations(Long trainerId, LocalDateTime fixedReservationDate);
+
     List<Reservation> getReservationsWithWaitingStatus(Long trainerId);
 
     List<Reservation> getReservations(UserRole role, Long userId);

--- a/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
@@ -17,6 +17,7 @@ import spring.fitlinkbe.support.security.SecurityUser;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -104,9 +105,13 @@ public class ReservationService {
     }
 
     @Transactional
-    public List<Reservation> createFixedReservations(List<Reservation> reservations) {
-        // 고정 예약 진행
-        List<Reservation> savedReservations = reservationRepository.saveReservations(reservations);
+    public List<Reservation> createFixedReservations(List<Reservation> baseReservations, int remainingCount) {
+
+
+        List<Reservation> newFixedReservations = Reservation.createFixedReservations(baseReservations, remainingCount);
+
+        List<Reservation> savedReservations = reservationRepository.saveReservations(newFixedReservations);
+
         // 세션 생성
         List<Session> sessions = savedReservations.stream()
                 .map(reservation -> Session.builder()
@@ -114,7 +119,7 @@ public class ReservationService {
                         .status(SESSION_WAITING)
                         .build())
                 .toList();
-        // 세션 저장
+
         reservationRepository.saveSessions(sessions);
 
         return savedReservations;

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationJpaRepository.java
@@ -27,14 +27,14 @@ public interface ReservationJpaRepository extends JpaRepository<ReservationEntit
             "LEFT JOIN FETCH r.trainer " +
             "LEFT JOIN FETCH r.sessionInfo " +
             "WHERE r.member.memberId = :memberId")
-    List<ReservationEntity> findByMember_MemberId(Long memberId);
+    List<ReservationEntity> findByMemberId(Long memberId);
 
     @Query("SELECT r FROM ReservationEntity r " +
             "LEFT JOIN FETCH r.member " +
             "LEFT JOIN FETCH r.trainer " +
             "LEFT JOIN FETCH r.sessionInfo " +
             "WHERE r.trainer.trainerId = :trainerId")
-    List<ReservationEntity> findByTrainer_TrainerId(Long trainerId);
+    List<ReservationEntity> findByTrainerId(Long trainerId);
 
     @Query("SELECT r FROM ReservationEntity r " +
             "LEFT JOIN FETCH r.member " +
@@ -48,7 +48,7 @@ public interface ReservationJpaRepository extends JpaRepository<ReservationEntit
             "LEFT JOIN FETCH r.member " +
             "LEFT JOIN FETCH r.trainer " +
             "LEFT JOIN FETCH r.sessionInfo")
-    List<ReservationEntity> findAllAfterToday();
+    List<ReservationEntity> findAllJoinFetch();
 
     @Query("SELECT r FROM ReservationEntity r " +
             "LEFT JOIN FETCH r.member " +

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationJpaRepository.java
@@ -60,6 +60,13 @@ public interface ReservationJpaRepository extends JpaRepository<ReservationEntit
     @Query("SELECT COUNT(r) > 0 FROM ReservationEntity r " +
             "WHERE r.trainer.trainerId = :trainerId " +
             "AND r.confirmDate = :checkDateTime " +
-            "AND r.status = 'RESERVATION_APPROVED'")
+            "AND (r.status = spring.fitlinkbe.domain.reservation.Reservation.Status.FIXED_RESERVATION " +
+            "OR r.status = spring.fitlinkbe.domain.reservation.Reservation.Status.RESERVATION_APPROVED)")
     boolean existsByTrainerIdAndConfirmDateTime(Long trainerId, LocalDateTime checkDateTime);
+
+    @Query("SELECT r FROM ReservationEntity r " +
+            "WHERE r.trainer.trainerId = :trainerId " +
+            "AND r.confirmDate = :checkDateTime " +
+            "AND r.status = spring.fitlinkbe.domain.reservation.Reservation.Status.FIXED_RESERVATION")
+    List<ReservationEntity> findAllFixedReservation(Long trainerId, LocalDateTime checkDateTime);
 }

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationJpaRepository.java
@@ -69,4 +69,9 @@ public interface ReservationJpaRepository extends JpaRepository<ReservationEntit
             "AND r.confirmDate = :checkDateTime " +
             "AND r.status = spring.fitlinkbe.domain.reservation.Reservation.Status.FIXED_RESERVATION")
     List<ReservationEntity> findAllFixedReservation(Long trainerId, LocalDateTime checkDateTime);
+
+    @Query("SELECT r FROM ReservationEntity r " +
+            "WHERE r.member.memberId = :memberId " +
+            "AND r.status = spring.fitlinkbe.domain.reservation.Reservation.Status.FIXED_RESERVATION")
+    List<ReservationEntity> findAllFixedReservation(Long memberId);
 }

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationRepositoryImpl.java
@@ -42,6 +42,15 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     }
 
     @Override
+    public List<Reservation> getFixedReservations(Long trainerId, LocalDateTime fixedReservationDate) {
+
+        return reservationJpaRepository.findAllFixedReservation(trainerId, fixedReservationDate)
+                .stream()
+                .map(ReservationEntity::toDomain)
+                .toList();
+    }
+
+    @Override
     public List<Reservation> getReservationsWithWaitingStatus(Long trainerId) {
 
         return reservationJpaRepository.findWaitingStatus(trainerId)

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationRepositoryImpl.java
@@ -26,7 +26,7 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     @Override
     public List<Reservation> getReservations() {
 
-        return reservationJpaRepository.findAllAfterToday()
+        return reservationJpaRepository.findAllJoinFetch()
                 .stream()
                 .map(ReservationEntity::toDomain)
                 .toList();
@@ -54,13 +54,13 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     public List<Reservation> getReservations(UserRole role, Long userId) {
 
         if (role == MEMBER) { //멤버의 경우
-            return reservationJpaRepository.findByMember_MemberId(userId)
+            return reservationJpaRepository.findByMemberId(userId)
                     .stream()
                     .map(ReservationEntity::toDomain)
                     .toList();
         }
 
-        return reservationJpaRepository.findByTrainer_TrainerId(userId)
+        return reservationJpaRepository.findByTrainerId(userId)
                 .stream()
                 .map(ReservationEntity::toDomain)
                 .toList();

--- a/src/main/java/spring/fitlinkbe/infra/reservation/ReservationRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/reservation/ReservationRepositoryImpl.java
@@ -42,6 +42,14 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     }
 
     @Override
+    public List<Reservation> getFixedReservations(Long memberId) {
+        return reservationJpaRepository.findAllFixedReservation(memberId)
+                .stream()
+                .map(ReservationEntity::toDomain)
+                .toList();
+    }
+
+    @Override
     public List<Reservation> getFixedReservations(Long trainerId, LocalDateTime fixedReservationDate) {
 
         return reservationJpaRepository.findAllFixedReservation(trainerId, fixedReservationDate)

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
@@ -122,6 +122,25 @@ public class ReservationController {
     }
 
     /**
+     * 고정 예약 해지
+     *
+     * @param reservationId reservationId 정보
+     * @return ApiResultResponse 고정 예약이 해지 된 reservationId 목록 정보를 반환한다.
+     */
+    @RoleCheck(allowedRoles = {UserRole.TRAINER})
+    @PostMapping("/fixed-reservations/{reservationId}/release")
+    public ApiResultResponse<List<ReservationResponseDto.Success>> releaseFixedReservation(@PathVariable("reservationId")
+                                                                                           @NotNull(message = "예약 ID는 필수값입니다.")
+                                                                                           Long reservationId) {
+
+        List<Reservation> result = reservationFacade.releaseFixedReservation(reservationId);
+
+        return ApiResultResponse.ok(result.stream()
+                .map(ReservationResponseDto.Success::of)
+                .toList());
+    }
+
+    /**
      * 직접 예약
      *
      * @param request memberId, name, dates 정보

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
@@ -210,21 +210,40 @@ public class ReservationController {
     }
 
     /**
-     * 예약 변경
-     * 트레이너 - 고정 예약 변경, 멤버 - 예약 변경 요청
+     * 고정 예약 변경
      *
      * @param request reservationDate, changeDate 정보
      * @return ApiResultResponse 변경 요청이 된 reservationId 결과를 반환한다.
      */
-    @PostMapping("{reservationId}/change")
-    public ApiResultResponse<ReservationResponseDto.Success> changeReservation(@PathVariable("reservationId")
-                                                                               @NotNull(message = "예약 ID는 필수값입니다.")
-                                                                               Long reservationId,
-                                                                               @RequestBody @Valid
-                                                                               ReservationRequestDto.ChangeReqeust
-                                                                                       request,
-                                                                               @Login SecurityUser user) {
-        Reservation result = reservationFacade.changeReservation(request.toCriteria(reservationId), user);
+    @RoleCheck(allowedRoles = {UserRole.TRAINER})
+    @PostMapping("{reservationId}/fixed-change-request")
+    public ApiResultResponse<ReservationResponseDto.Success> changeFixedReservation(@PathVariable("reservationId")
+                                                                                    @NotNull(message = "예약 ID는 필수값입니다.")
+                                                                                    Long reservationId,
+                                                                                    @RequestBody @Valid
+                                                                                    ReservationRequestDto.ChangeReqeust
+                                                                                            request,
+                                                                                    @Login SecurityUser user) {
+        Reservation result = reservationFacade.changeFixedReservation(request.toCriteria(reservationId), user);
+
+        return ApiResultResponse.ok(ReservationResponseDto.Success.of(result));
+    }
+
+    /**
+     * 예약 변경 요청
+     *
+     * @param request reservationDate, changeDate 정보
+     * @return ApiResultResponse 변경 요청이 된 reservationId 결과를 반환한다.
+     */
+    @RoleCheck(allowedRoles = {UserRole.MEMBER})
+    @PostMapping("{reservationId}/change-request")
+    public ApiResultResponse<ReservationResponseDto.Success> changeRequestReservation(@PathVariable("reservationId")
+                                                                                      @NotNull(message = "예약 ID는 필수값입니다.")
+                                                                                      Long reservationId,
+                                                                                      @RequestBody @Valid
+                                                                                      ReservationRequestDto.ChangeReqeust
+                                                                                              request) {
+        Reservation result = reservationFacade.changeRequestReservation(request.toCriteria(reservationId));
 
         return ApiResultResponse.ok(ReservationResponseDto.Success.of(result));
     }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationResponseDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationResponseDto.java
@@ -20,7 +20,8 @@ public class ReservationResponseDto {
             return Success.builder()
                     .reservationId(reservation.getReservationId())
                     .status(reservation.getStatus().getName())
-                    .reservationDate(reservation.getConfirmDate())
+                    .reservationDate(reservation.getConfirmDate() == null ? reservation.getReservationDate() :
+                            reservation.getConfirmDate())
                     .build();
         }
     }

--- a/src/main/java/spring/fitlinkbe/interfaces/scheduler/ReservationScheduler.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/scheduler/ReservationScheduler.java
@@ -16,7 +16,8 @@ public class ReservationScheduler { //
     /**
      * 매일 정각마다 고정 예약 확인하고, 예약 실행 (일주일 뒤에 고정 예약 함)
      */
-    @Scheduled(cron = "0 0 0 * * *") // 매일 00:00:00에 실행
+    @Deprecated
+//    @Scheduled(cron = "0 0 0 * * *") // 매일 00:00:00에 실행
     public void createFixedReservations() {
         reservationFacade.checkCreateFixedReservation();
     }

--- a/src/test/java/spring/fitlinkbe/domain/reservation/ReservationServiceTest.java
+++ b/src/test/java/spring/fitlinkbe/domain/reservation/ReservationServiceTest.java
@@ -469,15 +469,6 @@ class ReservationServiceTest {
                     .status(RESERVATION_CHANGE_REQUEST)
                     .build();
 
-            PersonalDetail personalDetail = PersonalDetail.builder()
-                    .personalDetailId(1L)
-                    .name("멤버1")
-                    .memberId(1L)
-                    .trainerId(null)
-                    .build();
-
-            SecurityUser user = new SecurityUser(personalDetail);
-
             when(reservationRepository.getReservation(command.reservationId()))
                     .thenReturn(Optional.ofNullable(reservation));
 
@@ -485,7 +476,7 @@ class ReservationServiceTest {
                     .thenReturn(Optional.ofNullable(compltedReservation));
 
             //when
-            Reservation result = reservationService.changeReservation(command, user);
+            Reservation result = reservationService.changeRequestReservation(command);
 
             //then
             assertThat(result).isNotNull();
@@ -527,7 +518,7 @@ class ReservationServiceTest {
                     .thenReturn(Optional.ofNullable(reservation));
 
             //when & then
-            assertThatThrownBy(() -> reservationService.changeReservation(command, user))
+            assertThatThrownBy(() -> reservationService.changeFixedReservation(command, user))
                     .isInstanceOf(CustomException.class)
                     .extracting("errorCode")
                     .isEqualTo(RESERVATION_CHANGE_REQUEST_NOT_ALLOWED);
@@ -554,20 +545,11 @@ class ReservationServiceTest {
                     .status(RESERVATION_APPROVED)
                     .build();
 
-            PersonalDetail personalDetail = PersonalDetail.builder()
-                    .personalDetailId(1L)
-                    .name("멤버1")
-                    .memberId(1L)
-                    .trainerId(null)
-                    .build();
-
-            SecurityUser user = new SecurityUser(personalDetail);
-
             when(reservationRepository.getReservation(command.reservationId()))
                     .thenReturn(Optional.ofNullable(reservation));
 
             //when & then
-            assertThatThrownBy(() -> reservationService.changeReservation(command, user))
+            assertThatThrownBy(() -> reservationService.changeRequestReservation(command))
                     .isInstanceOf(CustomException.class)
                     .extracting("errorCode")
                     .isEqualTo(RESERVATION_DATE_NOT_FOUND);

--- a/src/test/java/spring/fitlinkbe/integration/NotificationIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/NotificationIntegrationTest.java
@@ -332,7 +332,7 @@ public class NotificationIntegrationTest extends BaseIntegrationTest {
             // 알림 20개 저장
             createNotifications(personalDetail, trainer.getTrainerId(), userRole);
 
-            Notification.NotificationType refType = Notification.NotificationType.RESERVATION_CANCEL;
+            Notification.NotificationType refType = Notification.NotificationType.SESSION_REMINDER;
 
             Map<String, String> params = new HashMap<>();
             params.put("page", "0");
@@ -346,7 +346,7 @@ public class NotificationIntegrationTest extends BaseIntegrationTest {
             assertSoftly(softly -> {
                 softly.assertThat(result.body().jsonPath().getObject("status", Integer.class)).isEqualTo(400);
                 softly.assertThat(result.body().jsonPath().getObject("success", Boolean.class)).isEqualTo(false);
-                softly.assertThat(result.body().jsonPath().getObject("msg", String.class)).contains("요청 파라미터 'type'의 값 'RESERVATION_CANCEL'은(는) 유효하지 않습니다.");
+                softly.assertThat(result.body().jsonPath().getObject("msg", String.class)).contains("요청 파라미터 'type'의 값 'SESSION_REMINDER'은(는) 유효하지 않습니다.");
                 softly.assertThat(result.body().jsonPath().getObject("data", NotificationResponseDto.class)).isNull();
             });
         }

--- a/src/test/java/spring/fitlinkbe/integration/ReservationIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/ReservationIntegrationTest.java
@@ -1418,7 +1418,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
         @DisplayName("스케줄 고정 세션 예약 : 성공")
         void scheduledCreateFixedReservation() {
             // given
-            LocalDateTime requestDate = LocalDateTime.now().plusHours(1);
+            LocalDateTime requestDate = LocalDateTime.now().plusSeconds(1);
 
             Reservation reservation = Reservation.builder()
                     .reservationDates(List.of(requestDate))
@@ -1551,7 +1551,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
                 // 알림이 잘 생성됐는지 확인
                 List<Notification> notifications = notificationRepository.getNotification(content.reservationId(),
-                        Notification.ReferenceType.RESERVATION_CHANGE_CANCEL);
+                        Notification.ReferenceType.RESERVATION_CANCEL);
                 softly.assertThat(notifications.get(0)).isNotNull();
                 softly.assertThat(notifications.get(0).getNotificationType()).isEqualTo(RESERVATION_CANCEL);
             });
@@ -1613,7 +1613,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
                 // 알림이 잘 생성됐는지 확인
                 List<Notification> notifications = notificationRepository.getNotification(content.reservationId(),
-                        Notification.ReferenceType.RESERVATION_CHANGE_CANCEL);
+                        Notification.ReferenceType.RESERVATION_CANCEL);
                 softly.assertThat(notifications.get(0)).isNotNull();
                 softly.assertThat(notifications.get(0).getNotificationType()).isEqualTo(RESERVATION_CANCEL);
             });
@@ -2562,7 +2562,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
                 // 알림이 잘 생성됐는지 확인
                 List<Notification> notifications = notificationRepository.getNotification(content.reservationId(),
-                        Notification.ReferenceType.RESERVATION_CHANGE_CANCEL);
+                        Notification.ReferenceType.RESERVATION_CHANGE);
                 softly.assertThat(notifications.get(0)).isNotNull();
                 softly.assertThat(notifications.get(0).getNotificationType())
                         .isEqualTo(Notification.NotificationType.RESERVATION_CHANGE_REQUEST);
@@ -2617,7 +2617,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
                 // 알림이 잘 생성됐는지 확인
                 List<Notification> notifications = notificationRepository.getNotification(content.reservationId(),
-                        Notification.ReferenceType.RESERVATION_CHANGE_CANCEL);
+                        Notification.ReferenceType.RESERVATION_CHANGE);
                 softly.assertThat(notifications.get(0)).isNotNull();
                 softly.assertThat(notifications.get(0).getNotificationType())
                         .isEqualTo(Notification.NotificationType.RESERVATION_CHANGE_REQUEST);
@@ -2673,7 +2673,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
                 // 알림이 잘 생성됐는지 확인
                 List<Notification> notifications = notificationRepository.getNotification(content.reservationId(),
-                        Notification.ReferenceType.RESERVATION_CHANGE_CANCEL);
+                        Notification.ReferenceType.RESERVATION_CHANGE);
                 softly.assertThat(notifications.get(0)).isNotNull();
                 softly.assertThat(notifications.get(0).getNotificationType())
                         .isEqualTo(Notification.NotificationType.RESERVATION_CHANGE_REQUEST);
@@ -3150,7 +3150,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
                 // 알림이 잘 생성됐는지 확인
                 List<Notification> notifications = notificationRepository.getNotification(content.reservationId(),
-                        Notification.ReferenceType.RESERVATION_CHANGE_CANCEL);
+                        Notification.ReferenceType.RESERVATION_CHANGE);
                 softly.assertThat(notifications.get(0)).isNotNull();
                 softly.assertThat(notifications.get(0).getNotificationType()).isEqualTo(
                         Notification.NotificationType.RESERVATION_CHANGE_REQUEST_APPROVED);
@@ -3213,7 +3213,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
                 // 알림이 잘 생성됐는지 확인
                 List<Notification> notifications = notificationRepository.getNotification(content.reservationId(),
-                        Notification.ReferenceType.RESERVATION_CHANGE_CANCEL);
+                        Notification.ReferenceType.RESERVATION_CHANGE);
                 softly.assertThat(notifications.get(0)).isNotNull();
                 softly.assertThat(notifications.get(0).getNotificationType()).isEqualTo(
                         Notification.NotificationType.RESERVATION_CHANGE_REQUEST_REFUSED);
@@ -3289,7 +3289,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
                 // 알림이 잘 생성됐는지 확인
                 List<Notification> notifications = notificationRepository.getNotification(content.reservationId(),
-                        Notification.ReferenceType.RESERVATION_CHANGE_CANCEL);
+                        Notification.ReferenceType.RESERVATION_CHANGE);
                 softly.assertThat(notifications.get(0)).isNotNull();
                 softly.assertThat(notifications.get(0).getNotificationType()).isEqualTo(
                         Notification.NotificationType.RESERVATION_CHANGE_REQUEST_APPROVED);
@@ -3455,7 +3455,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
                 // 알림이 잘 생성됐는지 확인
                 List<Notification> notifications = notificationRepository.getNotification(content.reservationId(),
-                        Notification.ReferenceType.RESERVATION_CHANGE_CANCEL);
+                        Notification.ReferenceType.RESERVATION_CANCEL);
                 softly.assertThat(notifications.get(0)).isNotNull();
                 softly.assertThat(notifications.get(0).getNotificationType()).isEqualTo(
                         Notification.NotificationType.RESERVATION_CANCEL_REQUEST_APPROVED);
@@ -3515,7 +3515,7 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
 
                 // 알림이 잘 생성됐는지 확인
                 List<Notification> notifications = notificationRepository.getNotification(content.reservationId(),
-                        Notification.ReferenceType.RESERVATION_CHANGE_CANCEL);
+                        Notification.ReferenceType.RESERVATION_CANCEL);
                 softly.assertThat(notifications.get(0)).isNotNull();
                 softly.assertThat(notifications.get(0).getNotificationType()).isEqualTo(
                         Notification.NotificationType.RESERVATION_CANCEL_REQUEST_REFUSED);

--- a/src/test/java/spring/fitlinkbe/integration/ReservationIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/ReservationIntegrationTest.java
@@ -1138,9 +1138,12 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
     @DisplayName("고정 세션 예약 Integration TEST")
     class CreateFixedReservationIntegrationTest {
         @Test
-        @DisplayName("트레이너가 고정 세션 예약 성공 - 예약 1개")
+        @DisplayName("트레이너가 고정 세션 예약 성공 - 고정 예약 1개, 초기 남은 세션 6, 예약 6개 생성")
         void createFixedReservationWithTrainer() {
             // given
+            SessionInfo sessionInfo = sessionInfoRepository.getSessionInfo(1L).orElseThrow();
+            int originCount = sessionInfo.getRemainingCount();
+
             PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(1L)
                     .orElseThrow();
 
@@ -1176,13 +1179,23 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                 softly.assertThat(session).isNotNull();
                 softly.assertThat(session.getStatus()).isEqualTo(SESSION_WAITING);
 
+                //총 세션 수만큼 예약이 됐는지 확인
+                SessionInfo afterSessionInfo = sessionInfoRepository.getSessionInfo(1L).orElseThrow();
+                softly.assertThat(afterSessionInfo.getRemainingCount()).isEqualTo(0);
+
+                List<Reservation> reservations = reservationRepository.getReservations();
+                softly.assertThat(reservations.size()).isEqualTo(originCount);
+
             });
         }
 
         @Test
-        @DisplayName("트레이너가 고정 세션 예약 성공 - 예약 2개")
+        @DisplayName("트레이너가 고정 세션 예약 성공 - 고정 예약 2개, 초기 남은 세션 6, 예약 6개 생성")
         void twoCreateFixedReservationWithTrainer() {
             // given
+            SessionInfo sessionInfo = sessionInfoRepository.getSessionInfo(1L).orElseThrow();
+            int originCount = sessionInfo.getRemainingCount();
+
             PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(1L)
                     .orElseThrow();
 
@@ -1225,6 +1238,12 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                 softly.assertThat(session2).isNotNull();
                 softly.assertThat(session2.getStatus()).isEqualTo(SESSION_WAITING);
 
+                //총 세션 수만큼 예약이 됐는지 확인
+                SessionInfo afterSessionInfo = sessionInfoRepository.getSessionInfo(1L).orElseThrow();
+                softly.assertThat(afterSessionInfo.getRemainingCount()).isEqualTo(0);
+
+                List<Reservation> reservations = reservationRepository.getReservations();
+                softly.assertThat(reservations.size()).isEqualTo(originCount);
             });
         }
 
@@ -2228,12 +2247,6 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                         SESSION_DEDUCTED);
                 softly.assertThat(notification).isNotNull();
                 softly.assertThat(notification.getNotificationType()).isEqualTo(SESSION_DEDUCTED);
-                // 세션이 얼마 남지 않았다는 알림 잘 생성되었는지 확인
-                Notification notification2 = notificationRepository.getNotification(memberDetail.getPersonalDetailId(),
-                        SESSION_REMAIN_5);
-                softly.assertThat(notification2).isNotNull();
-                softly.assertThat(notification2.getNotificationType()).isEqualTo(SESSION_REMAIN_5);
-                softly.assertThat(notification2.getContent()).contains("PT 횟수가 얼마 남지 않았습니다.");
 
             });
         }

--- a/src/test/java/spring/fitlinkbe/integration/common/BaseIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/common/BaseIntegrationTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import spring.fitlinkbe.config.TestSqsConfig;
 import spring.fitlinkbe.infra.notification.PushManager;
+import spring.fitlinkbe.interfaces.comsumer.ReservationConsumer;
 
 import java.util.Map;
 
@@ -32,6 +33,9 @@ public class BaseIntegrationTest {
 
     @MockitoBean
     private PushManager pushManager;
+
+    @MockitoBean
+    private ReservationConsumer reservationConsumer;
 
     @LocalServerPort
     protected int port;

--- a/src/test/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationControllerTest.java
+++ b/src/test/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationControllerTest.java
@@ -1456,7 +1456,7 @@ class ReservationControllerTest {
     }
 
     @Nested
-    @DisplayName("예약 변경 요청 Controller TEST")
+    @DisplayName("멤버의 예약 변경 요청 Controller TEST")
     class ChangeReqeustReservationControllerTest {
         @Test
         @DisplayName("멤버의 예약 변경 요청 성공")
@@ -1486,11 +1486,11 @@ class ReservationControllerTest {
 
             String accessToken = getAccessToken(personalDetail);
 
-            when(reservationFacade.changeReservation(any(ReservationCriteria.ChangeReqeust.class),
-                    any(SecurityUser.class))).thenReturn(result);
+            when(reservationFacade.changeRequestReservation(any(ReservationCriteria.ChangeReqeust.class)))
+                    .thenReturn(result);
 
             //when & then
-            mockMvc.perform(post("/v1/reservations/%s/change".formatted(reservationId))
+            mockMvc.perform(post("/v1/reservations/%s/change-request".formatted(reservationId))
                             .header("Authorization", "Bearer " + accessToken)
                             .with(oauth2Login().oauth2User(user))
                             .with(csrf())
@@ -1532,11 +1532,11 @@ class ReservationControllerTest {
 
             String accessToken = getAccessToken(personalDetail);
 
-            when(reservationFacade.changeReservation(any(ReservationCriteria.ChangeReqeust.class),
-                    any(SecurityUser.class))).thenReturn(result);
+            when(reservationFacade.changeRequestReservation(any(ReservationCriteria.ChangeReqeust.class)))
+                    .thenReturn(result);
 
             //when & then
-            mockMvc.perform(post("/v1/reservations/%s/change".formatted(reservationId))
+            mockMvc.perform(post("/v1/reservations/%s/change-request".formatted(reservationId))
                             .header("Authorization", "Bearer " + accessToken)
                             .with(oauth2Login().oauth2User(user))
                             .with(csrf())
@@ -1577,11 +1577,11 @@ class ReservationControllerTest {
 
             String accessToken = getAccessToken(personalDetail);
 
-            when(reservationFacade.changeReservation(any(ReservationCriteria.ChangeReqeust.class),
-                    any(SecurityUser.class))).thenReturn(result);
+            when(reservationFacade.changeRequestReservation(any(ReservationCriteria.ChangeReqeust.class)))
+                    .thenReturn(result);
 
             //when & then
-            mockMvc.perform(post("/v1/reservations/%s/change".formatted(reservationId))
+            mockMvc.perform(post("/v1/reservations/%s/change-request".formatted(reservationId))
                             .header("Authorization", "Bearer " + accessToken)
                             .with(oauth2Login().oauth2User(user))
                             .with(csrf())
@@ -1623,11 +1623,11 @@ class ReservationControllerTest {
 
             String accessToken = getAccessToken(personalDetail);
 
-            when(reservationFacade.changeReservation(any(ReservationCriteria.ChangeReqeust.class),
-                    any(SecurityUser.class))).thenReturn(result);
+            when(reservationFacade.changeRequestReservation(any(ReservationCriteria.ChangeReqeust.class)))
+                    .thenReturn(result);
 
             //when & then
-            mockMvc.perform(post("/v1/reservations/%s/change".formatted(reservationId))
+            mockMvc.perform(post("/v1/reservations/%s/change-request".formatted(reservationId))
                             .header("Authorization", "Bearer " + accessToken)
                             .with(oauth2Login().oauth2User(user))
                             .with(csrf())

--- a/src/test/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationControllerTest.java
+++ b/src/test/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationControllerTest.java
@@ -496,6 +496,7 @@ class ReservationControllerTest {
             Reservation reservation = Reservation.builder()
                     .reservationId(1L)
                     .status(RESERVATION_APPROVED)
+                    .reservationDates(List.of(LocalDateTime.now()))
                     .build();
 
             when(reservationFacade.setDisabledReservation(any(ReservationCriteria.SetDisabledTime.class)
@@ -617,7 +618,9 @@ class ReservationControllerTest {
                     .build();
 
             Reservation reservation = Reservation.builder().reservationId(1L)
-                    .status(RESERVATION_APPROVED).build();
+                    .status(RESERVATION_APPROVED)
+                    .reservationDates(List.of(LocalDateTime.now()))
+                    .build();
 
             PersonalDetail personalDetail = PersonalDetail.builder()
                     .personalDetailId(1L)
@@ -661,7 +664,9 @@ class ReservationControllerTest {
                     .build();
 
             Reservation reservation = Reservation.builder().reservationId(1L)
-                    .status(RESERVATION_WAITING).build();
+                    .status(RESERVATION_WAITING)
+                    .reservationDates(List.of(LocalDateTime.now()))
+                    .build();
 
             PersonalDetail personalDetail = PersonalDetail.builder()
                     .personalDetailId(1L)
@@ -837,7 +842,9 @@ class ReservationControllerTest {
                     .dates(List.of(LocalDateTime.now().plusSeconds(2)))
                     .build();
 
-            Reservation reservation = Reservation.builder().reservationId(1L).status(RESERVATION_APPROVED).build();
+            Reservation reservation = Reservation.builder().reservationId(1L).status(RESERVATION_APPROVED)
+                    .reservationDates(List.of(LocalDateTime.now()))
+                    .build();
             List<Reservation> reservations = List.of(reservation);
 
             PersonalDetail personalDetail = PersonalDetail.builder()
@@ -1055,7 +1062,10 @@ class ReservationControllerTest {
 
             Long reservationId = 1L;
 
-            Reservation result = Reservation.builder().reservationId(reservationId).status(RESERVATION_CANCELLED).build();
+            Reservation result = Reservation.builder().reservationId(reservationId)
+                    .status(RESERVATION_CANCELLED)
+                    .reservationDates(List.of(LocalDateTime.now()))
+                    .build();
 
             PersonalDetail personalDetail = PersonalDetail.builder()
                     .personalDetailId(1L)
@@ -1101,7 +1111,9 @@ class ReservationControllerTest {
 
             Long reservationId = 1L;
 
-            Reservation result = Reservation.builder().reservationId(reservationId).status(RESERVATION_CANCEL_REQUEST).build();
+            Reservation result = Reservation.builder().reservationId(reservationId)
+                    .reservationDates(List.of(LocalDateTime.now()))
+                    .status(RESERVATION_CANCEL_REQUEST).build();
 
             PersonalDetail personalDetail = PersonalDetail.builder()
                     .personalDetailId(1L)
@@ -1196,6 +1208,7 @@ class ReservationControllerTest {
             Reservation result = Reservation.builder()
                     .reservationId(1L)
                     .status(RESERVATION_APPROVED)
+                    .reservationDates(List.of(LocalDateTime.now()))
                     .build();
 
             PersonalDetail personalDetail = PersonalDetail.builder()
@@ -1473,6 +1486,7 @@ class ReservationControllerTest {
             Reservation result = Reservation.builder()
                     .reservationId(1L)
                     .status(RESERVATION_CHANGE_REQUEST)
+                    .reservationDates(List.of(LocalDateTime.now()))
                     .build();
 
             PersonalDetail personalDetail = PersonalDetail.builder()
@@ -1665,6 +1679,7 @@ class ReservationControllerTest {
             Reservation result = Reservation.builder()
                     .reservationId(1L)
                     .status(RESERVATION_APPROVED)
+                    .reservationDates(List.of(LocalDateTime.now()))
                     .build();
 
             PersonalDetail personalDetail = PersonalDetail.builder()
@@ -1810,6 +1825,7 @@ class ReservationControllerTest {
 
             Reservation result = Reservation.builder()
                     .reservationId(1L)
+                    .reservationDates(List.of(LocalDateTime.now()))
                     .status(RESERVATION_CANCELLED)
                     .build();
 


### PR DESCRIPTION
### 구현 기능

- 고정 예약 변경과 예약 변경 요청 API 분리
- 고정 예약 변경 로직 변경
- 고정 예약 해지 API 추가
- 알림 타입 분리

### 세부 사항

- 고정 예약 변경과 예약 변경 요청 API 분리
- 고정 예약 변경 로직 변경
    - 처음 고정 예약할 때 세션이 다 소진될 때까지 예약 걸어두기로 변경
    - 스케줄러로 고정 예약하는 로직은 잠시 Deprecated 설정
- 고정 예약 해지 기능 추가
    - 이전에 걸어두었던 모든 고정 예약 취소 및 세션 복구
- 알림 타입 분리
    - RESERVATION_CHANGE_CANCEL
    -> RESERVATION_CANCEL
    -> RESERVATION_CHANGE

### DB 변동사항

- 없습니다.