### PR TITLE
[FLIZ-358] 트레이너 재연동 문제 해결

### DIFF
--- a/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/member/MemberFacade.java
@@ -26,12 +26,10 @@ import spring.fitlinkbe.domain.reservation.command.ReservationCommand;
 import spring.fitlinkbe.domain.trainer.Trainer;
 import spring.fitlinkbe.domain.trainer.TrainerService;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Component
 @RequiredArgsConstructor
@@ -44,17 +42,38 @@ public class MemberFacade {
 
     @Transactional
     public void connectTrainer(Long memberId, String trainerCode) {
-        memberService.checkMemberAlreadyConnected(memberId);
-
         Trainer trainer = trainerService.getTrainerByCode(trainerCode);
         Member member = memberService.getMember(memberId);
 
-        ConnectingInfo connectingInfo = memberService.requestConnectTrainer(trainer, member);
+        Optional<ConnectingInfo> exist = validateAndGetExistConnectingInfo(memberId, trainer);
+        ConnectingInfo connectingInfo;
+        if (exist.isPresent()) {
+            connectingInfo = exist.get();
+            connectingInfo.requestConnect();
+            memberService.saveConnectingInfo(connectingInfo);
+        } else {
+            connectingInfo = memberService.requestConnectTrainer(trainer, member);
+        }
         PersonalDetail trainerDetail = trainerService.getTrainerDetail(trainer.getTrainerId());
         Token token = authService.getTokenByPersonalDetailId(trainerDetail.getPersonalDetailId());
 
         notificationService.sendNotification(NotificationCommand.Connect.of(trainerDetail, member.getMemberId(),
                 member.getName(), connectingInfo.getConnectingInfoId(), token.getPushToken()));
+    }
+
+    private Optional<ConnectingInfo> validateAndGetExistConnectingInfo(Long memberId, Trainer trainer) {
+        List<ConnectingInfo> connectingInfos = memberService.findConnectingInfos(memberId);
+
+        // 현재 요청하는 트레이너 이외에 다른 트레이너에게 연결된 정보가 있는지 확인
+        Optional<ConnectingInfo> exist = connectingInfos.stream().filter(connectingInfo ->
+                !connectingInfo.getTrainerId().equals(trainer.getTrainerId()) && connectingInfo.isNotDisConnected()
+        ).findFirst();
+        if (exist.isPresent()) {
+            throw new CustomException(ErrorCode.CONNECT_AVAILABLE_AFTER_DISCONNECTED);
+        }
+
+        return connectingInfos.stream()
+                .filter(info -> info.getTrainerId().equals(trainer.getTrainerId())).findFirst();
     }
 
     @Transactional

--- a/src/main/java/spring/fitlinkbe/domain/common/ConnectingInfoRepository.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/ConnectingInfoRepository.java
@@ -2,6 +2,7 @@ package spring.fitlinkbe.domain.common;
 
 import spring.fitlinkbe.domain.common.model.ConnectingInfo;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ConnectingInfoRepository {
@@ -27,4 +28,6 @@ public interface ConnectingInfoRepository {
     Optional<ConnectingInfo> findConnectingInfo(Long trainerId, Long memberId);
 
     ConnectingInfo getConnectedInfoById(Long connectingInfoId);
+
+    List<ConnectingInfo> findConnectingInfos(Long memberId);
 }

--- a/src/main/java/spring/fitlinkbe/domain/common/model/ConnectingInfo.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/model/ConnectingInfo.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import spring.fitlinkbe.domain.common.exception.CustomException;
+import spring.fitlinkbe.domain.common.exception.ErrorCode;
 import spring.fitlinkbe.domain.member.Member;
 import spring.fitlinkbe.domain.trainer.Trainer;
 
@@ -50,6 +52,17 @@ public class ConnectingInfo {
         } else {
             this.status = ConnectingStatus.REJECTED;
         }
+    }
+
+    public boolean isNotDisConnected() {
+        return this.status != ConnectingStatus.DISCONNECTED && this.status != ConnectingStatus.REJECTED;
+    }
+
+    public void requestConnect() {
+        if (isNotDisConnected()) {
+            throw new CustomException(ErrorCode.CONNECT_AVAILABLE_AFTER_DISCONNECTED);
+        }
+        this.status = ConnectingStatus.REQUESTED;
     }
 
     public enum ConnectingStatus {

--- a/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
+++ b/src/main/java/spring/fitlinkbe/domain/member/MemberService.java
@@ -32,13 +32,6 @@ public class MemberService {
     private final ConnectingInfoRepository connectingInfoRepository;
     private final SessionInfoRepository sessionInfoRepository;
 
-    public PersonalDetail registerMember(Long personalDetailId, AuthCommand.MemberRegisterRequest command, Member savedMember) {
-        PersonalDetail personalDetail = personalDetailRepository.getById(personalDetailId);
-        personalDetailRepository.savePersonalDetail(personalDetail);
-
-        return personalDetail;
-    }
-
     @Transactional(readOnly = true)
     public List<WorkoutSchedule> getWorkoutSchedules(Long memberId) {
         return workoutScheduleRepository.findAllByMemberId(memberId);
@@ -57,19 +50,6 @@ public class MemberService {
 
     public List<WorkoutSchedule> saveWorkoutSchedules(List<WorkoutSchedule> workoutSchedules) {
         return workoutScheduleRepository.saveAll(workoutSchedules);
-    }
-
-    /**
-     * 이미 연결된, 연결 시도중인 트레이너가 있는지 확인
-     *
-     * @param memberId 연결 확인할 멤버 ID
-     * @throws CustomException 이미 연결된, 연결 시도중인 트레이너가 있을 경우
-     */
-    public void checkMemberAlreadyConnected(Long memberId) {
-        Optional<ConnectingInfo> existsConnectingInfo = connectingInfoRepository.getConnectedInfo(memberId);
-        if (existsConnectingInfo.isPresent()) {
-            throw new CustomException(ErrorCode.CONNECT_AVAILABLE_AFTER_DISCONNECTED);
-        }
     }
 
     @Transactional(readOnly = true)
@@ -203,11 +183,7 @@ public class MemberService {
         this.saveSessionInfo(getSessionInfo);
     }
 
-    public PersonalDetail getPersonalDetail(Long personalDetailId) {
-        return personalDetailRepository.getById(personalDetailId);
-    }
-
-    public void deleteSessionInfo(SessionInfo sessionInfo) {
-        sessionInfoRepository.delete(sessionInfo);
+    public List<ConnectingInfo> findConnectingInfos(Long memberId) {
+        return connectingInfoRepository.findConnectingInfos(memberId);
     }
 }

--- a/src/main/java/spring/fitlinkbe/infra/common/connectingInfo/ConnectingInfoJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/common/connectingInfo/ConnectingInfoJpaRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ConnectingInfoJpaRepository extends JpaRepository<ConnectingInfoEntity, Long> {
@@ -24,4 +25,7 @@ public interface ConnectingInfoJpaRepository extends JpaRepository<ConnectingInf
 
     @EntityGraph(attributePaths = {"member", "trainer"})
     Optional<ConnectingInfoEntity> findByTrainer_TrainerIdAndMember_MemberId(Long trainerId, Long memberId);
+
+    @EntityGraph(attributePaths = {"member", "trainer"})
+    List<ConnectingInfoEntity> findByMember_MemberId(Long memberId);
 }

--- a/src/main/java/spring/fitlinkbe/infra/common/connectingInfo/ConnectingInfoRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/common/connectingInfo/ConnectingInfoRepositoryImpl.java
@@ -7,6 +7,7 @@ import spring.fitlinkbe.domain.common.exception.CustomException;
 import spring.fitlinkbe.domain.common.exception.ErrorCode;
 import spring.fitlinkbe.domain.common.model.ConnectingInfo;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -45,5 +46,13 @@ public class ConnectingInfoRepositoryImpl implements ConnectingInfoRepository {
         return connectingInfoJpaRepository.findById(connectingInfoId)
                 .map(ConnectingInfoEntity::toDomain)
                 .orElseThrow(() -> new CustomException(ErrorCode.CONNECTING_INFO_NOT_FOUND));
+    }
+
+    @Override
+    public List<ConnectingInfo> findConnectingInfos(Long memberId) {
+        return connectingInfoJpaRepository.findByMember_MemberId(memberId)
+                .stream()
+                .map(ConnectingInfoEntity::toDomain)
+                .toList();
     }
 }

--- a/src/main/java/spring/fitlinkbe/infra/common/sessioninfo/SessionInfoEntity.java
+++ b/src/main/java/spring/fitlinkbe/infra/common/sessioninfo/SessionInfoEntity.java
@@ -23,7 +23,7 @@ public class SessionInfoEntity extends BaseTimeEntity {
     @JoinColumn(name = "trainer_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private TrainerEntity trainer;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private MemberEntity member;
 

--- a/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
@@ -129,8 +129,8 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
             // 멤버와 트레이너가 있을 때
             String trainerCode = "AB1423";
             Member member = testDataHandler.createMember();
-            Trainer trainer = testDataHandler.createTrainer(trainerCode);
-            testDataHandler.connectMemberAndTrainer(member, trainer);
+            testDataHandler.createTrainer(trainerCode);
+            testDataHandler.connectMemberAndTrainer(member, testDataHandler.createTrainer("AB1234"));
             String token = testDataHandler.createTokenFromMember(member);
 
             // when


### PR DESCRIPTION
### 작업 사항
- 같은 트레이너에게 재연결시
  - connecting info가 2개일 수 있음(connected, disconnected) 이때 연결되었는지 확인하는 로직이 2개의 결과를 리턴해서 문제
  - connecting info 는 트레이너 - 회원간 한개만 사용하도록 수정
- 다른 트레이너에게 재연결시
  - session info memberId에 unique key 걸러있어서 에러 발생. OneToOne → ManyToOne 매핑 수정

