### PR TITLE
[FLIZ-302] 연동 수락시 session 정보가 없을 때만 생성하도록 수정

### DIFF
--- a/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
@@ -70,11 +70,6 @@ public class MemberFacade {
 
         connectingInfo.disconnect();
         memberService.saveConnectingInfo(connectingInfo);
-
-        SessionInfo sessionInfo = memberService.findSessionInfo(connectingInfo.getTrainerId(), memberId);
-        if (sessionInfo != null) {
-            memberService.deleteSessionInfo(sessionInfo);
-        }
     }
 
 

--- a/src/main/java/spring/fitlinkbe/application/trainer/TrainerFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/trainer/TrainerFacade.java
@@ -164,11 +164,6 @@ public class TrainerFacade {
         ConnectingInfo connectingInfo = trainerService.getConnectingInfo(trainerId, memberId);
         connectingInfo.disconnect();
 
-        SessionInfo sessionInfo = memberService.getSessionInfo(trainerId, memberId);
-        if (sessionInfo != null) {
-            memberService.deleteSessionInfo(sessionInfo);
-        }
-
         trainerService.saveConnectingInfo(connectingInfo);
         // -> 멤버에게 알림 보내기
         Token token = authService.getTokenByPersonalDetailId(memberDetail.getPersonalDetailId());
@@ -194,8 +189,8 @@ public class TrainerFacade {
         Token token = authService.getTokenByPersonalDetailId(memberDetail.getPersonalDetailId());
         Trainer trainer = trainerService.getTrainerInfo(trainerId);
 
-        SessionInfo sessionInfo = null;
-        if (approved) {
+        SessionInfo sessionInfo = memberService.findSessionInfo(trainerId, connectingInfo.getMember().getMemberId());
+        if (approved && sessionInfo == null) {
             sessionInfo = trainerService.createSessionInfo(trainer, connectingInfo.getMember());
         }
 

--- a/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
@@ -194,10 +194,6 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
                 Notification notification = notificationRepository.getNotification(trainerPersonalDetail.getPersonalDetailId(),
                         Notification.NotificationType.DISCONNECT);
                 softly.assertThat(notification).isNotNull();
-
-                // 세션 정보가 삭제되었는지 확인
-                Optional<SessionInfo> updatedSessionInfo = sessionInfoRepository.getSessionInfoWithNoLock(trainer.getTrainerId(), member.getMemberId());
-                softly.assertThat(updatedSessionInfo).isEmpty();
             });
         }
 

--- a/src/test/java/spring/fitlinkbe/integration/TrainerIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/TrainerIntegrationTest.java
@@ -733,7 +733,7 @@ public class TrainerIntegrationTest extends BaseIntegrationTest {
                 softly.assertThat(notification).isNotNull();
 
                 Optional<SessionInfo> updatedSessionInfo = sessionInfoRepository.getSessionInfoWithNoLock(trainer.getTrainerId(), member.getMemberId());
-                softly.assertThat(updatedSessionInfo).isEmpty();
+                softly.assertThat(updatedSessionInfo).isNotEmpty();
             });
         }
 
@@ -1183,6 +1183,57 @@ public class TrainerIntegrationTest extends BaseIntegrationTest {
                 softly.assertThat(sessionInfo.getRemainingCount()).isEqualTo(0);
                 softly.assertThat(sessionInfo.getTotalCount()).isEqualTo(0);
 
+                ConnectingInfo updatedConnectingInfo = connectingInfoRepository.findConnectingInfo(trainer.getTrainerId(), member.getMemberId()).get();
+                softly.assertThat(updatedConnectingInfo.getStatus()).isEqualTo(ConnectingInfo.ConnectingStatus.CONNECTED);
+            });
+        }
+
+        @Test
+        @DisplayName("트레이너 멤버 연결 요청 처리 성공 - 이미 세션 정보가 있을 때")
+        void decisionConnectSuccessWithExistingSession() throws Exception {
+            // given
+            // 멤버가 트레이너와 연동한 세션 정보가 이미 있을 때
+            String trainerCode = "AB1423";
+            Trainer trainer = testDataHandler.createTrainer(trainerCode);
+            String token = testDataHandler.createTokenFromTrainer(trainer);
+            Member member = testDataHandler.createMember();
+            PersonalDetail trainerDetail = testDataHandler.getTrainerPersonalDetail(trainer.getTrainerId());
+            PersonalDetail memberDetail = testDataHandler.getMemberPersonalDetail(member.getMemberId());
+            testDataHandler.createToken(memberDetail);
+            ConnectingInfo connectingInfo = testDataHandler.createConnectingInfo(trainer, member);
+
+            Notification notification = testDataHandler.saveNotification(
+                    Notification.connectRequest(trainerDetail, member.getMemberId(),
+                            member.getName(), connectingInfo.getConnectingInfoId())
+            );
+
+            // 세션 정보 생성
+            SessionInfo sessionInfo = testDataHandler.createSessionInfo(member, trainer);
+
+            // when
+            // 트레이너가 멤버 연결 요청 처리 요청을 한다면
+            String url = URL.replace("{notificationId}", notification.getNotificationId().toString());
+            ExtractableResponse<Response> result = post(url, writeValueAsString(new ConnectRequestDecisionDto.Request(true)), token);
+
+            // then
+            // 멤버 연결 요청 처리 성공한다, 세션 정보는 새로 생성하지 않는다
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.statusCode()).isEqualTo(200);
+                ApiResultResponse<ConnectRequestDecisionDto.Response> response = readValue(result.body().jsonPath().prettify(), new TypeReference<>() {
+                });
+
+                softly.assertThat(response).isNotNull();
+                softly.assertThat(response.success()).isTrue();
+                softly.assertThat(response.status()).isEqualTo(204);
+                softly.assertThat(response.data().memberId()).isEqualTo(member.getMemberId());
+                softly.assertThat(response.data().sessionInfoId()).isEqualTo(sessionInfo.getSessionInfoId());
+
+                Notification createdNotification = notificationRepository.getNotification(memberDetail.getPersonalDetailId(), Notification.NotificationType.CONNECT_RESPONSE);
+                softly.assertThat(createdNotification).isNotNull();
+
+                Optional<SessionInfo> updatedSessionInfo = sessionInfoRepository.getSessionInfoWithNoLock(trainer.getTrainerId(), member.getMemberId());
+                softly.assertThat(updatedSessionInfo).isNotEmpty();
+                softly.assertThat(updatedSessionInfo.get().getSessionInfoId()).isEqualTo(sessionInfo.getSessionInfoId());
 
                 ConnectingInfo updatedConnectingInfo = connectingInfoRepository.findConnectingInfo(trainer.getTrainerId(), member.getMemberId()).get();
                 softly.assertThat(updatedConnectingInfo.getStatus()).isEqualTo(ConnectingInfo.ConnectingStatus.CONNECTED);


### PR DESCRIPTION
### 작업 사항
- 연동 수락시 session 정보가 없을 때만 생성하도록 수정