### PR TITLE
[Fliz-275] BE 알림 상세 조회 보완

### DIFF
--- a/src/main/java/spring/fitlinkbe/application/notification/criteria/NotificationResult.java
+++ b/src/main/java/spring/fitlinkbe/application/notification/criteria/NotificationResult.java
@@ -1,0 +1,19 @@
+package spring.fitlinkbe.application.notification.criteria;
+
+import lombok.Builder;
+import spring.fitlinkbe.domain.common.model.PersonalDetail;
+import spring.fitlinkbe.domain.notification.Notification;
+
+
+public class NotificationResult {
+    @Builder(toBuilder = true)
+    public record NotificationDetail(Notification notification, PersonalDetail personalDetail) {
+        public static NotificationResult.NotificationDetail from(Notification notification, PersonalDetail personalDetail) {
+
+            return NotificationDetail.builder()
+                    .notification(notification)
+                    .personalDetail(personalDetail)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/spring/fitlinkbe/domain/common/model/PersonalDetail.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/model/PersonalDetail.java
@@ -86,6 +86,10 @@ public class PersonalDetail {
         return trainerId == null ? MEMBER : TRAINER;
     }
 
+    public Long getUserId() {
+        return trainerId == null ? memberId : trainerId;
+    }
+
     public void updateName(String name) {
         this.name = name;
     }

--- a/src/main/java/spring/fitlinkbe/infra/notification/NotificationRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/notification/NotificationRepositoryImpl.java
@@ -29,7 +29,7 @@ public class NotificationRepositoryImpl implements NotificationRepository {
     }
 
     @Override
-    public Notification getNotification(Long personalDetailId, Long notificationId) {
+    public Notification getNotification(Long notificationId, Long personalDetailId) {
         return notificationJpaRepository.findByNotificationIdAndPersonalDetail_PersonalDetailId(notificationId,
                         personalDetailId).map(NotificationEntity::toDomain)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND));

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/common/exception/ApiControllerAdvice.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/common/exception/ApiControllerAdvice.java
@@ -102,8 +102,6 @@ public class ApiControllerAdvice {
         );
     }
 
-
-
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(Exception.class)
     public ApiResultResponse<Object> handlerException(Exception e) {

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/notification/NotificationController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/notification/NotificationController.java
@@ -9,6 +9,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 import spring.fitlinkbe.application.notification.NotificationFacade;
 import spring.fitlinkbe.application.notification.criteria.NotificationCriteria;
+import spring.fitlinkbe.application.notification.criteria.NotificationResult;
 import spring.fitlinkbe.domain.common.enums.UserRole;
 import spring.fitlinkbe.domain.notification.Notification;
 import spring.fitlinkbe.interfaces.controller.common.dto.ApiResultResponse;
@@ -61,7 +62,7 @@ public class NotificationController {
     public ApiResultResponse<NotificationResponseDto.Detail> getNotificationDetail(@PathVariable("notificationId")
                                                                                    Long notificationId,
                                                                                    @Login SecurityUser user) {
-        Notification result = notificationFacade.getNotificationDetail(notificationId, user);
+        NotificationResult.NotificationDetail result = notificationFacade.getNotificationDetail(notificationId, user);
 
         return ApiResultResponse.ok(NotificationResponseDto.Detail.of(result));
 

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/notification/dto/NotificationResponseDto.java
@@ -1,6 +1,7 @@
 package spring.fitlinkbe.interfaces.controller.notification.dto;
 
 import lombok.Builder;
+import spring.fitlinkbe.application.notification.criteria.NotificationResult;
 import spring.fitlinkbe.domain.notification.Notification;
 
 import java.time.LocalDate;
@@ -43,24 +44,25 @@ public class NotificationResponseDto {
     ) {
 
         @Builder(toBuilder = true)
-        public record UserDetail(String name, LocalDate birthDate, String phoneNumber,
+        public record UserDetail(Long userId, String name, LocalDate birthDate, String phoneNumber,
                                  String profilePictureUrl) {
         }
 
-        public static NotificationResponseDto.Detail of(Notification notification) {
+        public static NotificationResponseDto.Detail of(NotificationResult.NotificationDetail notificationDetail) {
 
             return Detail.builder()
-                    .notificationId(notification.getNotificationId())
-                    .refId(notification.getRefId())
-                    .type(notification.getRefType().getName())
-                    .content(notification.getContent())
-                    .sendDate(notification.getSendDate())
-                    .isProcessed(notification.isProcessed())
+                    .notificationId(notificationDetail.notification().getNotificationId())
+                    .refId(notificationDetail.notification().getRefId())
+                    .type(notificationDetail.notification().getRefType().getName())
+                    .content(notificationDetail.notification().getContent())
+                    .sendDate(notificationDetail.notification().getSendDate())
+                    .isProcessed(notificationDetail.notification().isProcessed())
                     .userDetail(UserDetail.builder()
-                            .name(notification.getPersonalDetail().getName())
-                            .birthDate(notification.getPersonalDetail().getBirthDate())
-                            .phoneNumber(notification.getPersonalDetail().getPhoneNumber())
-                            .profilePictureUrl(notification.getPersonalDetail().getProfilePictureUrl())
+                            .userId(notificationDetail.personalDetail().getUserId())
+                            .name(notificationDetail.personalDetail().getName())
+                            .birthDate(notificationDetail.personalDetail().getBirthDate())
+                            .phoneNumber(notificationDetail.personalDetail().getPhoneNumber())
+                            .profilePictureUrl(notificationDetail.personalDetail().getProfilePictureUrl())
                             .build())
                     .build();
         }

--- a/src/test/java/spring/fitlinkbe/integration/NotificationIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/NotificationIntegrationTest.java
@@ -423,6 +423,7 @@ public class NotificationIntegrationTest extends BaseIntegrationTest {
 
                 softly.assertThat(content.notificationId()).isEqualTo(1L);
                 softly.assertThat(content.content()).contains("예약");
+                softly.assertThat(content.userDetail().name()).contains("김민수"); //회원 이름
                 softly.assertThat(content.userDetail()).isNotNull();
             });
         }
@@ -455,6 +456,7 @@ public class NotificationIntegrationTest extends BaseIntegrationTest {
 
                 softly.assertThat(content.notificationId()).isEqualTo(1L);
                 softly.assertThat(content.content()).contains("예약");
+                softly.assertThat(content.userDetail().name()).contains("트레이너황"); //트레이너 이름
                 softly.assertThat(content.userDetail()).isNotNull();
             });
         }

--- a/src/test/java/spring/fitlinkbe/integration/NotificationIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/NotificationIntegrationTest.java
@@ -396,8 +396,8 @@ public class NotificationIntegrationTest extends BaseIntegrationTest {
     @DisplayName("알림 상세 조회 Integration TEST")
     class GetNotificationDetailIntegrationTest {
         @Test
-        @DisplayName("알림 상세 조회 - 성공")
-        void getNotificationDetail() {
+        @DisplayName("트레이너 알림 상세 조회 - 성공")
+        void getNotificationDetailWithTrainer() {
             // given
             PersonalDetail personalDetail = personalDetailRepository.getTrainerDetail(1L)
                     .orElseThrow();
@@ -411,6 +411,38 @@ public class NotificationIntegrationTest extends BaseIntegrationTest {
 
             // 알림 20개 저장
             createNotifications(personalDetail, member.getMemberId(), userRole);
+
+            // when
+            ExtractableResponse<Response> result = get(LOCAL_HOST + port + PATH + "/1", accessToken);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.statusCode()).isEqualTo(200);
+                NotificationResponseDto.Detail content = result.body().jsonPath()
+                        .getObject("data", NotificationResponseDto.Detail.class);
+
+                softly.assertThat(content.notificationId()).isEqualTo(1L);
+                softly.assertThat(content.content()).contains("예약");
+                softly.assertThat(content.userDetail()).isNotNull();
+            });
+        }
+
+        @Test
+        @DisplayName("멤버 알림 상세 조회 - 성공")
+        void getNotificationDetailWithMember() {
+            // given
+            PersonalDetail personalDetail = personalDetailRepository.getMemberDetail(1L)
+                    .orElseThrow();
+
+            String accessToken = tokenProvider.createAccessToken(PersonalDetail.Status.NORMAL,
+                    personalDetail.getPersonalDetailId(), personalDetail.getUserRole());
+
+            Trainer trainer = trainerRepository.getTrainerInfo(1L).orElseThrow();
+
+            UserRole userRole = UserRole.MEMBER;
+
+            // 알림 20개 저장
+            createNotifications(personalDetail, trainer.getTrainerId(), userRole);
 
             // when
             ExtractableResponse<Response> result = get(LOCAL_HOST + port + PATH + "/1", accessToken);

--- a/src/test/java/spring/fitlinkbe/interfaces/controller/notification/NotificationControllerTest.java
+++ b/src/test/java/spring/fitlinkbe/interfaces/controller/notification/NotificationControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import spring.fitlinkbe.application.notification.NotificationFacade;
 import spring.fitlinkbe.application.notification.criteria.NotificationCriteria;
+import spring.fitlinkbe.application.notification.criteria.NotificationResult;
 import spring.fitlinkbe.domain.common.PersonalDetailRepository;
 import spring.fitlinkbe.domain.common.model.PersonalDetail;
 import spring.fitlinkbe.domain.notification.Notification;
@@ -279,8 +280,12 @@ public class NotificationControllerTest {
                     .isProcessed(false)
                     .build();
 
+            NotificationResult.NotificationDetail notificationDetail = NotificationResult.NotificationDetail
+                    .from(notification, personalDetail);
+
+
             when(notificationFacade.getNotificationDetail(any(Long.class), any(SecurityUser.class)))
-                    .thenReturn(notification);
+                    .thenReturn(notificationDetail);
 
             //when & then
             mockMvc.perform(get("/v1/notifications/%s".formatted(notificationId))


### PR DESCRIPTION
### 구현 기능

- 알림 상세 조회 API 수정

### 세부 사항

- 반환 내용에 userId 컬럼 추가
- 멤버가 조회하면 트레이너 정보를, 트레이너가 조회하면 멤버조회를 리턴

### DB 변동사항

- 없습니다.