### PR TITLE
[FLIZ-245] 핸드폰 번호 sns 인증 이후에도 변경 가능하도록 수정

### DIFF
--- a/src/main/java/spring/fitlinkbe/domain/common/model/PersonalDetail.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/model/PersonalDetail.java
@@ -99,11 +99,11 @@ public class PersonalDetail {
     }
 
     public void verifySnsEmail(PhoneNumber phoneNumber) {
-        if (this.status != Status.REQUIRED_SMS) {
-            throw new CustomException(ErrorCode.USER_STATUS_NOT_ALLOWED);
-        }
         this.phoneNumber = phoneNumber;
-        this.status = Status.REQUIRED_REGISTER;
+
+        if (this.status == Status.REQUIRED_SMS) {
+            this.status = Status.REQUIRED_REGISTER;
+        }
     }
 
     public void updateProfile(String uploadFilePath) {

--- a/src/main/java/spring/fitlinkbe/domain/member/Member.java
+++ b/src/main/java/spring/fitlinkbe/domain/member/Member.java
@@ -58,4 +58,8 @@ public class Member {
     public void updateProfile(String uploadFilePath) {
         this.profilePictureUrl = uploadFilePath;
     }
+
+    public void updatePhoneNumber(PhoneNumber phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
 }

--- a/src/main/java/spring/fitlinkbe/domain/trainer/Trainer.java
+++ b/src/main/java/spring/fitlinkbe/domain/trainer/Trainer.java
@@ -51,4 +51,8 @@ public class Trainer {
     public void updateProfile(String uploadFilePath) {
         this.profilePictureUrl = uploadFilePath;
     }
+
+    public void updatePhoneNumber(PhoneNumber phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
 }

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/auth/AuthController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/auth/AuthController.java
@@ -54,7 +54,6 @@ public class AuthController {
     public ApiResultResponse<AuthDto.EmailAuthTokenResponse> getEmailVerificationToken(
             @Login SecurityUser user
     ) {
-        user.checkUserStatusOrThrow(PersonalDetail.Status.REQUIRED_SMS);
         String verificationToken = authFacade.getEmailVerificationToken(user.getPersonalDetailId());
 
         return ApiResultResponse.ok(new AuthDto.EmailAuthTokenResponse(verificationToken));

--- a/src/test/java/spring/fitlinkbe/integration/AuthIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/AuthIntegrationTest.java
@@ -731,7 +731,7 @@ public class AuthIntegrationTest extends BaseIntegrationTest {
         }
 
         @Test
-        @DisplayName("회원 이메일 인증 코드 발급 실패 - 회원의 상태가 REQUIRED_SMS 가 아닌 경우")
+        @DisplayName("회원 이메일 인증 코드 발급 성공 - 회원의 상태가 REQUIRED_SMS 가 아닌 경우")
         public void sendEmailAuthCodeFailBecauseOfNotRequiredSmsStatus() throws Exception {
             // given
             // NORMAL 상태의 유저가 있을 때
@@ -743,14 +743,14 @@ public class AuthIntegrationTest extends BaseIntegrationTest {
             ExtractableResponse<Response> result = get(EMAIL_AUTH_API, accessToken);
 
             // then
-            // 에러를 반환한다
+            // 요청에 성공해야 한다
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(result.statusCode()).isEqualTo(200);
                 ApiResultResponse<AuthDto.EmailAuthTokenResponse> response = readValue(result.body().jsonPath().prettify(), new TypeReference<>() {
                 });
+
                 softly.assertThat(response).isNotNull();
-                softly.assertThat(response.status()).isEqualTo(403);
-                softly.assertThat(response.success()).isFalse();
+                softly.assertThat(response.data().verificationToken()).isNotNull();
             });
         }
     }


### PR DESCRIPTION
### 작업 내용
- 핸드폰 번호 sns 인증 이후에도 변경 가능하도록 수정했습니다
- 기존에 sns 토큰 발급 api가 required sns 일때만 요청 가능했는데 검증 로직 모두 제거했습니다