### PR TITLE
[FLIZ-402] 트레이너 수업 가능시간 조회 쿼리 수정

### DIFF
--- a/src/main/java/spring/fitlinkbe/infra/trainer/AvailableTimeJpaRepository.java
+++ b/src/main/java/spring/fitlinkbe/infra/trainer/AvailableTimeJpaRepository.java
@@ -14,13 +14,13 @@ public interface AvailableTimeJpaRepository extends JpaRepository<AvailableTimeE
 
     @Query("SELECT MAX(at.applyAt) FROM AvailableTimeEntity at " +
             "WHERE at.trainer.trainerId = :trainerId " +
-            "AND at.applyAt <= CURRENT_TIMESTAMP")
-    LocalDate getCurrentAppliedDate(Long trainerId);
+            "AND at.applyAt <= :currentDate")
+    LocalDate getCurrentAppliedDate(Long trainerId, LocalDate currentDate);
 
     @Query("SELECT MIN(at.applyAt) FROM AvailableTimeEntity at " +
             "WHERE at.trainer.trainerId = :trainerId " +
-            "AND at.applyAt > CURRENT_TIMESTAMP")
-    LocalDate getScheduledAppliedDate(Long trainerId);
+            "AND at.applyAt > :currentDate")
+    LocalDate getScheduledAppliedDate(Long trainerId, LocalDate currentDate);
 
     @Query("SELECT at FROM AvailableTimeEntity at " +
             "JOIN FETCH at.trainer " +

--- a/src/main/java/spring/fitlinkbe/infra/trainer/AvailableTimeRepositoryImpl.java
+++ b/src/main/java/spring/fitlinkbe/infra/trainer/AvailableTimeRepositoryImpl.java
@@ -16,12 +16,12 @@ public class AvailableTimeRepositoryImpl implements AvailableTimeRepository {
 
     @Override
     public LocalDate getCurrentAppliedDate(Long trainerId) {
-        return availableTimeJpaRepository.getCurrentAppliedDate(trainerId);
+        return availableTimeJpaRepository.getCurrentAppliedDate(trainerId, LocalDate.now());
     }
 
     @Override
     public LocalDate getScheduledAppliedDate(Long trainerId) {
-        return availableTimeJpaRepository.getScheduledAppliedDate(trainerId);
+        return availableTimeJpaRepository.getScheduledAppliedDate(trainerId, LocalDate.now());
     }
 
     @Override


### PR DESCRIPTION
### 작업사항
- 트레이너 수업 가능시간 조회시 스케줄이 날짜에 따라 바로 바뀌지 않는 문제 수정했습니다

### 세부 사항
- 트레이너 수업 가능시간 조회히시 CURRENT_TIMESTAMP 함수를 사용했는데 DB timestemp 기준이 utc 기준이라 한국 시간으로 00시에 바로 새로운 스케줄이 적용되지 않아서 LocalDate.now() 함수를 통해 처리하도록 수정했습니다.