### PR TITLE
[FLIZ-428] 남은 세션 수가 총 세션 수를 넘어가지 못하도록 검증 추가

### DIFF
--- a/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
+++ b/src/main/java/spring/fitlinkbe/domain/common/exception/ErrorCode.java
@@ -58,6 +58,7 @@ public enum ErrorCode {
 
     // Session 관련 ErrorCode
     SESSION_CREATE_FAILED("세션 생성에 실패하였습니다.", 400),
+    INVALID_SESSION_COUNT("세션 횟수가 적절하지 않습니다.", 400),
     SESSION_NOT_FOUND("세션 정보를 찾지 못하였습니다.", 404),
     SESSION_IS_ALREADY_CANCEL("이미 세션이 취소되었습니다.", 409),
     SESSION_IS_ALREADY_END("이미 세션이 종료되었습니다.", 409),

--- a/src/main/java/spring/fitlinkbe/infra/common/sessioninfo/SessionInfoEntity.java
+++ b/src/main/java/spring/fitlinkbe/infra/common/sessioninfo/SessionInfoEntity.java
@@ -2,6 +2,8 @@ package spring.fitlinkbe.infra.common.sessioninfo;
 
 import jakarta.persistence.*;
 import lombok.*;
+import spring.fitlinkbe.domain.common.exception.CustomException;
+import spring.fitlinkbe.domain.common.exception.ErrorCode;
 import spring.fitlinkbe.domain.common.model.SessionInfo;
 import spring.fitlinkbe.infra.common.model.BaseTimeEntity;
 import spring.fitlinkbe.infra.member.MemberEntity;
@@ -54,5 +56,19 @@ public class SessionInfoEntity extends BaseTimeEntity {
                 .totalCount(totalCount)
                 .remainingCount(remainingCount)
                 .build();
+    }
+
+    @PrePersist
+    @PreUpdate
+    public void prePersist() {
+        validateSessionCount();
+    }
+
+    public void validateSessionCount() {
+        if (remainingCount > totalCount) {
+            throw new CustomException(ErrorCode.INVALID_SESSION_COUNT,
+                    "남은 세션 수는 총 세션 수보다 클 수 없습니다. [remainingCount: %d, totalCount: %d]"
+                            .formatted(remainingCount, totalCount));
+        }
     }
 }

--- a/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
+++ b/src/test/java/spring/fitlinkbe/integration/MemberIntegrationTest.java
@@ -1154,6 +1154,43 @@ public class MemberIntegrationTest extends BaseIntegrationTest {
             });
         }
 
+        @Test
+        @DisplayName("회원 PT 횟수 수정 실패 - 남은 세션 수가 총 세션 수보다 많을 때")
+        public void memberSessionCountUpdateFailByRemainingCountExceedingTotalCount() {
+            // given
+            // 회원, 트레이너 정보가 있을 때
+            Member member = testDataHandler.createMember();
+            testDataHandler.createToken(testDataHandler.getMemberPersonalDetail(member.getMemberId()));
+            Trainer trainer = testDataHandler.createTrainer("AB1423");
+            testDataHandler.connectMemberAndTrainer(member, trainer);
+            String token = testDataHandler.createTokenFromTrainer(trainer);
+
+            SessionInfo sessionInfo = testDataHandler.createSessionInfo(member, trainer);
+
+            // when
+            // 트레이너가 회원 PT 횟수 수정 요청을 보낸다면 남은 세션 수가 총 세션 수보다 많을 때
+            int remainingCount = 6;
+            int totalCount = 5;
+            String url = MEMBER_SESSION_COUNT_UPDATE_API.replace("{memberId}", member.getMemberId().toString())
+                    .replace("{sessionInfoId}", sessionInfo.getSessionInfoId().toString());
+            SessionInfoDto.UpdateRequest request = new SessionInfoDto.UpdateRequest(remainingCount, totalCount);
+            String requestBody = writeValueAsString(request);
+            ExtractableResponse<Response> result = patch(url, requestBody, token);
+
+            // then
+            // 남은 세션 수가 총 세션 수보다 많다는 에러 응답을 받는다
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.statusCode()).isEqualTo(200);
+                ApiResultResponse<Object> response = readValue(result.body().jsonPath().prettify(), new TypeReference<>() {
+                });
+
+                softly.assertThat(response).isNotNull();
+                softly.assertThat(response.success()).isFalse();
+                softly.assertThat(response.status()).isEqualTo(400);
+                softly.assertThat(response.data()).isNull();
+            });
+        }
+
     }
 
     @Nested


### PR DESCRIPTION
### 작업 사항
- 남은 세션 수가 총 세션 수를 넘어가지 못하도록 검증 추가했습니다.
- 세션 바뀌는 부분이 여러 군데인데 entity 쪽에서 persist, update 할때 검증이 모두 들어가면 좋을 것 같아서 entity 내부에서 처리하도록 했습니다