### PR TITLE
[Fliz-405] BE 트레이너 일정 조회 api

### DIFF
--- a/src/main/java/spring/fitlinkbe/application/reservation/ReservationFacade.java
+++ b/src/main/java/spring/fitlinkbe/application/reservation/ReservationFacade.java
@@ -79,6 +79,13 @@ public class ReservationFacade {
         return List.of();
     }
 
+    public List<Reservation> getTrainerReservations(LocalDate date, SecurityUser user) {
+        ConnectingInfo connectingInfo = memberService.getConnectingInfo(user.getMemberId());
+        Trainer trainer = connectingInfo.getTrainer();
+
+        return reservationService.getTrainerReservations(date, trainer.getTrainerId());
+    }
+
 
     public ReservationResult.ReservationDetail getReservationDetail(Long reservationId) {
 

--- a/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
+++ b/src/main/java/spring/fitlinkbe/domain/reservation/ReservationService.java
@@ -7,6 +7,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import spring.fitlinkbe.domain.common.enums.UserRole;
 import spring.fitlinkbe.domain.common.exception.CustomException;
 import spring.fitlinkbe.domain.common.exception.ErrorCode;
 import spring.fitlinkbe.domain.producer.EventTopic;
@@ -15,6 +16,7 @@ import spring.fitlinkbe.domain.reservation.event.GenerateFixedReservationEvent;
 import spring.fitlinkbe.domain.reservation.strategy.cancel.ReservationCancelStrategy;
 import spring.fitlinkbe.domain.trainer.Trainer;
 import spring.fitlinkbe.support.security.SecurityUser;
+import spring.fitlinkbe.support.utils.DateUtils;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -45,6 +47,16 @@ public class ReservationService {
         LocalDateTime startDate = command.date().atStartOfDay();
         LocalDateTime endDate = getEndDate(startDate, command.role());
         List<Reservation> reservations = reservationRepository.getReservations(command.role(), command.userId());
+
+        return reservations.stream()
+                .filter(reservation -> reservation.isReservationInRange(startDate, endDate))
+                .toList();
+    }
+
+    public List<Reservation> getTrainerReservations(LocalDate date, Long trainerId) {
+        LocalDateTime startDate = date.atStartOfDay();
+        LocalDateTime endDate = DateUtils.getTwoWeekAfterDate(startDate);
+        List<Reservation> reservations = reservationRepository.getReservations(UserRole.TRAINER, trainerId);
 
         return reservations.stream()
                 .filter(reservation -> reservation.isReservationInRange(startDate, endDate))

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/ReservationController.java
@@ -48,6 +48,25 @@ public class ReservationController {
     }
 
     /**
+     * 트레이너 예약 목록 조회
+     *
+     * @param date 예약 정보를 받고 싶은 date 정보
+     * @param user 인증된 유저 정보
+     * @return ApiResultResponse 예약 목록을 반환한다.
+     */
+    @RoleCheck(allowedRoles = {UserRole.MEMBER})
+    @GetMapping("/trainers")
+    public ApiResultResponse<List<ReservationResponseDto.Summary>> getTrainerReservations(@RequestParam LocalDate date,
+                                                                                   @Login SecurityUser user) {
+
+        List<Reservation> result = reservationFacade.getTrainerReservations(date, user);
+
+        return ApiResultResponse.ok(result.stream()
+                .map(ReservationResponseDto.Summary::of)
+                .toList());
+    }
+
+    /**
      * 예약 상세 조회
      *
      * @param reservationId reservationId

--- a/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationResponseDto.java
+++ b/src/main/java/spring/fitlinkbe/interfaces/controller/reservation/dto/ReservationResponseDto.java
@@ -57,7 +57,7 @@ public class ReservationResponseDto {
                     .build();
         }
 
-        private record MemberInfo(Long memberId, String name) {
+        public record MemberInfo(Long memberId, String name) {
 
         }
     }

--- a/src/test/java/spring/fitlinkbe/integration/ReservationIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/ReservationIntegrationTest.java
@@ -354,6 +354,106 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
     }
 
     @Nested
+    @DisplayName("트레이너 예약 목록 조회 Integration TEST")
+    class GetTrainerReservationsIntegrationTest {
+        @Test
+        @DisplayName("멤버가 트레이너의 예약 목록 조회 성공")
+        void GetTrainerReservations() {
+            // given
+            Map<String, String> params = new HashMap<>();
+            params.put("date", LocalDate.now().toString());
+
+            Trainer trainer = trainerRepository.getTrainerInfo(1L).orElseThrow();
+            Member member = memberRepository.getMember(1L).orElseThrow();
+
+            LocalDate dayOffDate = LocalDate.now().plusDays(1);
+
+            DayOff dayOff1 = DayOff.builder()
+                    .trainer(trainer)
+                    .dayOffDate(LocalDate.now().plusDays(1))
+                    .build();
+
+            DayOff dayOff2 = DayOff.builder()
+                    .trainer(trainer)
+                    .dayOffDate(LocalDate.now().plusDays(2))
+                    .build();
+
+            trainerRepository.saveDayOff(dayOff1);
+            trainerRepository.saveDayOff(dayOff2);
+
+            ConnectingInfo connectingInfo = ConnectingInfo.builder()
+                    .trainer(trainer)
+                    .member(member)
+                    .status(ConnectingInfo.ConnectingStatus.CONNECTED)
+                    .build();
+
+            connectingInfoRepository.save(connectingInfo);
+            // 예약 불가 설정1
+            Reservation disabledReservation1 = Reservation.builder()
+                    .reservationDates(List.of(dayOffDate.atStartOfDay()))
+                    .trainer(trainer)
+                    .isDayOff(true)
+                    .status(DISABLED_TIME_RESERVATION)
+                    .createdAt(LocalDateTime.now().plusSeconds(2))
+                    .build();
+
+            reservationRepository.saveReservation(disabledReservation1);
+
+            // 예약 불가 설정2
+            Reservation disabledReservation2 = Reservation.builder()
+                    .reservationDates(List.of(dayOffDate.atStartOfDay()))
+                    .trainer(trainer)
+                    .isDayOff(true)
+                    .status(DISABLED_TIME_RESERVATION)
+                    .createdAt(LocalDateTime.now().plusDays(3))
+                    .build();
+
+            reservationRepository.saveReservation(disabledReservation2);
+
+            // 새로운 회원 생성
+            Member newMember = testDataHandler.createMember();
+            SessionInfo sessionInfo = testDataHandler.createSessionInfo(newMember, trainer);
+
+            // 새로운 회원 예약 생성
+            Reservation confirmedReservation = Reservation.builder()
+                    .trainer(trainer)
+                    .member(newMember)
+                    .sessionInfo(sessionInfo)
+                    .reservationDates(List.of(LocalDateTime.now().plusDays(4)))
+                    .status(RESERVATION_APPROVED)
+                    .confirmDate(LocalDateTime.now().plusDays(4))
+                    .createdAt(LocalDateTime.now().plusSeconds(3))
+                    .build();
+
+            reservationRepository.saveReservation(confirmedReservation).orElseThrow();
+
+            PersonalDetail personalDetail = personalDetailRepository.getMemberDetail(1L)
+                    .orElseThrow();
+
+            String accessToken = tokenProvider.createAccessToken(PersonalDetail.Status.NORMAL,
+                    personalDetail.getPersonalDetailId(), personalDetail.getUserRole());
+
+            // when
+            ExtractableResponse<Response> result = get(LOCAL_HOST + port + PATH + "/trainers", params, accessToken);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.statusCode()).isEqualTo(200);
+                List<ReservationResponseDto.Summary> content = result.body().jsonPath()
+                        .getList("data", ReservationResponseDto.Summary.class);
+                softly.assertThat(content.size()).isEqualTo(3);
+                softly.assertThat(content.get(0).isDayOff()).isTrue();
+                softly.assertThat(content.get(2).memberInfo().memberId()).isNotEqualTo(member.getMemberId());
+
+                // 휴무일 잘 등록됐는지 확인
+                List<DayOff> dayOffs = trainerRepository.findScheduledDayOff(1L);
+                softly.assertThat(dayOffs.size()).isEqualTo(2);
+            });
+        }
+
+    }
+
+    @Nested
     @DisplayName("예약 상세 조회 Integration TEST")
     class GetReservationDetailIntegrationTest {
 


### PR DESCRIPTION
### 구현 기능

- 트레이너 일정 조회 api 구현

### 세부 사항

- 멤버에 연동되어 있는 트레이너의 2주치 예약을 조회합니다.

### DB 변동사항

- 없습니다.