### PR TITLE
[FLIZ-249] read only 트랜잭션 관련 문제 해결

### DIFF
--- a/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
@@ -72,7 +72,7 @@ public class MemberFacade {
         memberService.saveConnectingInfo(connectingInfo);
     }
 
-    @Transactional(readOnly = true)
+
     public MemberInfoResult.Response getMyInfo(Long memberId) {
         ConnectingInfo connectingInfo = memberService.findConnectingInfo(memberId);
         SessionInfo sessionInfo = connectingInfo != null ? memberService
@@ -215,7 +215,6 @@ public class MemberFacade {
         return memberPage.map(member -> MemberInfoResult.SimpleResponse.of(member, grouped.get(member.getMemberId())));
     }
 
-    @Transactional(readOnly = true)
     public MemberInfoResult.Response getMemberInfo(Long trainerId, Long memberId) {
         memberService.checkConnected(trainerId, memberId);
 


### PR DESCRIPTION
### 작업 사항
- read only 트랜잭션 관련 문제 해결 
- read only 트랜잭션에서 findSessionInfo 호출하는데 이 함수에서 실행되는 쿼리가 `PESSIMISTIC_WRITE` Lock 이 걸려있어서 for update 구문이 나가고 있었습니다. 이 문제 해결했습니다.
- H2 테스트 db에서는 정상적으로 동작하는데 mysql은 에러가 발생하더라구요